### PR TITLE
Point users towards compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,7 @@ This will launch Puter at http://localhost:4000 (or the next available port).
 ```bash
 git clone https://github.com/HeyPuter/puter
 cd puter
-docker build -t puter .
-docker run puter
+docker compose up
 ```
 
 <br/>


### PR DESCRIPTION
A point of confusion was, that the current instructions for deploying the project locally on docker didn't expose the app to `localhost:4000`. The `docker-compose.yml` file already specifies this, which is why `docker compose up` ought to be used.

Alternatively you could pass the port through the `docker run` command using the `-p` option, though this would raise the question of why is there a `docker-compose.yml` to begin with.