### PR TITLE
style: fix tooltip shadow on taskBarItem

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -2117,16 +2117,16 @@ label {
 
 .ui-tooltip, .arrow:after {
     background-color: rgba(231, 238, 245, .92);
-    backdrop-filter: blur(3px);
+    box-shadow: none;
 }
 
 .ui-tooltip {
-    padding: 5px 10px;
+    padding: 7px 11px;
     border-radius: 2px;
     font: 14px "Helvetica Neue", Sans-Serif;
-    box-shadow: 0 0 3px rgba(0, 0, 0, 0.455);
-    background-color: rgba(231, 238, 245, .92);
+    border: none !important;
     backdrop-filter: blur(3px);
+    filter: drop-shadow(0 0 3px rgba(0,0,0,.455));
 }
 
 .arrow {


### PR DESCRIPTION
Fixed the shadow style of tooltip popover on taskBarItem, mostly about not showing shadow on the arrow, also removed the border of tooltip body to make it looks more natural with an arrow.

Before: 
![before](https://github.com/HeyPuter/puter/assets/24271362/abfb0935-d670-46d2-a5e1-6c0212bc2667)

After: 
![after](https://github.com/HeyPuter/puter/assets/24271362/fc3c032c-bc93-441c-9fb2-09ebca2ce0b8)

