### PR TITLE
feat: Add support for GitHub Actions to automatically build a docker image on push to master branch

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -5,12 +5,7 @@ name: Docker Image CI
 # branch called `master`.
 on:
   push:
-    branches: ['master']
-  pull_request:
-    branches: ['master']
-  schedule:
-    - cron: "0 2 * * 1-5"
-  
+    branches: ['master']  
 
 # Defines two custom environment variables for the workflow. These are used
 # for the Container registry domain, and a name for the Docker image that
@@ -48,8 +43,10 @@ jobs:
       # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about)
       # to extract tags and labels that will be applied to the specified image.
       # The `id` "meta" allows the output of this step to be referenced in
-      # a subsequent step. The `images` value provides the base name for the
-      # tags and labels.
+      # a subsequent step.
+      # The `images` value provides the base name for the tags and labels.
+      # Finally, the `tags` value provides instructions on which pattern/tag
+      # value to apply based on the event that triggered the run.
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5

--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -1,0 +1,83 @@
+#
+name: Docker Image CI
+
+# Configures this workflow to run every time a change is pushed to the
+# branch called `master`.
+on:
+  push:
+    branches: ['master']
+  pull_request:
+    branches: ['master']
+  schedule:
+    - cron: "0 2 * * 1-5"
+  
+
+# Defines two custom environment variables for the workflow. These are used
+# for the Container registry domain, and a name for the Docker image that
+# this workflow builds.
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+# There is a single job in this workflow. It's configured to run on the
+# latest available version of Ubuntu.
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions
+    # in this job.
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Uses the `docker/login-action` action to log in to the Container
+      # registry using the account and password that will publish the packages.
+      # Once published, the packages are scoped to the account defined here.
+      - name: Log in to GitHub Package Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about)
+      # to extract tags and labels that will be applied to the specified image.
+      # The `id` "meta" allows the output of this step to be referenced in
+      # a subsequent step. The `images` value provides the base name for the
+      # tags and labels.
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
+            type=sha
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+
+      # This step uses the `docker/build-push-action` action to build the
+      # image, based on your repository's `Dockerfile`. If the build succeeds,
+      # it pushes the image to GitHub Packages.
+      # It uses the `context` parameter to define the build's context as the
+      # set of files located in the specified path. For more information, see
+      # "[Usage](https://github.com/docker/build-push-action#usage)" in the
+      # README of the `docker/build-push-action` repository.
+      # It uses the `tags` and `labels` parameters to tag and label the image
+      # with the output from the "meta" step.
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
* Initial version

1) This will initiate a build of the docker image automatically, through GitHub Actions, each time a commit is pushed into the `master` branch. It requires that GitHub Actions be enabled and allowed to run on the repo.

2) The output of the action will create a package in the GitHub Container Registry (visible initially only to admins here: https://github.com/orgs/HeyPuter/packages/container/puter/settings)

3) An admin of the org will need to make the initial version of the package public, by going to that page and scrolling all the way to the bottom of the page and clicking on "Change Visibility" red button, selecting `Public`, then following the instructions.

Once this is done on the first build, subsequent builds will automatically be public.

The tagging logic is very simple for now, it will apply a tag for the sha of the image, another for the branch (so for now, only master) and another one for `latest`.
This last one can be controversial, as it means people can simply run `docker run --rm -it -p 4000:4000 ghcr.io/puter/puter`
(or the equivalent docker-compose) to get puter going, without having to pull the code/clone the repo, as this will be done on GH side automatically.

All those rules can be tweaked in the appropriate section of the `.github/workflows/docker-image.yaml` file (Lines 56 to 63 at the time of writing this).

Thank you for taking the time to read and consider this PR, I made it more for me originally, to simplify automated builds of puter from sources (get new features, bug and security fixes, work with containrrr's Watchtower, etc.), but I thought it could be useful for others :)