### PR TITLE
Add a CI script to check translations are valid

### DIFF
--- a/.github/workflows/check-translations.yml
+++ b/.github/workflows/check-translations.yml
@@ -1,0 +1,28 @@
+# This workflow runs the tools/check-translations.js script to make sure that the translation data is valid.
+
+name: Check Translations
+
+env:
+  NODE_VERSION: 21.x
+  # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Use Node.js ${{ env.NODE_VERSION }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ env.NODE_VERSION }}
+        cache: 'npm'
+        cache-dependency-path: ./package-lock.json
+    - run: npm ci
+    - run: npm run check-translations

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "nodemon --exec \"node dev-server.js\" ",
-    "build": "node ./build.js"
+    "build": "node ./build.js",
+    "check-translations": "node tools/check-translations.js"
   },
   "nodemonConfig": {
     "ext": "js, json, mjs, jsx, svg, css",

--- a/src/UI/UIDesktop.js
+++ b/src/UI/UIDesktop.js
@@ -1146,9 +1146,9 @@ $(document).on('click', '.user-options-menu-btn', async function(e){
     }
 
     // -------------------------------------------
-    // Load avaialble languages
+    // Load available languages
     // -------------------------------------------
-    const supoprtedLanguagesItems = ListSupportedLanugages().map(lang => {
+    const supportedLanguagesItems = ListSupportedLanguages().map(lang => {
         return {
             html: lang.name,
             icon: window.locale === lang.code ? '✓' : '',
@@ -1198,7 +1198,7 @@ $(document).on('click', '.user-options-menu-btn', async function(e){
             //--------------------------------------------------
             {
                 html: i18n('change_language'),
-                items: supoprtedLanguagesItems
+                items: supportedLanguagesItems
             },
             //--------------------------------------------------
             // Contact Us

--- a/src/i18n/i18n.js
+++ b/src/i18n/i18n.js
@@ -18,7 +18,7 @@
  */
 import translations from './translations/translations.js';
 
-window.ListSupportedLanugages = () => Object.keys(translations).map(lang => translations[lang]);
+window.ListSupportedLanguages = () => Object.keys(translations).map(lang => translations[lang]);
 
 window.i18n = function (key, replacements = [], encode_html = true) {
     if(typeof replacements === 'boolean' && encode_html === undefined){

--- a/src/i18n/i18n.js
+++ b/src/i18n/i18n.js
@@ -1,3 +1,21 @@
+/**
+ * Copyright (C) 2024 Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 import translations from './translations/translations.js';
 
 window.ListSupportedLanugages = () => Object.keys(translations).map(lang => translations[lang]);

--- a/src/i18n/i18nChangeLanguage.js
+++ b/src/i18n/i18nChangeLanguage.js
@@ -1,3 +1,22 @@
+/**
+ * Copyright (C) 2024 Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 function ChangeLanguage(lang) {
     window.locale = lang;
     window.mutate_user_preferences({

--- a/src/i18n/translations/ar.js
+++ b/src/i18n/translations/ar.js
@@ -1,3 +1,21 @@
+/**
+ * Copyright (C) 2024 Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 const ar = {
 	name: "العربية",
 	code: "ar",

--- a/src/i18n/translations/bn.js
+++ b/src/i18n/translations/bn.js
@@ -1,3 +1,21 @@
+/**
+ * Copyright (C) 2024 Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 const bn = {
     name: "বাংলা",
     code: "bn",

--- a/src/i18n/translations/da.js
+++ b/src/i18n/translations/da.js
@@ -1,3 +1,21 @@
+/**
+ * Copyright (C) 2024 Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 const da = {
     name: "Dansk",
     code: "da",

--- a/src/i18n/translations/de.js
+++ b/src/i18n/translations/de.js
@@ -1,3 +1,21 @@
+/**
+ * Copyright (C) 2024 Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 const de = {
     name: "Deutsch",
     code: "de",

--- a/src/i18n/translations/emoji.js
+++ b/src/i18n/translations/emoji.js
@@ -1,3 +1,21 @@
+/**
+ * Copyright (C) 2024 Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 const emoji = {
     name: "🌍",
     code: "emoji",

--- a/src/i18n/translations/en.js
+++ b/src/i18n/translations/en.js
@@ -1,3 +1,21 @@
+/**
+ * Copyright (C) 2024 Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 const en = {
     name: "English",
     code: "en",

--- a/src/i18n/translations/es.js
+++ b/src/i18n/translations/es.js
@@ -1,3 +1,21 @@
+/**
+ * Copyright (C) 2024 Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 const es = {
     name: "Español",
     code: "es",

--- a/src/i18n/translations/fa.js
+++ b/src/i18n/translations/fa.js
@@ -1,3 +1,21 @@
+/**
+ * Copyright (C) 2024 Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 const fa = {
     name: "فارسی",
     code: "fa",

--- a/src/i18n/translations/fi.js
+++ b/src/i18n/translations/fi.js
@@ -1,3 +1,21 @@
+/**
+ * Copyright (C) 2024 Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 const fi = {
     name: "Suomi",
     code: "fi",

--- a/src/i18n/translations/fr.js
+++ b/src/i18n/translations/fr.js
@@ -1,3 +1,21 @@
+/**
+ * Copyright (C) 2024 Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 const fr = {
     name: "Français",
     code: "fr",

--- a/src/i18n/translations/hy.js
+++ b/src/i18n/translations/hy.js
@@ -1,3 +1,21 @@
+/**
+ * Copyright (C) 2024 Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 const hy = {
     name: "Հայերեն",
     code: "hy",

--- a/src/i18n/translations/it.js
+++ b/src/i18n/translations/it.js
@@ -1,3 +1,21 @@
+/**
+ * Copyright (C) 2024 Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 const it = {
     name: "Italiano",
     code: "it",

--- a/src/i18n/translations/ko.js
+++ b/src/i18n/translations/ko.js
@@ -1,3 +1,21 @@
+/**
+ * Copyright (C) 2024 Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 const ko = {
     name: "한국어",
     code: "ko",

--- a/src/i18n/translations/nb.js
+++ b/src/i18n/translations/nb.js
@@ -1,3 +1,21 @@
+/**
+ * Copyright (C) 2024 Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 const nb = {
     name: "Norsk Bokmål",
     code: "nb",

--- a/src/i18n/translations/nn.js
+++ b/src/i18n/translations/nn.js
@@ -1,3 +1,21 @@
+/**
+ * Copyright (C) 2024 Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 const nn = {
     name: "Norsk Nynorsk",
     code: "nn",

--- a/src/i18n/translations/ro.js
+++ b/src/i18n/translations/ro.js
@@ -1,3 +1,21 @@
+/**
+ * Copyright (C) 2024 Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 const ro = {
     name: "Română",
     code: "ro",

--- a/src/i18n/translations/sv.js
+++ b/src/i18n/translations/sv.js
@@ -1,3 +1,21 @@
+/**
+ * Copyright (C) 2024 Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 const sv = {
     name: "Svenska",
     code: "sv",

--- a/src/i18n/translations/th.js
+++ b/src/i18n/translations/th.js
@@ -1,3 +1,21 @@
+/**
+ * Copyright (C) 2024 Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 const th = {
     name: "ไทย",
     code: "th",

--- a/src/i18n/translations/translations.js
+++ b/src/i18n/translations/translations.js
@@ -1,3 +1,21 @@
+/**
+ * Copyright (C) 2024 Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 import ar from './ar.js';
 import bn from './bn.js'
 import da from './da.js';

--- a/src/i18n/translations/ur.js
+++ b/src/i18n/translations/ur.js
@@ -1,3 +1,21 @@
+/**
+ * Copyright (C) 2024 Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 const ur = {
     name: "اردو",
     code: "ur",

--- a/src/i18n/translations/zh.js
+++ b/src/i18n/translations/zh.js
@@ -1,3 +1,21 @@
+/**
+ * Copyright (C) 2024 Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 const zh = {
     name: "中文",
     code: "zh",

--- a/tools/check-translations.js
+++ b/tools/check-translations.js
@@ -1,0 +1,83 @@
+/**
+ * Copyright (C) 2024 Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import translations from '../src/i18n/translations/translations.js';
+import fs from 'fs';
+
+let hadError = false;
+function reportError(message) {
+    hadError = true;
+    process.stderr.write(`❌ ${message}\n`);
+}
+
+// Check that each translation file is recorded in `translations`
+async function checkTranslationRegistrations() {
+    const files = await fs.promises.readdir('./src/i18n/translations');
+    for (const fileName of files) {
+        if (!fileName.endsWith('.js')) continue;
+        const translationName = fileName.substring(0, fileName.length - 3);
+        if (translationName === 'translations') continue;
+
+        const translation = translations[translationName];
+        if (!translation) {
+            reportError(`Translation '${translationName}' is not listed in translations.js, please add it!`);
+            continue;
+        }
+
+        if (!translation.name) {
+            reportError(`Translation '${translationName}' is missing a name!`);
+        }
+        if (!translation.code) {
+            reportError(`Translation '${translationName}' is missing a code!`);
+        } else if (translation.code !== translationName) {
+            reportError(`Translation '${translationName}' has code '${translation.code}', which should be '${translationName}'!`);
+        }
+        if (typeof translation.dictionary !== 'object') {
+            reportError(`Translation '${translationName}' is missing a translations dictionary! Should be an object.`);
+        }
+    }
+}
+
+function checkTranslationKeys() {
+    const enDictionary = translations.en.dictionary;
+
+    for (const translation of Object.values(translations)) {
+        // We compare against the en translation, so checking it doesn't make sense.
+        if (translation.code === 'en') continue;
+
+        // If the dictionary is missing, we already reported that in checkTranslationRegistrations().
+        if (typeof translation.dictionary !== "object") continue;
+
+        for (const [key, value] of Object.entries(translation.dictionary)) {
+            if (!enDictionary[key]) {
+                reportError(`Translation '${translation.code}' has key '${key}' that doesn't exist in 'en'!`);
+            }
+        }
+    }
+}
+
+await checkTranslationRegistrations();
+checkTranslationKeys();
+
+if (hadError) {
+    process.stdout.write('Errors were found in translation files.\n');
+    process.exit(1);
+}
+
+process.stdout.write('✅ Translations appear valid.\n');
+process.exit(0);


### PR DESCRIPTION
Checks the following:
- Translation files are valid JS
- Each translation file is registered in translations.mjs
- Each translation's code matches its name
- Translation dictionaries only contain keys that exist in the English translation.

An example output for when things are right:
![image](https://github.com/HeyPuter/puter/assets/222642/44811d12-f425-4a67-9324-04ebda5151b9)

...and when various things are wrong:
![image](https://github.com/HeyPuter/puter/assets/222642/fca66869-d6b7-4647-bb61-ea17b4e53d1c)

On second thought I might have gone overboard with exclamation marks. :laughing: 