### PR TITLE
Migrate to JavaScript modules

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,3 +1,3 @@
-const {build} = require("./utils.js")
+import { build } from "./utils.js"
 
 build();

--- a/dev-server.js
+++ b/dev-server.js
@@ -1,8 +1,8 @@
-const express = require("express");
-const { generateDevHtml, build } = require("./utils.js");
-const { argv } = require('node:process');
-const chalk = require('chalk');
-const dotenv = require('dotenv');
+import express from "express";
+import { generateDevHtml, build } from "./utils.js";
+import { argv } from 'node:process';
+import chalk from 'chalk';
+import dotenv from 'dotenv';
 dotenv.config();
 
 const app = express();
@@ -55,4 +55,4 @@ if(env === "dev"){
     app.use(express.static('./src/'));
 }
 
-module.exports = app;
+export { app };

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "license": "AGPL-3.0-only",
   "description": "Desktop environment in the browser!",
   "homepage": "https://puter.com",
+  "type": "module",
   "directories": {
     "lib": "lib"
   },

--- a/src/static-assets.js
+++ b/src/static-assets.js
@@ -51,4 +51,4 @@ const js_paths = [
     `/i18n/i18n.js`,
 ]
 
-module.exports = { lib_paths, css_paths, js_paths }
+export { lib_paths, css_paths, js_paths };

--- a/utils.js
+++ b/utils.js
@@ -16,15 +16,17 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
+import { encode } from 'html-entities';
+import fs from 'fs';
+import path from 'path';
+import webpack from 'webpack';
+import CleanCSS from 'clean-css';
+import uglifyjs from 'uglify-js';
+import { lib_paths, css_paths, js_paths } from './src/static-assets.js';
+import { fileURLToPath } from 'url';
 
-
-const {encode} = require('html-entities');
-const fs = require('fs');
-const path = require('path');
-const webpack = require('webpack');
-const CleanCSS = require('clean-css');
-const uglifyjs = require('uglify-js');
-const {lib_paths, css_paths, js_paths} = require('./src/static-assets.js');
+// Polyfill __dirname, which doesn't exist in modules mode
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /**
  * Builds the application by performing various tasks such as cleaning the distribution directory,
@@ -348,4 +350,4 @@ function generateDevHtml(options){
 }
 
 // export
-module.exports = {generateDevHtml, build};
+export { generateDevHtml, build };


### PR DESCRIPTION
This turned out to not be difficult actually!

Discovered when working on #149. We already use modules for most of the code, but not the parts that Node deals with. Making the whole project use modules, means that tests and other scripts that interact with module code will work nicely, without having to rename things.