### PR TITLE
fixing html encoding issue in i18n

### DIFF
--- a/src/UI/PuterDialog.js
+++ b/src/UI/PuterDialog.js
@@ -29,7 +29,7 @@ async function PuterDialog(options) {
             <button class="button button-auth" id="launch-auth-popup-cancel">${i18n('cancel')}</button>
             <button class="button button-primary button-auth" id="launch-auth-popup" style="margin-left:10px;">${i18n('continue')}</button>
         </div>
-        <p style="text-align: center; font-size: 14px;">${i18n('powered_by_puter_js')}</p>
+        <p style="text-align: center; font-size: 14px;">${i18n('powered_by_puter_js', [], false)}</p>
         <p class="launch-auth-popup-footnote">${i18n('tos_fineprint')}</p>
         </div>`;
 

--- a/src/UI/UIWindowPublishWebsite.js
+++ b/src/UI/UIWindowPublishWebsite.js
@@ -26,7 +26,7 @@ async function UIWindowPublishWebsite(target_dir_uid, target_dir_name, target_di
         // success
         h += `<div class="window-publishWebsite-success">`;
             h += `<img src="${html_encode(window.icons['c-check.svg'])}" style="width:80px; height:80px; display: block; margin:10px auto;">`;
-            h += `<p style="text-align:center;">${i18n('dir_published_as_website', `<strong>${target_dir_name}</strong>`)}<p>`;
+            h += `<p style="text-align:center;">${i18n('dir_published_as_website', `<strong>${target_dir_name}</strong>`, false)}<p>`;
             h += `<p style="text-align:center;"><a class="publishWebsite-published-link" target="_blank"></a><img class="publishWebsite-published-link-icon" src="${html_encode(window.icons['launch.svg'])}"></p>`;
             h += `<button class="button button-normal button-block button-primary publish-window-ok-btn" style="margin-top:20px;">OK</button>`;
         h+= `</div>`;

--- a/src/UI/UIWindowSignup.js
+++ b/src/UI/UIWindowSignup.js
@@ -64,7 +64,7 @@ function UIWindowSignup(options){
                     h += `<input type="text" name="p102xyzname" class="p102xyzname" value="">`;
 
                     // terms and privacy
-                    h += `<p class="signup-terms">${i18n('tos_fineprint', false)}</p>`;
+                    h += `<p class="signup-terms">${i18n('tos_fineprint', [], false)}</p>`;
                     // Create Account
                     h += `<button class="signup-btn button button-primary button-block button-normal">${i18n('create_free_account')}</button>`
                 h += `</form>`;

--- a/src/i18n/i18n.js
+++ b/src/i18n/i18n.js
@@ -21,10 +21,7 @@ import translations from './translations/translations.js';
 window.ListSupportedLanguages = () => Object.keys(translations).map(lang => translations[lang]);
 
 window.i18n = function (key, replacements = [], encode_html = true) {
-    if(typeof replacements === 'boolean' && encode_html === undefined){
-        encode_html = replacements;
-        replacements = [];
-    }else if(Array.isArray(replacements) === false){
+    if(Array.isArray(replacements) === false){
         replacements = [replacements];
     }
 


### PR DESCRIPTION
There was a bug which was causing html_encoding to always be set to true resulting in HTML elements not rendering properly

<img width="722" alt="Screenshot 2024-03-23 at 11 45 52 AM" src="https://github.com/HeyPuter/puter/assets/46136355/94ff8d8b-6436-4b75-8f0b-9741a903c92e">
<img width="491" alt="Screenshot 2024-03-23 at 11 49 10 AM" src="https://github.com/HeyPuter/puter/assets/46136355/6ab4f96c-c070-43db-bfc0-39b668492230">
<img width="479" alt="Screenshot 2024-03-23 at 1 55 50 PM" src="https://github.com/HeyPuter/puter/assets/46136355/b5a9b04f-2145-4bc6-8bc8-f1b61b6ac3ae">
