### PR TITLE
Fixes #148 - Added functionalities for i18n module

### DIFF
--- a/src/UI/UIAlert.js
+++ b/src/UI/UIAlert.js
@@ -59,7 +59,7 @@ function UIAlert(options){
                                 data-label="${html_encode(options.buttons[y].label)}"
                                 data-value="${html_encode(options.buttons[y].value ?? options.buttons[y].label)}"
                                 ${options.buttons[y].type === 'primary' ? 'autofocus' : ''}
-                                >${html_encode(options.buttons[y].label)}</button>`;
+                                >${options.buttons[y].label}</button>`; //old: ${html_encode(options.buttons[y].label) | updated to accomodate for the i18n html element change
             }
             h += `</div>`;
         }

--- a/src/UI/UIContextMenu.js
+++ b/src/UI/UIContextMenu.js
@@ -62,7 +62,7 @@ function UIContextMenu(options){
                         h += `<span class="context-menu-item-icon">${options.items[i].icon ?? ''}</span>`;
                         h += `<span class="context-menu-item-icon-active">${options.items[i].icon_active ?? (options.items[i].icon ?? '')}</span>`;
                         // label
-                        h += `${html_encode(options.items[i].html)}`;
+                        h += `${options.items[i].html}`; // old: `${html_encode(options.items[i].html)}`
                         // arrow
                         h += `<img class="submenu-arrow" src="${html_encode(window.icons['chevron-right.svg'])}"><img class="submenu-arrow submenu-arrow-active" src="${html_encode(window.icons['chevron-right-active.svg'])}">`;
                     h += `</li>`;

--- a/src/UI/UITaskbar.js
+++ b/src/UI/UITaskbar.js
@@ -50,7 +50,8 @@ async function UITaskbar(options){
     //---------------------------------------------
     UITaskbarItem({
         icon: window.icons['start.svg'],
-        name: i18n('start'),
+        name: i18n('start', false),
+        i18n_key: 'start',
         sortable: false,
         keep_in_taskbar: true,
         disable_context_menu: true,
@@ -217,7 +218,8 @@ async function UITaskbar(options){
     UITaskbarItem({
         icon: trash.is_empty ? window.icons['trash.svg'] : window.icons['trash-full.svg'],
         app: 'trash',
-        name: `${i18n('trash')}`,
+        name: `${i18n('trash', false)}`,
+        i18n_key: 'trash',
         sortable: false,
         keep_in_taskbar: true,
         lock_keep_in_taskbar: true,

--- a/src/UI/UITaskbarItem.js
+++ b/src/UI/UITaskbarItem.js
@@ -28,9 +28,10 @@ function UITaskbarItem(options){
     options.open_windows_count = options.open_windows_count ?? 0;
     options.lock_keep_in_taskbar = options.lock_keep_in_taskbar ?? false;
     options.append_to_taskbar = options.append_to_taskbar ?? true;
+    options.i18n_key = options.i18n_key ?? "";
     const element_id = global_element_id++;
 
-    h += `<div  class = "taskbar-item ${options.sortable ? 'taskbar-item-sortable' : ''} disable-user-select"
+    h += `<div  class = "taskbar-item ${options.sortable ? 'taskbar-item-sortable' : ''} disable-user-select i18n"
                 id = "taskbar-item-${tray_item_id}"
                 data-taskbar-item-id = "${tray_item_id}"
                 data-element-id = "${html_encode(element_id)}"
@@ -38,6 +39,7 @@ function UITaskbarItem(options){
                 data-app = "${html_encode(options.app)}"
                 data-keep-in-taskbar = "${html_encode(options.keep_in_taskbar ?? 'false')}"
                 data-open-windows="${(options.open_windows_count)}"
+                data-i18n-key="${(options.i18n_key)}"
                 title = "${html_encode(options.name)}"
                 style= "${options.style ? html_encode(options.style) : ''}"
             >`;

--- a/src/UI/UIWindow.js
+++ b/src/UI/UIWindow.js
@@ -109,6 +109,7 @@ async function UIWindow(options) {
     options.width = options.width ?? 680;
     options.window_css = options.window_css ?? {};
     options.window_class = (options.window_class !== undefined ? ' ' + options.window_class : '');
+    options.i18n_key = options.i18n_key ?? ""
 
     // if only one instance is allowed, bring focus to the window that is already open
     if(options.single_instance && options.app !== ''){
@@ -181,6 +182,7 @@ async function UIWindow(options) {
                 data-app_uuid="${html_encode(options.app_uuid ?? '')}" 
                 data-disable_parent_window = "${html_encode(options.disable_parent_window)}"
                 data-name="${html_encode(options.title)}" 
+                data-i18n-key="${options.i18n_key}"
                 data-path ="${html_encode(options.path)}"
                 data-uid ="${options.uid}"
                 data-element_uuid="${options.element_uuid}"
@@ -225,7 +227,7 @@ async function UIWindow(options) {
                     if(options.icon)
                         h += `<img class="window-head-icon" />`;
                     // title
-                    h += `<span class="window-head-title" title="${html_encode(options.title)}"></span>`;
+                    h += `<span class="window-head-title i18n" data-i18n-key="${options.i18n_key}" title="${html_encode(options.title)}"></span>`;
                 h += `</div>`;
                 // Minimize button, only if window is resizable and not embedded
                 if(options.is_resizable && options.show_minimize_button && !is_embedded)
@@ -2923,7 +2925,7 @@ window.scale_window = (el_window)=>{
 window.update_explorer_footer_item_count = function(el_window){
     //update dir count in explorer footer
     let item_count = $(el_window).find('.item').length;
-    $(el_window).find('.explorer-footer .explorer-footer-item-count').html(item_count + ` ${i18n('item')}` + (item_count == 0 || item_count > 1 ? `${i18n('plural_suffix')}` : ''));
+    $(el_window).find('.explorer-footer .explorer-footer-item-count').html(item_count + ` ${i18n('item', false)}` + (item_count == 0 || item_count > 1 ? `${i18n('plural_suffix', false)}` : ''));
 }
 
 window.update_explorer_footer_selected_items_count = function(el_window){
@@ -2931,7 +2933,7 @@ window.update_explorer_footer_selected_items_count = function(el_window){
     let item_count = $(el_window).find('.item-selected').length;
     if(item_count > 0){
         $(el_window).find('.explorer-footer-seperator, .explorer-footer-selected-items-count').show();
-        $(el_window).find('.explorer-footer .explorer-footer-selected-items-count').html(item_count + ` ${i18n('item')}` + (item_count == 0 || item_count > 1 ? `${i18n('plural_suffix')}` : '') + ` ${i18n('selected')}`);
+        $(el_window).find('.explorer-footer .explorer-footer-selected-items-count').html(item_count + ` ${i18n('item', false)}` + (item_count == 0 || item_count > 1 ? `${i18n('plural_suffix', false)}` : '') + ` ${i18n('selected')}`);
     }else{
         $(el_window).find('.explorer-footer-seperator, .explorer-footer-selected-items-count').hide();
     }

--- a/src/UI/UIWindowChangeUsername.js
+++ b/src/UI/UIWindowChangeUsername.js
@@ -39,7 +39,8 @@ async function UIWindowChangeUsername(){
     h += `</div>`;
 
     const el_window = await UIWindow({
-        title: i18n('change_username'),
+        title: i18n('change_username', false),
+        i18n_key: 'change_username',
         app: 'change-username',
         single_instance: true,
         icon: null,

--- a/src/UI/UIWindowColorPicker.js
+++ b/src/UI/UIWindowColorPicker.js
@@ -48,7 +48,8 @@ async function UIWindowColorPicker(options){
         h += `</div>`;
         
         const el_window = await UIWindow({
-            title: i18n('select_color'),
+            title: i18n('select_color', false),
+            i18n_key: 'select_color',
             app: 'color-picker',
             single_instance: true,
             icon: null,

--- a/src/UI/UIWindowCopyProgress.js
+++ b/src/UI/UIWindowCopyProgress.js
@@ -42,7 +42,8 @@ async function UIWindowCopyProgress(options){
     h += `</div>`;
 
     const el_window = await UIWindow({
-        title: i18n('copying'),
+        title: i18n('copying', false),
+        i18n_key: 'copying',
         icon: window.icons[`app-icon-copying.svg`],
         uid: null,
         is_dir: false,

--- a/src/UI/UIWindowDesktopBGSettings.js
+++ b/src/UI/UIWindowDesktopBGSettings.js
@@ -32,8 +32,8 @@ async function UIWindowDesktopBGSettings(){
             // type
             h += `<label>${i18n('background')}:</label>`;
             h += `<select class="desktop-bg-type" style="width: 150px; margin-bottom: 20px;">`
-                h += `<option value="picture">${i18n('picture')}</option>`;
-                h += `<option value="color">${i18n('color')}</option>`;
+                h += `<option value="picture" class="i18n" data-i18n-key="picture">${i18n('picture', false)}</option>`;
+                h += `<option value="color" class="i18n" data-i18n-key="color">${i18n('color', false)}</option>`;
             h += `</select>`;
 
             // Picture
@@ -42,10 +42,10 @@ async function UIWindowDesktopBGSettings(){
                 h += `<button class="button button-default button-small browse">${i18n('browse')}</button>`;
                 h += `<label style="margin-top: 20px;">${i18n('fit')}:</label>`;
                 h += `<select class="desktop-bg-fit" style="width: 150px;">`
-                    h += `<option value="cover">${i18n('cover')}</option>`;
-                    h += `<option value="center">${i18n('center')}</option>`;
-                    h += `<option value="contain">${i18n('contain')}</option>`;
-                    h += `<option value="repeat">${i18n('repeat')}</option>`;
+                    h += `<option value="cover" class="i18n" data-i18n-key="cover">${i18n('cover', false)}</option>`;
+                    h += `<option value="center" class="i18n" data-i18n-key="center">${i18n('center', false)}</option>`;
+                    h += `<option value="contain" class="i18n" data-i18n-key="contain">${i18n('contain', false)}</option>`;
+                    h += `<option value="repeat" class="i18n" data-i18n-key="repeat">${i18n('repeat', false)}</option>`;
                 h += `</select>`;
             h += `</div>`
 
@@ -76,7 +76,8 @@ async function UIWindowDesktopBGSettings(){
         h += `</div>`;
 
         const el_window = await UIWindow({
-            title: i18n('change_desktop_background'),
+            title: i18n('change_desktop_background', false),
+            i18n_key: 'change_desktop_background',
             icon: null,
             uid: null,
             is_dir: false,

--- a/src/UI/UIWindowFeedback.js
+++ b/src/UI/UIWindowFeedback.js
@@ -39,7 +39,8 @@ async function UIWindowQR(options){
         h += `</div>`;
 
         const el_window = await UIWindow({
-            title: i18n('contact_us'),
+            title: i18n('contact_us', false),
+            i18n_key: 'contact_us',
             app: 'feedback',
             single_instance: true,
             icon: null,

--- a/src/UI/UIWindowGetCopyLink.js
+++ b/src/UI/UIWindowGetCopyLink.js
@@ -71,8 +71,8 @@ async function UIWindowGetCopyLink(options){
     $(el_window).find('.window-body .share-copy-link-on-social').on('click', function(e){    
         const social_links = socialLink({
             url: url, 
-            title: i18n('get_a_copy_of_on_puter', options.name, false), 
-            description: i18n('get_a_copy_of_on_puter', options.name, false),
+            title: i18n('get_a_copy_of_on_puter', false, options.name, false), 
+            description: i18n('get_a_copy_of_on_puter', false, options.name, false),
         });
 
         let social_links_html = ``;

--- a/src/UI/UIWindowProgressEmptyTrash.js
+++ b/src/UI/UIWindowProgressEmptyTrash.js
@@ -35,7 +35,8 @@ async function UIWindowProgressEmptyTrash(options){
     h += `</div>`;
 
     const el_window = await UIWindow({
-        title: i18n('emptying_trash'),
+        title: i18n('emptying_trash', false),
+        i18n_key: 'emptying_trash',
         icon: window.icons[`app-icon-newfolder.svg`],
         uid: null,
         is_dir: false,

--- a/src/UI/UIWindowPublishWebsite.js
+++ b/src/UI/UIWindowPublishWebsite.js
@@ -26,7 +26,7 @@ async function UIWindowPublishWebsite(target_dir_uid, target_dir_name, target_di
         // success
         h += `<div class="window-publishWebsite-success">`;
             h += `<img src="${html_encode(window.icons['c-check.svg'])}" style="width:80px; height:80px; display: block; margin:10px auto;">`;
-            h += `<p style="text-align:center;">${i18n('dir_published_as_website', `<strong>${target_dir_name}</strong>`)}<p>`;
+            h += `<p style="text-align:center;">${i18n('dir_published_as_website', false, `<strong>${target_dir_name}</strong>`)}<p>`;
             h += `<p style="text-align:center;"><a class="publishWebsite-published-link" target="_blank"></a><img class="publishWebsite-published-link-icon" src="${html_encode(window.icons['launch.svg'])}"></p>`;
             h += `<button class="button button-normal button-block button-primary publish-window-ok-btn" style="margin-top:20px;">OK</button>`;
         h+= `</div>`;

--- a/src/UI/UIWindowRefer.js
+++ b/src/UI/UIWindowRefer.js
@@ -72,7 +72,7 @@ async function UIWindowRefer(options){
     $(el_window).find('.window-body .downloadable-link').val(url);
 
     $(el_window).find('.window-body .share-copy-link-on-social').on('click', function(e){    
-        const social_links = socialLink({url: url, title: i18n('refer_friends_social_media_c2a'), description: i18n('refer_friends_social_media_c2a')});
+        const social_links = socialLink({url: url, title: i18n('refer_friends_social_media_c2a', false), description: i18n('refer_friends_social_media_c2a', false)});
 
         let social_links_html = ``;
         social_links_html += `<div style="padding: 10px;">`;

--- a/src/UI/UIWindowSignup.js
+++ b/src/UI/UIWindowSignup.js
@@ -64,7 +64,7 @@ function UIWindowSignup(options){
                     h += `<input type="text" name="p102xyzname" class="p102xyzname" value="">`;
 
                     // terms and privacy
-                    h += `<p class="signup-terms">${i18n('tos_fineprint', false)}</p>`;
+                    h += `<p class="signup-terms">${i18n('tos_fineprint')}</p>`;
                     // Create Account
                     h += `<button class="signup-btn button button-primary button-block button-normal">${i18n('create_free_account')}</button>`
                 h += `</form>`;

--- a/src/UI/UIWindowUploadProgress.js
+++ b/src/UI/UIWindowUploadProgress.js
@@ -41,7 +41,8 @@ async function UIWindowUploadProgress(options){
     h += `</div>`;
 
     const el_window = await UIWindow({
-        title: i18n('Upload'),
+        title: i18n('Upload', false),
+        i18n_key: 'upload',
         icon: window.icons[`app-icon-uploader.svg`],
         uid: null,
         is_dir: false,

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -409,17 +409,17 @@ window.globToRegExp = function (glob, opts) {
  */
 window.validate_fsentry_name = function(name){
     if(!name)
-        throw {message: i18n('name_cannot_be_empty')}
+        throw {message: i18n('name_cannot_be_empty', false)}
     else if(!isString(name))
-        throw {message: i18n('name_must_be_string')}
+        throw {message: i18n('name_must_be_string', false)}
     else if(name.includes('/'))
-        throw {message: i18n('name_cannot_contain_slash')}
+        throw {message: i18n('name_cannot_contain_slash', false)}
     else if(name === '.')
-        throw {message: i18n('name_cannot_contain_period')};
+        throw {message: i18n('name_cannot_contain_period', false)};
     else if(name === '..')
-        throw {message: i18n('name_cannot_contain_double_period')};
+        throw {message: i18n('name_cannot_contain_double_period', false)};
     else if(name.length > window.max_item_name_length)
-        throw {message: i18n('name_too_long', config.max_item_name_length)}
+        throw {message: i18n('name_too_long', false, config.max_item_name_length)}
     else
         return true
 }
@@ -1820,12 +1820,14 @@ window.trigger_download = (paths)=>{
  */
 window.launch_app = async (options)=>{
     const uuid = uuidv4();
-    let icon, title, file_signature;
+    let icon, title, i18n_key, file_signature;
     const window_options = options.window_options ?? {};
 
     // try to get 3rd-party app info
     let app_info = options.app_obj ?? await get_apps(options.name);
 
+    // set i18n key to be able to accomodate language change
+    i18n_key = options.name;
     //-----------------------------------
     // icon
     //-----------------------------------
@@ -1875,7 +1877,8 @@ window.launch_app = async (options)=>{
             icon = window.icons['folder-home.svg'];
         }
         else if(options.path === window.trash_path){
-            title = 'Trash';
+            title = i18n('trash', false);
+            i18n_key = 'trash';
         }
         else if(!options.path)
             title = root_dirname;
@@ -1888,6 +1891,7 @@ window.launch_app = async (options)=>{
             icon: icon,
             path: options.path ?? window.home_path,
             title: title,
+            i18n_key: i18n_key,
             uid: null,
             is_dir: true,
             app: 'explorer',
@@ -1981,6 +1985,7 @@ window.launch_app = async (options)=>{
         UIWindow({
             element_uuid: uuid,
             title: title,
+            i18n_key: i18n_key,
             iframe_url: iframe_url.href,
             icon: icon,
             window_class: 'window-app',
@@ -2153,9 +2158,16 @@ window.open_item = async function(options){
     // Dir with no open windows: create a new window
     //----------------------------------------------------------------
     else if(is_dir && ($el_parent_window.length === 0 || options.new_window)){
+        let title = path.basename(item_path);
+        let i18n_key = "";
+        if (title === "Trash") {
+            title = i18n("trash", false);
+            i18n_key = "trash";
+        }
         UIWindow({
             path: item_path,
-            title: path.basename(item_path),
+            title: title,
+            i18n_key: i18n_key,
             icon: await item_icon({is_dir: true, path: item_path}),
             uid: $(el_item).attr('data-uid'),
             is_dir: is_dir,

--- a/src/i18n/i18n.js
+++ b/src/i18n/i18n.js
@@ -20,7 +20,7 @@ import translations from './translations/translations.js';
 
 window.ListSupportedLanguages = () => Object.keys(translations).map(lang => translations[lang]);
 
-window.i18n = function (key, replacements = [], encode_html = true) {
+window.i18n = function (key, return_html = true, replacements = [], encode_html = true) {
     if(typeof replacements === 'boolean' && encode_html === undefined){
         encode_html = replacements;
         replacements = [];
@@ -61,6 +61,12 @@ window.i18n = function (key, replacements = [], encode_html = true) {
             str = str.replace('%%', replacements[i]);
         }
     }
+
+    // if a callers asks with the paramaeter "return_html == true", return the span element, otherwise return the string. 
+    if (return_html === true) {
+        str = `<span class='i18n' data-i18n-key="${key}">${str}</span>`;
+    }
+    
     return str;
 }
 

--- a/src/i18n/i18nChangeLanguage.js
+++ b/src/i18n/i18nChangeLanguage.js
@@ -22,6 +22,40 @@ function ChangeLanguage(lang) {
     window.mutate_user_preferences({
         language : lang,
     });
+
+    // -------------------------------------------
+            // Get all 'i18n' elements and update their text, title, and data name attributes based on the new language
+    // -------------------------------------------
+
+    // find all element with the 'i18n' class to replace their values based on the new translation
+    var elements = Array.prototype.slice.call(document.getElementsByClassName('i18n'))
+
+    //iterate over all the elements and change attribute values
+    elements.forEach(element => {
+        if (element.getAttribute('data-i18n-key') !== undefined && element.getAttribute('data-i18n-key') !== null && element.getAttribute('data-i18n-key') !== ""){
+            let i18n_key = element.getAttribute('data-i18n-key');
+            let i18n_text = i18n(element.getAttribute('data-i18n-key'), false);
+
+            // if there is no translation for this key, do not proceed
+            if (i18n_key === i18n_text)
+                return;
+            
+            // update the inner text of the element based on the new translation
+            if (element.innerText !== undefined && element.innerText.trim() !== ""){
+                element.innerText = html_encode(i18n_text);
+            }
+
+            // if there is a "title" attribute, change the attribute value base on the new translation
+            if (element.hasAttribute("title")) {
+                element.setAttribute("title", html_encode(i18n_text));
+            }
+
+            // if there is a "data-name" attribute, change the attribute value base on the new translation
+            if (element.hasAttribute("data-name")) {
+                element.setAttribute("data-name", html_encode(i18n_text));
+            }
+        }
+    });
 }
 
 export default ChangeLanguage;


### PR DESCRIPTION
Fixes #148. Added functionalities for i18n module to return html in order to grab elements and update relevant attributes based on the new language translation.

Added class `i18n` to the elements that need update at the time of changing language. In addition, a `data-i18n-key` attribute is added for elements that contains the i18n keys in order to make the correct translation.

`i18n()` function has been updated to include a new parameter `return_html = true` to return html element to be used in the application. 

For calls of `i18n()` to the title of  UI elements, a new attribute has been introduced to the UI modules (e.g., UIWindow, UIAlert) to include `i18n_key` field and set to the UI elements' `data-i18n-key` attribute.  