### PR TITLE
UIWindowRefer.js bugfix

### DIFF
--- a/src/UI/UIWindowRefer.js
+++ b/src/UI/UIWindowRefer.js
@@ -30,7 +30,7 @@ async function UIWindowRefer(options){
         h += `<p style="text-align: center; font-size: 16px; padding: 20px; font-weight: 400; margin: -10px 10px 20px 10px; -webkit-font-smoothing: antialiased; color: #5f626d;">${i18n('refer_friends_c2a')}</p>`;
         h += `<label style="font-weight: bold;">${i18n('invite_link')}</label>`;
         h += `<input type="text" style="margin-bottom:10px;" class="downloadable-link" readonly />`;
-        h += `<button class="button button-primary copy-downloadable-link" style="width:130px; white-space:nowrap; display:flex; justify-content: center;">${i18n('copy_link')}</button>` 
+        h += `<button class="button button-primary copy-downloadable-link" style="white-space:nowrap; text-align:center;">${i18n('copy_link')}</button>` 
         h += `<img class="share-copy-link-on-social" src="${window.icons['share-outline.svg']}">`;
     h += `</div>`;
 

--- a/src/UI/UIWindowRefer.js
+++ b/src/UI/UIWindowRefer.js
@@ -22,8 +22,6 @@ import UIPopover from './UIPopover.js'
 
 async function UIWindowRefer(options){
     let h = '';
-    let copy_btn_text = 'Copy Link';
-    let copied_btn_text = 'Copied!';
     const url = `${gui_origin}/?r=${user.referral_code}`;
 
     h += `<div>`;
@@ -32,7 +30,7 @@ async function UIWindowRefer(options){
         h += `<p style="text-align: center; font-size: 16px; padding: 20px; font-weight: 400; margin: -10px 10px 20px 10px; -webkit-font-smoothing: antialiased; color: #5f626d;">${i18n('refer_friends_c2a')}</p>`;
         h += `<label style="font-weight: bold;">${i18n('invite_link')}</label>`;
         h += `<input type="text" style="margin-bottom:10px;" class="downloadable-link" readonly />`;
-        h += `<button class="button button-primary copy-downloadable-link" style="width:130px;">${copy_btn_text}</button>`
+        h += `<button class="button button-primary copy-downloadable-link" style="width:130px; white-space:nowrap; display:flex; justify-content: center;">${i18n('copy_link')}</button>` 
         h += `<img class="share-copy-link-on-social" src="${window.icons['share-outline.svg']}">`;
     h += `</div>`;
 
@@ -110,9 +108,9 @@ async function UIWindowRefer(options){
             document.execCommand('copy');
         }
 
-        $(this).html(copied_btn_text);
+        $(this).html(i18n('copying'));
         setTimeout(function(){
-            $(copy_btn).html(copy_btn_text);
+            $(copy_btn).html(i18n('copy_link'));
         }, 1000);
     });
 }

--- a/src/i18n/translations/pl.js
+++ b/src/i18n/translations/pl.js
@@ -48,7 +48,7 @@ const pl = {
         continue: "Kontynuuj",
         copy: 'Kopiuj',
         copy_link: "Kopiuj Link",
-        copying: "Copying",
+        copying: "Kopiowanie",
         cover: 'Zakryj',
         create_account: "Stwórz konto",
         create_free_account: "Stwórz darmowe konto",


### PR DESCRIPTION
Changes:
- Changed copy link button text to the i18n translation.
- Translated an untranslated word in the polish translation.

## Before:

![img](https://github.com/HeyPuter/puter/assets/58781463/052d041f-299b-4d97-8d27-d41d21541bc0)

## After:
![img](https://github.com/HeyPuter/puter/assets/58781463/c1e6a89f-5bea-4c62-81a1-00bd484c1160)

Notes:
 - I had to add three styling changes to the button, because the translated text was overflowing.