### PR TITLE
Fix typo in parameter name

### DIFF
--- a/src/initgui.js
+++ b/src/initgui.js
@@ -969,7 +969,7 @@ window.initgui = async function(){
             && !$(e.target).hasClass('launch-search') 
             && !$(e.target).hasClass('launch-search-clear') 
             && $(e.target).closest('.start-app').length === 0  
-            && !isMobile.phone && !isMobile.table
+            && !isMobile.phone && !isMobile.tablet
             && !$(e.target).hasClass('popover')
             && $(e.target).parents('.popover').length === 0){
 


### PR DESCRIPTION
Randomly stumbled across this instance which calls `isMobile.table` instead of `isMobile.tablet`. Using the code from `isMobile.min.js` there was no parameter for `table` so I'm assuming this is unintentional. Apologies if it is