### PR TITLE
feat: Add support for running Puter self-hosted using the automatically built Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
 .dockerignore
 Dockerfile
 node_modules
+config
+data

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ dist/
 .env
 # this is for jetbrain IDEs
 .idea/
+config
+data

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,10 @@ FROM node:21-alpine
 # Set labels
 LABEL repo="https://github.com/HeyPuter/puter"
 LABEL license="AGPL-3.0,https://github.com/HeyPuter/puter/blob/master/LICENSE.txt"
-LABEL version="v1.2.40-beta"
+LABEL version="1.2.46-beta-1"
 
-# Debugging
-RUN apk add --no-cache bash # useful for debugging
+# Install git (required by Puter to check version)
+RUN apk add --no-cache git
 
 # Setup working directory
 RUN mkdir -p /opt/puter/app
@@ -24,7 +24,9 @@ USER node
 RUN npm cache clean --force \
     && npm install
 
-EXPOSE 4000
+EXPOSE 4100
 
+HEALTHCHECK  --interval=5m --timeout=3s \
+  CMD wget --no-verbose --tries=1 --spider http://localhost:4100/ || exit 1
 
 CMD [ "npm", "start" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN npm cache clean --force \
 
 EXPOSE 4100
 
-HEALTHCHECK  --interval=5m --timeout=3s \
-  CMD wget --no-verbose --tries=1 --spider http://localhost:4100/ || exit 1
+# HEALTHCHECK  --interval=5m --timeout=3s \
+#   CMD wget --no-verbose --tries=1 --spider http://localhost:4100/ || exit 1
 
 CMD [ "npm", "start" ]

--- a/README.md
+++ b/README.md
@@ -45,8 +45,14 @@ This will launch Puter at http://localhost:4000 (or the next available port).
 ### Using Docker
 
 ```bash
-git clone https://github.com/HeyPuter/puter
-cd puter
+docker run --rm -p 4100:4100 -v `pwd`/data:/opt/puter/app/volatile/runtime -v `pwd`/config:/opt/puter/app/volatile/config ghcr.io/heyputer/puter
+```
+
+### Using Docker Compose
+
+```bash
+mkdir puter && cd puter
+wget https://raw.githubusercontent.com/HeyPuter/puter/main/docker-compose.yml
 docker compose up
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,9 +17,9 @@ services:
     volumes:
       - ./config:/opt/puter/app/volatile/config
       - ./data:/opt/puter/app/volatile/runtime
-    healthcheck:
-      test: wget --no-verbose --tries=1 --spider http://localhost:4100 || exit 1
-      interval: 5m
-      timeout: 3s
-      retries: 3
-      start_period: 2m
+    # healthcheck:
+    #   test: wget --no-verbose --tries=1 --spider http://localhost:4100 || exit 1
+    #   interval: 5m
+    #   timeout: 3s
+    #   retries: 3
+    #   start_period: 2m

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,25 @@
-version: '3'
-
+---
+version: "3.8"
 services:
-  app:
-    build: ./
+  puter:
+    container_name: puter
+    image: ghcr.io/heyputer/puter:latest
+    pull_policy: always
+    # build: ./
+    restart: unless-stopped
     ports:
-      - 4000:4000    
+      - '4100:4100'
+    environment:
+      # TZ: Europe/Paris
+      # CONFIG_PATH: /etc/puter
+      PUID: 1000
+      PGID: 1000
+    volumes:
+      - ./config:/opt/puter/app/volatile/config
+      - ./data:/opt/puter/app/volatile/runtime
+    healthcheck:
+      test: wget --no-verbose --tries=1 --spider http://localhost:4100 || exit 1
+      interval: 5m
+      timeout: 3s
+      retries: 3
+      start_period: 2m


### PR DESCRIPTION
Hello team Puter!

First of all, thank you for releasing the backend of Puter into the world!
Been playing with it for a few hours, and I really like it :)

As promised, I've updated a bunch of things to support running Puter self-hosted without having to clone the entire repo locally.

In this PR you'll find:
1) Updated instructions on how to run Puter using Docker
2) Updated instructions on how to run Puter using Docker Compose
3) Updated Dockerfile to add missing `git` command (used by Puter to check if there's a new version available, as far as I can tell)
4) Updated Dockerfile to reflect the current app version
5) Updated ignore file to ignore the data & config folder used to persist files & config between runs, when running from the main repo
6) Placeholders for a healthcheck


Regarding that last point, to the folks at Puter: What's a good URL docker can check (from inside the container's context) to see if Puter is running healthy?
I've included, commented, an example of what that could/should look like, feel free to update accordingly.

Happy Puter'ing folks :)