### PR TITLE
Prevent calling String.repeat() with a negative number in dev console

### DIFF
--- a/packages/backend/src/services/DevConsoleService.js
+++ b/packages/backend/src/services/DevConsoleService.js
@@ -179,7 +179,7 @@ class DevConsoleService extends BaseService {
     generateSeparator(text) {
         text = text || '[ Dev Console ]';
         const totalWidth = process.stdout.columns;
-        const paddingSize = (totalWidth - text.length) / 2;
+        const paddingSize = Math.max((totalWidth - text.length) / 2, 0);
 
         // Construct the separator
         return '═'.repeat(Math.floor(paddingSize)) + text + '═'.repeat(Math.ceil(paddingSize));


### PR DESCRIPTION
If the number of columns is less than the length of the text string, we would previously call '='.repeat() with a negative number, which crashes. So, pass 0 if it would be negative.

This is not needed for the generateEnd() function below, because the number of columns can't be less than 0.

Fixes #203, but doesn't explain why that had a column count of 0.