### PR TITLE
fix: Fix permission errors when running Docker. Update Docker Compose & Docker instructions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 .dockerignore
 Dockerfile
 node_modules
-config
-data
+puter

--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,4 @@ dist/
 .env
 # this is for jetbrain IDEs
 .idea/
-config
-data
+puter

--- a/README.md
+++ b/README.md
@@ -45,13 +45,15 @@ This will launch Puter at http://localhost:4000 (or the next available port).
 ### Using Docker
 
 ```bash
-docker run --rm -p 4100:4100 -v `pwd`/data:/opt/puter/app/volatile/runtime -v `pwd`/config:/opt/puter/app/volatile/config ghcr.io/heyputer/puter
+mkdir puter && cd puter && mkdir config data && sudo chown -R 1000:1000 config data && docker run --rm -p 4100:4100 -v `pwd`/data:/opt/puter/app/volatile/runtime -v `pwd`/config:/opt/puter/app/volatile/config ghcr.io/heyputer/puter
 ```
 
 ### Using Docker Compose
 
 ```bash
 mkdir puter && cd puter
+mkdir data config
+sudo chown -R 1000:1000 config data
 wget https://raw.githubusercontent.com/HeyPuter/puter/main/docker-compose.yml
 docker compose up
 ```

--- a/README.md
+++ b/README.md
@@ -45,15 +45,15 @@ This will launch Puter at http://localhost:4000 (or the next available port).
 ### Using Docker
 
 ```bash
-mkdir puter && cd puter && mkdir config data && sudo chown -R 1000:1000 config data && docker run --rm -p 4100:4100 -v `pwd`/data:/opt/puter/app/volatile/runtime -v `pwd`/config:/opt/puter/app/volatile/config ghcr.io/heyputer/puter
+mkdir puter && cd puter && mkdir -p puter/config puter/runtime && sudo chown -R 1000:1000 puter && docker run --rm -p 4100:4100 -v `pwd`/data:/opt/puter/app/volatile/runtime -v `pwd`/config:/opt/puter/app/volatile/config ghcr.io/heyputer/puter
 ```
 
 ### Using Docker Compose
 
 ```bash
 mkdir puter && cd puter
-mkdir data config
-sudo chown -R 1000:1000 config data
+mkdir -p puter/config puter/runtime
+sudo chown -R 1000:1000 puter
 wget https://raw.githubusercontent.com/HeyPuter/puter/main/docker-compose.yml
 docker compose up
 ```

--- a/README.md
+++ b/README.md
@@ -45,14 +45,14 @@ This will launch Puter at http://localhost:4000 (or the next available port).
 ### Using Docker
 
 ```bash
-mkdir puter && cd puter && mkdir -p puter/config puter/runtime && sudo chown -R 1000:1000 puter && docker run --rm -p 4100:4100 -v `pwd`/data:/opt/puter/app/volatile/runtime -v `pwd`/config:/opt/puter/app/volatile/config ghcr.io/heyputer/puter
+mkdir puter && cd puter && mkdir -p puter/config puter/data && sudo chown -R 1000:1000 puter && docker run --rm -p 4100:4100 -v `pwd`/puter/config:/etc/puter -v `pwd`/puter/data:/var/puter  ghcr.io/heyputer/puter
 ```
 
 ### Using Docker Compose
 
 ```bash
 mkdir puter && cd puter
-mkdir -p puter/config puter/runtime
+mkdir -p puter/config puter/data
 sudo chown -R 1000:1000 puter
 wget https://raw.githubusercontent.com/HeyPuter/puter/main/docker-compose.yml
 docker compose up

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,8 @@ services:
       PUID: 1000
       PGID: 1000
     volumes:
-      - ./puter/config:/opt/puter/app/volatile/config
-      - ./puter/runtime:/opt/puter/app/volatile/runtime
+      - ./puter/config:/etc/puter
+      - ./puter/data:/var/puter
     healthcheck:
       test: wget --no-verbose --tries=1 --spider http://puter.localhost:4100/test || exit 1
       interval: 30s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,8 @@ services:
       PUID: 1000
       PGID: 1000
     volumes:
-      - ./volatile/config:/opt/puter/app/volatile/config
-      - ./volatile/runtime:/opt/puter/app/volatile/runtime
+      - ./puter/config:/opt/puter/app/volatile/config
+      - ./puter/runtime:/opt/puter/app/volatile/runtime
     healthcheck:
       test: wget --no-verbose --tries=1 --spider http://puter.localhost:4100/test || exit 1
       interval: 30s


### PR DESCRIPTION
Fixes #209 

Docker Compose was configured to run as the user ID (UID) 1000 and group ID (GID) 1000,
which correspond to the `node` user inside the container image.

However by default, when the docker daemon creates a folder does not yet exists
and that is required to mount into a container, it creates that folder as owned
by root (UID & GID == `0`).

That caused puter to be unable to start, as it couldn't access the 2 mounted folders.

This PR fixes this.

cc @KernelDeimos @jelveh 