### PR TITLE
Add requirements for multi-platform docker build to the CI

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -79,7 +79,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64, linux/arm/v7
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -79,7 +79,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
-          platforms: linux/amd64,linux/arm6
+          platforms: linux/amd64,linux/arm64
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -79,7 +79,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
-          platforms: linux/amd64,linux/arm64, linux/arm/v7
+          platforms: linux/amd64,linux/arm64
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -79,7 +79,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
-          platforms: linux/amd64,linux/386,linux/arm64,linux/arm/v7,linux/arm/v6,linux/ppc64le,linux/s390x
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -40,6 +40,12 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Set up QEMU 
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
 
       # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about)
       # to extract tags and labels that will be applied to the specified image.

--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -79,7 +79,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
+          platforms: linux/amd64,linux/arm6
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ LABEL version="1.2.46-beta-1"
 # python3 would be required by node-gyp to natively build node addon 
 # This is required if we build for multi-platform
 RUN apk add --no-cache git python3 make g++ \
-    && ln -s /usr/bin/python3 /usr/bin/python
+    && ln -sf /usr/bin/python3 /usr/bin/python
     
 # Setup working directory
 RUN mkdir -p /opt/puter/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,11 @@ LABEL license="AGPL-3.0,https://github.com/HeyPuter/puter/blob/master/LICENSE.tx
 LABEL version="1.2.46-beta-1"
 
 # Install git (required by Puter to check version)
-RUN apk add --no-cache git
-
+# python3 would be required by node-gyp to natively build node addon 
+# This is required if we build for multi-platform
+RUN apk add --no-cache git python3 make g++ \
+    && ln -s /usr/bin/python3 /usr/bin/python
+    
 # Setup working directory
 RUN mkdir -p /opt/puter/app
 WORKDIR /opt/puter/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,27 @@
+# Build stage
+FROM node:21-alpine AS build
+
+# Install build dependencies
+RUN apk add --no-cache git python3 make g++ \
+    && ln -sf /usr/bin/python3 /usr/bin/python
+
+# Set up working directory
+WORKDIR /app
+
+# Copy package.json and package-lock.json
+COPY package*.json ./
+
+# Install node modules
+RUN npm cache clean --force \
+    && npm ci
+
+# Copy the rest of the source files
+COPY . .
+
+# Run the build command if necessary
+RUN npm run build
+
+# Production stage
 FROM node:21-alpine
 
 # Set labels
@@ -6,30 +30,24 @@ LABEL license="AGPL-3.0,https://github.com/HeyPuter/puter/blob/master/LICENSE.tx
 LABEL version="1.2.46-beta-1"
 
 # Install git (required by Puter to check version)
-# python3 would be required by node-gyp to natively build node addon 
-# This is required if we build for multi-platform
-RUN apk add --no-cache git python3 make g++ \
-    && ln -sf /usr/bin/python3 /usr/bin/python
-    
-# Setup working directory
+RUN apk add --no-cache git
+
+# Set up working directory
 RUN mkdir -p /opt/puter/app
 WORKDIR /opt/puter/app
 
-# Add source files
-# NOTE: This might change (https://github.com/HeyPuter/puter/discussions/32)
-COPY . .
+# Copy built artifacts and necessary files from the build stage
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/node_modules ./node_modules
+COPY package*.json ./
 
 # Set permissions
 RUN chown -R node:node /opt/puter/app
 USER node
 
-# Install node modules
-RUN npm cache clean --force \
-    && npm install
-
 EXPOSE 4100
 
-HEALTHCHECK  --interval=30s --timeout=3s \
-  CMD wget --no-verbose --tries=1 --spider http://puter.localhost:4100/test || exit 1
+HEALTHCHECK --interval=30s --timeout=3s \
+    CMD wget --no-verbose --tries=1 --spider http://puter.localhost:4100/test || exit 1
 
-CMD [ "npm", "start" ]
+CMD ["npm", "start"]


### PR DESCRIPTION
This PR address the problem of multi-platform docker image build. 

I would suggest adding a separate docker CI to test the build process without publishing to GitHub registry. And then we can add trigger on PRs. 