### PR TITLE
fixing issues in copy while overwriting

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1579,8 +1579,13 @@ window.copy_clipboard_items = async function(dest_path, dest_container_element){
                             dedupeName: dest_path === path.dirname(copy_path),
                     });
 
+                    // remove overwritten item from the DOM
+                    if(resp[0].overwritten?.id){
+                        $(`.item[data-uid=${resp[0].overwritten.id}]`).removeItems();
+                    }
+
                     // copy new path for undo copy
-                    copied_item_paths.push(resp[0].path);
+                    copied_item_paths.push(resp[0].copied.path);
 
                     // skips next loop iteration
                     break;
@@ -1676,8 +1681,13 @@ window.copy_items = function(el_items, dest_path){
                             dedupeName: dest_path === path.dirname(copy_path),
                     })
 
+                    // remove overwritten item from the DOM
+                    if(resp[0].overwritten?.id){
+                        $(`.item[data-uid=${resp.overwritten.id}]`).removeItems();
+                    }
+
                     // copy new path for undo copy
-                    copied_item_paths.push(resp[0].path);
+                    copied_item_paths.push(resp[0].copied.path);
 
                     // skips next loop iteration
                     item_with_same_name_already_exists = false;


### PR DESCRIPTION
This PR closes #80 

options.user.id was causing the issue since there is no variable named options, has to change it to values

The other changes are related to handling the removal of overwritten item from DOM on the frontend.

Followed a similar approach to move operation, returned the overwritten item id in the api response and removed the item with that uid from DOM.