### PR TITLE
Notify apps when a child app closes, and let them close their children manually

### DIFF
--- a/src/IPC.js
+++ b/src/IPC.js
@@ -1100,6 +1100,43 @@ window.addEventListener('message', async (event) => {
             contents,
         }, targetAppOrigin);
     }
+    //--------------------------------------------------------
+    // closeApp
+    //--------------------------------------------------------
+    else if (event.data.msg === 'closeApp') {
+        const { appInstanceID, targetAppInstanceID } = event.data;
+
+        const target_window = window_for_app_instance(targetAppInstanceID);
+        if (!target_window) {
+            console.warn(`Failed to close non-existent app ${targetAppInstanceID}`);
+            return;
+        }
+
+        // Check permissions
+        const allowed = (() => {
+            // Parents can close their children
+            if (target_window.dataset['parent_instance_id']) {
+                console.log(`⚠️ Allowing app ${appInstanceID} to close child app ${targetAppInstanceID}`);
+                return true;
+            }
+
+            // God-mode apps can close anything
+            const app_info = await get_apps(app_name);
+            if (app_info.godmode === 1) {
+                console.log(`⚠️ Allowing GODMODE app ${appInstanceID} to close app ${targetAppInstanceID}`);
+                return true;
+            }
+
+            // TODO: What other situations should we allow?
+            return false;
+        })();
+
+        if (allowed) {
+            $(target_window).close();
+        } else {
+            console.warn(`⚠️ App ${appInstanceID} is not permitted to close app ${targetAppInstanceID}`);
+        }
+    }
 
     //--------------------------------------------------------
     // exit

--- a/src/IPC.js
+++ b/src/IPC.js
@@ -74,11 +74,15 @@ window.addEventListener('message', async (event) => {
         return;
     }
 
-    const iframe_for_app_instance = (instanceID) => {
-        return $(`.window[data-element_uuid="${instanceID}"]`).find('.window-app-iframe').get(0)
+    const window_for_app_instance = (instance_id) => {
+        return $(`.window[data-element_uuid="${instance_id}"]`).get(0);
     };
 
-    const $el_parent_window = $(`.window[data-element_uuid="${event.data.appInstanceID}"]`);
+    const iframe_for_app_instance = (instance_id) => {
+        return $(window_for_app_instance(instance_id)).find('.window-app-iframe').get(0);
+    };
+
+    const $el_parent_window = $(window_for_app_instance(event.data.appInstanceID));
     const parent_window_id = $el_parent_window.attr('data-id');
     const $el_parent_disable_mask = $el_parent_window.find('.window-disable-mask');
     const target_iframe = iframe_for_app_instance(event.data.appInstanceID);
@@ -354,7 +358,7 @@ window.addEventListener('message', async (event) => {
     // setWindowTitle
     //--------------------------------------------------------
     else if(event.data.msg === 'setWindowTitle' && event.data.new_title !== undefined){
-        const el_window = $(`.window[data-element_uuid="${event.data.appInstanceID}"]`).get(0);
+        const el_window = window_for_app_instance(event.data.appInstanceID);
         // set window title
         $(el_window).find(`.window-head-title`).html(html_encode(event.data.new_title));
         // send confirmation to requester window
@@ -1101,6 +1105,6 @@ window.addEventListener('message', async (event) => {
     // exit
     //--------------------------------------------------------
     else if(event.data.msg === 'exit'){
-        $(`.window[data-element_uuid="${event.data.appInstanceID}"]`).close({bypass_iframe_messaging: true});
+        $(window_for_app_instance(event.data.appInstanceID)).close({bypass_iframe_messaging: true});
     }
 });

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1853,6 +1853,10 @@ window.launch_app = async (options)=>{
     let icon, title, file_signature;
     const window_options = options.window_options ?? {};
 
+    if (options.parent_instance_id) {
+        window_options.parent_instance_id = options.parent_instance_id;
+    }
+
     // try to get 3rd-party app info
     let app_info = options.app_obj ?? await get_apps(options.name);
 


### PR DESCRIPTION
Two parts to this, both related to closing. Further details in commit messages. See also https://github.com/HeyPuter/puter.js/pull/12 which is the puter.js part.

### Send an `appClosed` event to parent/child apps when an app is closed.

For now, the only close notifications are from child -> parent, and parent -> child, because that relationship is represented in the DOM. I think we need a proper representation in JS for what connections apps have between each other. It's been suggested for apps to be able to discover other running apps and communicate with them, and `AppConnection` can reasonably support this, but Puter itself would need to know that those connections exist to be able to send `appClosed` events, and whatever else.

### Listen to the 'closeApp' message, allowing apps to request to close other apps.

Currently, this is limited to apps being able to close their children, and godmode apps being able to close anything.