### PR TITLE
Fix permission check for closeApp message

### DIFF
--- a/src/IPC.js
+++ b/src/IPC.js
@@ -1116,9 +1116,9 @@ window.addEventListener('message', async (event) => {
         }
 
         // Check permissions
-        const allowed = (() => {
+        const allowed = await (async () => {
             // Parents can close their children
-            if (target_window.dataset['parent_instance_id']) {
+            if (target_window.dataset['parent_instance_id'] === appInstanceID) {
                 console.log(`⚠️ Allowing app ${appInstanceID} to close child app ${targetAppInstanceID}`);
                 return true;
             }


### PR DESCRIPTION
Firstly, I was missing an `async` here, which somehow still worked for me then, but produced errors for me when I tried it today.

Then, actually await the promise.

Finally, actually check the target's parent is us, and not just that it has the attribute!

I don't know what was going on in my head that day. 🤦‍♂️