### PR TITLE
fixing on conflict issue in sqlite kv write

### DIFF
--- a/packages/backend/src/services/database/sqlite_setup/0001_create-tables.sql
+++ b/packages/backend/src/services/database/sqlite_setup/0001_create-tables.sql
@@ -120,7 +120,10 @@ CREATE TABLE `kv` (
   `value` text,
 
   -- 0016
-    `migrated` tinyint(1) DEFAULT '0'
+    `migrated` tinyint(1) DEFAULT '0',
+  
+  -- 0019
+    UNIQUE (user_id, app, kkey_hash)
 );
 
 CREATE TABLE `subdomains` (

--- a/packages/backend/src/services/drivers/implementations/DBKVStore.js
+++ b/packages/backend/src/services/drivers/implementations/DBKVStore.js
@@ -90,8 +90,7 @@ class DBKVStore extends BaseImplementation {
                     VALUES (?, ?, ?, ?, ?) ` +
                     db.case({
                         mysql: 'ON DUPLICATE KEY UPDATE value = ?',
-                        sqlite: ' ',
-                        // sqlite: 'ON CONFLICT(user_id, app, kkey_hash) DO UPDATE SET value = ?',
+                        sqlite: 'ON CONFLICT(user_id, app, kkey_hash) DO UPDATE SET value = excluded.value',
                     }),
                     [
                         user.id, app?.uid ?? 'global', key_hash, key, value,


### PR DESCRIPTION
Closes #206

Currently, the UPSERT query on kv table in sqlite is not properly handled causing new rows to get added for the same key instead of the existing row getting updated. 

This was causing issues when updating languages and others preferences.

