### PR TITLE
Settings: Organise code to be grouped by tab, and add desktop background picker

### DIFF
--- a/src/UI/Settings/UITabAbout.js
+++ b/src/UI/Settings/UITabAbout.js
@@ -18,79 +18,109 @@
  */
 
 // About
-function UITabAbout(){
-    let h = ``;
-
-    h += `<div class="settings-content active" data-settings="about">`;
-        h += `<div class="about-container">`
-        h += `<div class="about">
-                <a href="https://puter.com" target="_blank" class="logo"><img src="/images/logo.png"></a>
-                <p class="description">${i18n('puter_description')}</p>
-                <p class="links">
-                    <a href="mailto:hey@puter.com" target="_blank">hey@puter.com</a>
-                    <span style="color: #CCC;">•</span>
-                    <a href="https://docs.puter.com" target="_blank">${i18n('developers')}</a>
-                    <span style="color: #CCC;">•</span>
-                    <a href="https://status.puter.com" target="_blank">${i18n('status')}</a>
-                    <span style="color: #CCC;">•</span>
-                    <a href="https://puter.com/terms" target="_blank">${i18n('terms')}</a>
-                    <span style="color: #CCC;">•</span>
-                    <a href="https://puter.com/privacy" target="_blank">${i18n('privacy')}</a>
-                    <span style="color: #CCC;">•</span>
-                    <a href="#" class="show-credits">${i18n('credits')}</a>
-                </p>
-                <div class="social-links">
-                    <a href="https://twitter.com/HeyPuter/" target="_blank">
-                        <svg viewBox="0 0 24 24" aria-hidden="true" style="opacity: 0.7;"><g><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"></path></g></svg>
-                    </a>
-                    <a href="https://github.com/HeyPuter/" target="_blank">
-                        <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="48px" height="48px" viewBox="0 0 48 48">
-                            <g transform="translate(0, 0)">
-                                <path fill-rule="evenodd" clip-rule="evenodd" fill="#5a606b" d="M24,0.6c-13.3,0-24,10.7-24,24c0,10.6,6.9,19.6,16.4,22.8 c1.2,0.2,1.6-0.5,1.6-1.2c0-0.6,0-2.1,0-4.1c-6.7,1.5-8.1-3.2-8.1-3.2c-1.1-2.8-2.7-3.5-2.7-3.5c-2.2-1.5,0.2-1.5,0.2-1.5 c2.4,0.2,3.7,2.5,3.7,2.5c2.1,3.7,5.6,2.6,7,2c0.2-1.6,0.8-2.6,1.5-3.2c-5.3-0.6-10.9-2.7-10.9-11.9c0-2.6,0.9-4.8,2.5-6.4 c-0.2-0.6-1.1-3,0.2-6.4c0,0,2-0.6,6.6,2.5c1.9-0.5,4-0.8,6-0.8c2,0,4.1,0.3,6,0.8c4.6-3.1,6.6-2.5,6.6-2.5c1.3,3.3,0.5,5.7,0.2,6.4 c1.5,1.7,2.5,3.8,2.5,6.4c0,9.2-5.6,11.2-11,11.8c0.9,0.7,1.6,2.2,1.6,4.4c0,3.2,0,5.8,0,6.6c0,0.6,0.4,1.4,1.7,1.2 C41.1,44.2,48,35.2,48,24.6C48,11.3,37.3,0.6,24,0.6z">
-                                </path>
-                            </g>
-                        </svg>
-                    </a>
-                    <a href="https://discord.gg/PQcx7Teh8u" target="_blank">
-                        <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="48px" height="48px" viewBox="0 0 48 48"><g transform="translate(0, 0)"><path d="M19.837,20.3a2.562,2.562,0,0,0,0,5.106,2.562,2.562,0,0,0,0-5.106Zm8.4,0a2.562,2.562,0,1,0,2.346,2.553A2.45,2.45,0,0,0,28.232,20.3Z" fill="#444444" data-color="color-2"></path> <path d="M39.41,1H8.59A4.854,4.854,0,0,0,4,6V37a4.482,4.482,0,0,0,4.59,4.572H34.672l-1.219-4.255L36.4,40.054,39.18,42.63,44,47V6A4.854,4.854,0,0,0,39.41,1ZM30.532,31.038s-.828-.989-1.518-1.863a7.258,7.258,0,0,0,4.163-2.737A13.162,13.162,0,0,1,30.532,27.8a15.138,15.138,0,0,1-3.335.989,16.112,16.112,0,0,1-5.957-.023,19.307,19.307,0,0,1-3.381-.989,13.112,13.112,0,0,1-2.622-1.357,7.153,7.153,0,0,0,4.025,2.714c-.69.874-1.541,1.909-1.541,1.909-5.083-.161-7.015-3.5-7.015-3.5a30.8,30.8,0,0,1,3.312-13.409,11.374,11.374,0,0,1,6.463-2.415l.23.276a15.517,15.517,0,0,0-6.049,3.013s.506-.276,1.357-.667a17.272,17.272,0,0,1,5.221-1.449,2.266,2.266,0,0,1,.391-.046,19.461,19.461,0,0,1,4.646-.046A18.749,18.749,0,0,1,33.2,15.007a15.307,15.307,0,0,0-5.727-2.921l.322-.368a11.374,11.374,0,0,1,6.463,2.415A30.8,30.8,0,0,1,37.57,27.542S35.615,30.877,30.532,31.038Z" fill="#444444"></path></g></svg>            </a>
-                    <a href="https://www.linkedin.com/company/puter/" target="_blank">
-                        <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="48px" height="48px" viewBox="0 0 48 48">
-                            <g transform="translate(0, 0)">
-                                <path fill="#5a606b" d="M46,0H2C0.9,0,0,0.9,0,2v44c0,1.1,0.9,2,2,2h44c1.1,0,2-0.9,2-2V2C48,0.9,47.1,0,46,0z M14.2,40.9H7.1V18 h7.1V40.9z M10.7,14.9c-2.3,0-4.1-1.8-4.1-4.1c0-2.3,1.8-4.1,4.1-4.1c2.3,0,4.1,1.8,4.1,4.1C14.8,13,13,14.9,10.7,14.9z M40.9,40.9 h-7.1V29.8c0-2.7,0-6.1-3.7-6.1c-3.7,0-4.3,2.9-4.3,5.9v11.3h-7.1V18h6.8v3.1h0.1c0.9-1.8,3.3-3.7,6.7-3.7c7.2,0,8.5,4.7,8.5,10.9 V40.9z">
-                                </path>
-                            </g>
-                        </svg>
-                    </a>
-                </div>
-            </div>
-            <div class="version"></div>
-
-            <dialog class="credits">
-                <div class="credit-content">
-                    <p style="margin: 0; font-size: 18px; text-align: center;">${i18n('oss_code_and_content')}</p>
-                    <div style="max-height: 300px; overflow-y: scroll;">
-                        <ul style="padding-left: 25px; padding-top:15px;">
-                            <li>FileSaver.js <a target="_blank" href="https://github.com/eligrey/FileSaver.js/blob/master/LICENSE.md">${i18n('license')}</a></li>
-                            <li>html-entities <a target="_blank" href="https://github.com/mdevils/html-entities/blob/master/LICENSE">${i18n('license')}</a></li>
-                            <li>iro.js <a target="_blank" href="https://github.com/jaames/iro.js/blob/master/LICENSE.txt">${i18n('license')}</a></li>
-                            <li>jQuery <a target="_blank" href="https://jquery.org/license/">${i18n('license')}</a></li>
-                            <li>jQuery-dragster <a target="_blank" href="https://github.com/catmanjan/jquery-dragster/blob/master/LICENSE">${i18n('license')}</a></li>
-                            <li>jQuery-menu-aim <a target="_blank" href="https://github.com/kamens/jQuery-menu-aim?tab=readme-ov-file#faq">${i18n('license')}</a></li>
-                            <li>jQuery UI <a target="_blank" href="https://jquery.org/license/">${i18n('license')}</a></li>
-                            <li>lodash <a target="_blank" href="https://lodash.com/license">${i18n('license')}</a></li>
-                            <li>mime <a target="_blank" href="https://github.com/broofa/mime/blob/main/LICENSE">${i18n('license')}</a></li>
-                            <li>qrcodejs <a target="_blank" href="https://github.com/davidshimjs/qrcodejs/blob/master/LICENSE">${i18n('license')}</a></li>
-                            <li>Selection <a target="_blank" href="https://github.com/simonwep/selection/blob/master/LICENSE">${i18n('license')}</a></li>
-                            <li>socket.io <a target="_blank" href="https://github.com/socketio/socket.io/blob/main/LICENSE">${i18n('license')}</a></li>
-                            <li>Wallpaper by <a target="_blank" href="https://unsplash.com/@fakurian?utm_content=creditCopyText&utm_medium=referral&utm_source=unsplash">Milad Fakurian</a> on <a target="_blank" href="https://unsplash.com/photos/blue-orange-and-yellow-wallpaper-E8Ufcyxz514?utm_content=creditCopyText&utm_medium=referral&utm_source=unsplash">Unsplash</a></li>
-                        </ul>
+export default {
+    id: 'about',
+    title_i18n_key: 'about',
+    icon: 'logo-outline.svg',
+    html: () => {
+        return `
+            <div class="about-container">
+                <div class="about">
+                    <a href="https://puter.com" target="_blank" class="logo"><img src="/images/logo.png"></a>
+                    <p class="description">${i18n('puter_description')}</p>
+                    <p class="links">
+                        <a href="mailto:hey@puter.com" target="_blank">hey@puter.com</a>
+                        <span style="color: #CCC;">•</span>
+                        <a href="https://docs.puter.com" target="_blank">${i18n('developers')}</a>
+                        <span style="color: #CCC;">•</span>
+                        <a href="https://status.puter.com" target="_blank">${i18n('status')}</a>
+                        <span style="color: #CCC;">•</span>
+                        <a href="https://puter.com/terms" target="_blank">${i18n('terms')}</a>
+                        <span style="color: #CCC;">•</span>
+                        <a href="https://puter.com/privacy" target="_blank">${i18n('privacy')}</a>
+                        <span style="color: #CCC;">•</span>
+                        <a href="#" class="show-credits">${i18n('credits')}</a>
+                    </p>
+                    <div class="social-links">
+                        <a href="https://twitter.com/HeyPuter/" target="_blank">
+                            <svg viewBox="0 0 24 24" aria-hidden="true" style="opacity: 0.7;"><g><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"></path></g></svg>
+                        </a>
+                        <a href="https://github.com/HeyPuter/" target="_blank">
+                            <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="48px" height="48px" viewBox="0 0 48 48">
+                                <g transform="translate(0, 0)">
+                                    <path fill-rule="evenodd" clip-rule="evenodd" fill="#5a606b" d="M24,0.6c-13.3,0-24,10.7-24,24c0,10.6,6.9,19.6,16.4,22.8 c1.2,0.2,1.6-0.5,1.6-1.2c0-0.6,0-2.1,0-4.1c-6.7,1.5-8.1-3.2-8.1-3.2c-1.1-2.8-2.7-3.5-2.7-3.5c-2.2-1.5,0.2-1.5,0.2-1.5 c2.4,0.2,3.7,2.5,3.7,2.5c2.1,3.7,5.6,2.6,7,2c0.2-1.6,0.8-2.6,1.5-3.2c-5.3-0.6-10.9-2.7-10.9-11.9c0-2.6,0.9-4.8,2.5-6.4 c-0.2-0.6-1.1-3,0.2-6.4c0,0,2-0.6,6.6,2.5c1.9-0.5,4-0.8,6-0.8c2,0,4.1,0.3,6,0.8c4.6-3.1,6.6-2.5,6.6-2.5c1.3,3.3,0.5,5.7,0.2,6.4 c1.5,1.7,2.5,3.8,2.5,6.4c0,9.2-5.6,11.2-11,11.8c0.9,0.7,1.6,2.2,1.6,4.4c0,3.2,0,5.8,0,6.6c0,0.6,0.4,1.4,1.7,1.2 C41.1,44.2,48,35.2,48,24.6C48,11.3,37.3,0.6,24,0.6z">
+                                    </path>
+                                </g>
+                            </svg>
+                        </a>
+                        <a href="https://discord.gg/PQcx7Teh8u" target="_blank">
+                            <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="48px" height="48px" viewBox="0 0 48 48"><g transform="translate(0, 0)"><path d="M19.837,20.3a2.562,2.562,0,0,0,0,5.106,2.562,2.562,0,0,0,0-5.106Zm8.4,0a2.562,2.562,0,1,0,2.346,2.553A2.45,2.45,0,0,0,28.232,20.3Z" fill="#444444" data-color="color-2"></path> <path d="M39.41,1H8.59A4.854,4.854,0,0,0,4,6V37a4.482,4.482,0,0,0,4.59,4.572H34.672l-1.219-4.255L36.4,40.054,39.18,42.63,44,47V6A4.854,4.854,0,0,0,39.41,1ZM30.532,31.038s-.828-.989-1.518-1.863a7.258,7.258,0,0,0,4.163-2.737A13.162,13.162,0,0,1,30.532,27.8a15.138,15.138,0,0,1-3.335.989,16.112,16.112,0,0,1-5.957-.023,19.307,19.307,0,0,1-3.381-.989,13.112,13.112,0,0,1-2.622-1.357,7.153,7.153,0,0,0,4.025,2.714c-.69.874-1.541,1.909-1.541,1.909-5.083-.161-7.015-3.5-7.015-3.5a30.8,30.8,0,0,1,3.312-13.409,11.374,11.374,0,0,1,6.463-2.415l.23.276a15.517,15.517,0,0,0-6.049,3.013s.506-.276,1.357-.667a17.272,17.272,0,0,1,5.221-1.449,2.266,2.266,0,0,1,.391-.046,19.461,19.461,0,0,1,4.646-.046A18.749,18.749,0,0,1,33.2,15.007a15.307,15.307,0,0,0-5.727-2.921l.322-.368a11.374,11.374,0,0,1,6.463,2.415A30.8,30.8,0,0,1,37.57,27.542S35.615,30.877,30.532,31.038Z" fill="#444444"></path></g></svg>            </a>
+                        <a href="https://www.linkedin.com/company/puter/" target="_blank">
+                            <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="48px" height="48px" viewBox="0 0 48 48">
+                                <g transform="translate(0, 0)">
+                                    <path fill="#5a606b" d="M46,0H2C0.9,0,0,0.9,0,2v44c0,1.1,0.9,2,2,2h44c1.1,0,2-0.9,2-2V2C48,0.9,47.1,0,46,0z M14.2,40.9H7.1V18 h7.1V40.9z M10.7,14.9c-2.3,0-4.1-1.8-4.1-4.1c0-2.3,1.8-4.1,4.1-4.1c2.3,0,4.1,1.8,4.1,4.1C14.8,13,13,14.9,10.7,14.9z M40.9,40.9 h-7.1V29.8c0-2.7,0-6.1-3.7-6.1c-3.7,0-4.3,2.9-4.3,5.9v11.3h-7.1V18h6.8v3.1h0.1c0.9-1.8,3.3-3.7,6.7-3.7c7.2,0,8.5,4.7,8.5,10.9 V40.9z">
+                                    </path>
+                                </g>
+                            </svg>
+                        </a>
                     </div>
                 </div>
-            </dialog>                    
-            `;
-        h += `</div>`;
-    h += `</div>`;
+                <div class="version"></div>
+    
+                <dialog class="credits">
+                    <div class="credit-content">
+                        <p style="margin: 0; font-size: 18px; text-align: center;">${i18n('oss_code_and_content')}</p>
+                        <div style="max-height: 300px; overflow-y: scroll;">
+                            <ul style="padding-left: 25px; padding-top:15px;">
+                                <li>FileSaver.js <a target="_blank" href="https://github.com/eligrey/FileSaver.js/blob/master/LICENSE.md">${i18n('license')}</a></li>
+                                <li>html-entities <a target="_blank" href="https://github.com/mdevils/html-entities/blob/master/LICENSE">${i18n('license')}</a></li>
+                                <li>iro.js <a target="_blank" href="https://github.com/jaames/iro.js/blob/master/LICENSE.txt">${i18n('license')}</a></li>
+                                <li>jQuery <a target="_blank" href="https://jquery.org/license/">${i18n('license')}</a></li>
+                                <li>jQuery-dragster <a target="_blank" href="https://github.com/catmanjan/jquery-dragster/blob/master/LICENSE">${i18n('license')}</a></li>
+                                <li>jQuery-menu-aim <a target="_blank" href="https://github.com/kamens/jQuery-menu-aim?tab=readme-ov-file#faq">${i18n('license')}</a></li>
+                                <li>jQuery UI <a target="_blank" href="https://jquery.org/license/">${i18n('license')}</a></li>
+                                <li>lodash <a target="_blank" href="https://lodash.com/license">${i18n('license')}</a></li>
+                                <li>mime <a target="_blank" href="https://github.com/broofa/mime/blob/main/LICENSE">${i18n('license')}</a></li>
+                                <li>qrcodejs <a target="_blank" href="https://github.com/davidshimjs/qrcodejs/blob/master/LICENSE">${i18n('license')}</a></li>
+                                <li>Selection <a target="_blank" href="https://github.com/simonwep/selection/blob/master/LICENSE">${i18n('license')}</a></li>
+                                <li>socket.io <a target="_blank" href="https://github.com/socketio/socket.io/blob/main/LICENSE">${i18n('license')}</a></li>
+                                <li>Wallpaper by <a target="_blank" href="https://unsplash.com/@fakurian?utm_content=creditCopyText&utm_medium=referral&utm_source=unsplash">Milad Fakurian</a> on <a target="_blank" href="https://unsplash.com/photos/blue-orange-and-yellow-wallpaper-E8Ufcyxz514?utm_content=creditCopyText&utm_medium=referral&utm_source=unsplash">Unsplash</a></li>
+                            </ul>
+                        </div>
+                    </div>
+                </dialog>
+            </div>`;
+    },
+    init: ($el_window) => {
+        // version
+        $.ajax({
+            url: api_origin + "/version",
+            type: 'GET',
+            async: true,
+            contentType: "application/json",
+            headers: {
+                "Authorization": "Bearer " + auth_token
+            },
+            statusCode: {
+                401: function () {
+                    logout();
+                },
+            },
+            success: function (res) {
+                var d = new Date(0);
+                $el_window.find('.version').html('Version: ' + res.version + ' &bull; ' + 'Server: ' + res.location + ' &bull; ' + 'Deployed: ' + new Date(res.deploy_timestamp));
+            }
+        });
 
-    return h;
-}
-export default UITabAbout;
+        $el_window.find('.credits').on('click', function (e) {
+            if($(e.target).hasClass('credits')){
+                $('.credits').get(0).close();
+            }
+        });
+
+        $el_window.find('.show-credits').on('click', function (e) {
+            $('.credits').get(0).showModal();
+        })
+
+    },
+};

--- a/src/UI/Settings/UITabAccount.js
+++ b/src/UI/Settings/UITabAccount.js
@@ -1,0 +1,134 @@
+/**
+ * Copyright (C) 2024 Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import UIWindowChangePassword from '../UIWindowChangePassword.js';
+import UIWindowChangeEmail from './UIWindowChangeEmail.js';
+import UIWindowChangeUsername from '../UIWindowChangeUsername.js';
+import UIWindowConfirmUserDeletion from './UIWindowConfirmUserDeletion.js';
+import UIWindowManageSessions from '../UIWindowManageSessions.js';
+
+// About
+export default {
+    id: 'account',
+    title_i18n_key: 'account',
+    icon: 'user.svg',
+    html: () => {
+        let h = `<h1>${i18n('account')}</h1>`;
+        // change password button
+        h += `<div class="settings-card">`;
+            h += `<strong>${i18n('password')}</strong>`;
+            h += `<div style="flex-grow:1;">`;
+                h += `<button class="button change-password" style="float:right;">${i18n('change_password')}</button>`;
+            h += `</div>`;
+        h += `</div>`;
+
+        // change username button
+        h += `<div class="settings-card">`;
+            h += `<div>`;
+                h += `<strong style="display:block;">${i18n('username')}</strong>`;
+                h += `<span class="username" style="display:block; margin-top:5px;">${user.username}</span>`;
+            h += `</div>`;
+            h += `<div style="flex-grow:1;">`;
+                h += `<button class="button change-username" style="float:right;">${i18n('change_username')}</button>`;
+            h += `</div>`
+        h += `</div>`;
+
+        // change email button
+        if(user.email){
+            h += `<div class="settings-card">`;
+                h += `<div>`;
+                    h += `<strong style="display:block;">${i18n('email')}</strong>`;
+                    h += `<span class="user-email" style="display:block; margin-top:5px;">${user.email}</span>`;
+                h += `</div>`;
+                h += `<div style="flex-grow:1;">`;
+                    h += `<button class="button change-email" style="margin-bottom: 10px; float:right;">${i18n('change_email')}</button>`;
+                h += `</div>`;
+            h += `</div>`;
+        }
+
+        // session manager
+        h += `<div class="settings-card">`;
+            h += `<strong>${i18n('sessions')}</strong>`;
+            h += `<div style="flex-grow:1;">`;
+                h += `<button class="button manage-sessions" style="float:right;">${i18n('manage_sessions')}</button>`;
+            h += `</div>`;
+        h += `</div>`;
+
+        // 'Delete Account' button
+        h += `<div class="settings-card settings-card-danger">`;
+            h += `<strong style="display: inline-block;">${i18n("delete_account")}</strong>`;
+            h += `<div style="flex-grow:1;">`;
+                h += `<button class="button button-danger delete-account" style="float:right;">${i18n("delete_account")}</button>`;
+            h += `</div>`;
+        h += `</div>`;
+
+        return h;
+    },
+    init: ($el_window) => {
+        $el_window.find('.change-password').on('click', function (e) {
+            UIWindowChangePassword({
+                window_options:{
+                    parent_uuid: $el_window.attr('data-element_uuid'),
+                    disable_parent_window: true,
+                    parent_center: true,
+                }
+            });
+        });
+
+        $el_window.find('.change-username').on('click', function (e) {
+            UIWindowChangeUsername({
+                window_options:{
+                    parent_uuid: $el_window.attr('data-element_uuid'),
+                    disable_parent_window: true,
+                    parent_center: true,
+                }
+            });
+        });
+
+        $el_window.find('.change-email').on('click', function (e) {
+            console.log('change email', $el_window.attr('data-element_uuid'));
+            UIWindowChangeEmail({
+                window_options:{
+                    parent_uuid: $el_window.attr('data-element_uuid'),
+                    disable_parent_window: true,
+                    parent_center: true,
+                }
+            });
+        });
+
+        $el_window.find('.manage-sessions').on('click', function (e) {
+            UIWindowManageSessions({
+                window_options:{
+                    parent_uuid: $el_window.attr('data-element_uuid'),
+                    disable_parent_window: true,
+                    parent_center: true,
+                }
+            });
+        });
+
+        $el_window.find('.delete-account').on('click', function (e) {
+            UIWindowConfirmUserDeletion({
+                window_options:{
+                    parent_uuid: $el_window.attr('data-element_uuid'),
+                    disable_parent_window: true,
+                    parent_center: true,
+                }
+            });
+        });
+    },
+};

--- a/src/UI/Settings/UITabClock.js
+++ b/src/UI/Settings/UITabClock.js
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) 2024 Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import UIWindowThemeDialog from '../UIWindowThemeDialog.js';
+
+// About
+export default {
+    id: 'clock',
+    title_i18n_key: 'clock',
+    icon: 'clock.svg',
+    html: () => {
+        return `
+            <h1>${i18n('clock')}</h1>
+            <div style="display: flex;align-items: center">
+                <span>${i18n('visibility')}:</span>
+                <select class="change-clock-visible" style="margin-left: 10px;flex: 1">
+                    <option value="auto">${i18n('clock_visible_auto')}</option>
+                    <option value="hide">${i18n('clock_visible_hide')}</option>
+                    <option value="show">${i18n('clock_visible_show')}</option>
+                </select>
+            </div>`;
+    },
+    init: ($el_window) => {
+        $el_window.on('change', 'select.change-clock-visible', function(e){
+            window.change_clock_visible(this.value);
+        });
+
+        window.change_clock_visible();
+    },
+};

--- a/src/UI/Settings/UITabLanguage.js
+++ b/src/UI/Settings/UITabLanguage.js
@@ -1,0 +1,83 @@
+/**
+ * Copyright (C) 2024 Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import UIWindowThemeDialog from '../UIWindowThemeDialog.js';
+import changeLanguage from '../../i18n/i18nChangeLanguage.js';
+
+// About
+export default {
+    id: 'language',
+    title_i18n_key: 'language',
+    icon: 'language.svg',
+    html: () => {
+        let h = `<h1>${i18n('language')}</h1>`;
+
+        // search
+        h += `<div class="search-container" style="margin-bottom: 10px;">
+                <input type="text" class="search search-language" placeholder="Search">
+            </div>`;
+
+        // list of languages
+        const available_languages = listSupportedLanguages();
+        h += `<div class="language-list">`;
+            for (let lang of available_languages) {
+                h += `<div class="language-item ${window.locale === lang.code ? 'active': ''}" data-lang="${lang.code}" data-english-name="${html_encode(lang.english_name)}">${lang.name}</div>`;
+            }
+        h += `</div>`;
+        return h;
+    },
+    init: ($el_window) => {
+        $el_window.on('click', '.language-item', function(){
+            const $this = $(this);
+            const lang = $this.attr('data-lang');
+            changeLanguage(lang);
+            $this.siblings().removeClass('active');
+            $this.addClass('active');
+            // make sure all other language items are visible
+            $this.closest('.language-list').find('.language-item').show();
+        });
+
+        $el_window.on('input', '.search-language', function(){
+            const $this = $(this);
+            const search = $this.val().toLowerCase();
+            const $container = $this.closest('.settings').find('.settings-content-container');
+            const $content = $container.find('.settings-content.active');
+            const $list = $content.find('.language-list');
+            const $items = $list.find('.language-item');
+            $items.each(function(){
+                const $item = $(this);
+                const lang = $item.attr('data-lang');
+                const name = $item.text().toLowerCase();
+                const english_name = $item.attr('data-english-name').toLowerCase();
+                if(name.includes(search) || lang.includes(search) || english_name.includes(search)){
+                    $item.show();
+                }else{
+                    $item.hide();
+                }
+            })
+        });
+    },
+    on_show: ($content) => {
+        // Focus on search
+        $content.find('.search').first().focus();
+        // make sure all language items are visible
+        $content.find('.language-item').show();
+        // empty search
+        $content.find('.search').val('');
+    },
+};

--- a/src/UI/Settings/UITabPersonalization.js
+++ b/src/UI/Settings/UITabPersonalization.js
@@ -17,6 +17,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 import UIWindowThemeDialog from '../UIWindowThemeDialog.js';
+import UIWindowDesktopBGSettings from '../UIWindowDesktopBGSettings.js';
 
 // About
 export default {
@@ -31,11 +32,26 @@ export default {
                 <div style="flex-grow:1;">
                     <button class="button change-ui-colors" style="float:right;">${i18n('change_ui_colors')}</button>
                 </div>
+            </div>
+            <div class="settings-card">
+                <strong>${i18n('background')}</strong>
+                <div style="flex-grow:1;">
+                    <button class="button change-background" style="float:right;">${i18n('change_desktop_background')}</button>
+                </div>
             </div>`;
     },
     init: ($el_window) => {
         $el_window.find('.change-ui-colors').on('click', function (e) {
             UIWindowThemeDialog({
+                window_options:{
+                    parent_uuid: $el_window.attr('data-element_uuid'),
+                    disable_parent_window: true,
+                    parent_center: true,
+                }
+            });
+        });
+        $el_window.find('.change-background').on('click', function (e) {
+            UIWindowDesktopBGSettings({
                 window_options:{
                     parent_uuid: $el_window.attr('data-element_uuid'),
                     disable_parent_window: true,

--- a/src/UI/Settings/UITabPersonalization.js
+++ b/src/UI/Settings/UITabPersonalization.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright (C) 2024 Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import UIWindowThemeDialog from '../UIWindowThemeDialog.js';
+
+// About
+export default {
+    id: 'personalization',
+    title_i18n_key: 'personalization',
+    icon: 'palette-outline.svg',
+    html: () => {
+        return `
+            <h1>${i18n('personalization')}</h1>
+            <div class="settings-card">
+                <strong>${i18n('ui_colors')}</strong>
+                <div style="flex-grow:1;">
+                    <button class="button change-ui-colors" style="float:right;">${i18n('change_ui_colors')}</button>
+                </div>
+            </div>`;
+    },
+    init: ($el_window) => {
+        $el_window.find('.change-ui-colors').on('click', function (e) {
+            UIWindowThemeDialog({
+                window_options:{
+                    parent_uuid: $el_window.attr('data-element_uuid'),
+                    disable_parent_window: true,
+                    parent_center: true,
+                }
+            });
+        });
+    },
+};

--- a/src/UI/Settings/UITabUsage.js
+++ b/src/UI/Settings/UITabUsage.js
@@ -1,0 +1,141 @@
+/**
+ * Copyright (C) 2024 Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// About
+export default {
+    id: 'usage',
+    title_i18n_key: 'usage',
+    icon: 'speedometer-outline.svg',
+    html: () => {
+        return `
+            <h1>Usage</h1>
+            <div class="driver-usage">
+                <h3 style="margin-bottom: 5px; font-size: 14px;">${i18n('storage_usage')}</h3>
+                <div style="font-size: 13px; margin-bottom: 3px;">
+                    <span id="storage-used"></span>
+                    <span> used of </span>
+                    <span id="storage-capacity"></span>
+                    <span id="storage-puter-used-w" style="display:none;">&nbsp;(<span id="storage-puter-used"></span> ${i18n('storage_puter_used')})</span>
+                </div>
+                <div id="storage-bar-wrapper">
+                    <span id="storage-used-percent"></span>
+                    <div id="storage-bar"></div>
+                    <div id="storage-bar-host"></div>
+                </div>
+            </div>`;
+    },
+    init: ($el_window) => {
+        $.ajax({
+            url: api_origin + "/drivers/usage",
+            type: 'GET',
+            async: true,
+            contentType: "application/json",
+            headers: {
+                "Authorization": "Bearer " + auth_token
+            },
+            statusCode: {
+                401: function () {
+                    logout();
+                },
+            },
+            success: function (res) {
+                let h = ''; // Initialize HTML string for driver usage bars
+
+                // Loop through user services
+                res.user.forEach(service => {
+                    const { monthly_limit, monthly_usage } = service;
+                    let usageDisplay = ``;
+
+                    if (monthly_limit !== null) {
+                        let usage_percentage = (monthly_usage / monthly_limit * 100).toFixed(0);
+                        usage_percentage = usage_percentage > 100 ? 100 : usage_percentage; // Cap at 100%
+                        usageDisplay = `
+                            <div class="driver-usage" style="margin-bottom: 10px;">
+                                <h3 style="margin-bottom: 5px; font-size: 14px;">${service.service['driver.interface']} (${service.service['driver.method']}):</h3>
+                                <span style="font-size: 13px; margin-bottom: 3px;">${monthly_usage} used of ${monthly_limit}</span>
+                                <div class="usage-progbar-wrapper" style="width: 100%;">
+                                    <div class="usage-progbar" style="width: ${usage_percentage}%;"><span class="usage-progbar-percent">${usage_percentage}%</span></div>
+                                </div>
+                            </div>
+                        `;
+                    }
+                    else {
+                        usageDisplay = `
+                            <div class="driver-usage" style="margin-bottom: 10px;">
+                                <h3 style="margin-bottom: 5px; font-size: 14px;">${service.service['driver.interface']} (${service.service['driver.method']}):</h3>
+                                <span style="font-size: 13px; margin-bottom: 3px;">${i18n('usage')}: ${monthly_usage} (${i18n('unlimited')})</span>
+                            </div>
+                        `;
+                    }
+                    h += usageDisplay;
+                });
+
+                // Append driver usage bars to the container
+                $('.settings-content[data-settings="usage"]').append(`<div class="driver-usage-container">${h}</div>`);
+            }
+        });
+
+        // df
+        $.ajax({
+            url: api_origin + "/df",
+            type: 'GET',
+            async: true,
+            contentType: "application/json",
+            headers: {
+                "Authorization": "Bearer " + auth_token
+            },
+            statusCode: {
+                401: function () {
+                    logout();
+                },
+            },
+            success: function (res) {
+                let usage_percentage = (res.used / res.capacity * 100).toFixed(0);
+                usage_percentage = usage_percentage > 100 ? 100 : usage_percentage;
+
+                let general_used = res.used;
+
+                let host_usage_percentage = 0;
+                if ( res.host_used ) {
+                    $('#storage-puter-used').html(byte_format(res.used));
+                    $('#storage-puter-used-w').show();
+
+                    general_used = res.host_used;
+                    host_usage_percentage = ((res.host_used - res.used) / res.capacity * 100).toFixed(0);
+                }
+
+                $('#storage-used').html(byte_format(general_used));
+                $('#storage-capacity').html(byte_format(res.capacity));
+                $('#storage-used-percent').html(
+                    usage_percentage + '%' +
+                    (host_usage_percentage > 0
+                        ? ' / ' + host_usage_percentage + '%' : '')
+                );
+                $('#storage-bar').css('width', usage_percentage + '%');
+                $('#storage-bar-host').css('width', host_usage_percentage + '%');
+                if (usage_percentage >= 100) {
+                    $('#storage-bar').css({
+                        'border-top-right-radius': '3px',
+                        'border-bottom-right-radius': '3px',
+                    });
+                }
+            }
+        });
+    },
+};

--- a/src/UI/Settings/UIWindowSettings.js
+++ b/src/UI/Settings/UIWindowSettings.js
@@ -27,6 +27,7 @@ import AboutTab from './UITabAbout.js';
 import UsageTab from './UITabUsage.js';
 import AccountTab from './UITabAccount.js';
 import PersonalizationTab from './UITabPersonalization.js';
+import LanguageTab from './UITabLanguage.js';
 import UIWindowThemeDialog from '../UIWindowThemeDialog.js';
 import UIWindowManageSessions from '../UIWindowManageSessions.js';
 
@@ -39,7 +40,7 @@ async function UIWindowSettings(options){
             UsageTab,
             AccountTab,
             PersonalizationTab,
-            // LanguageTab,
+            LanguageTab,
             // ClockTab,
         ];
 
@@ -52,7 +53,6 @@ async function UIWindowSettings(options){
             tabs.forEach((tab, i) => {
                 h += `<div class="settings-sidebar-item disable-user-select ${i === 0 ? 'active' : ''}" data-settings="${tab.id}" style="background-image: url(${icons[tab.icon]});">${i18n(tab.title_i18n_key)}</div>`;
             });
-                h += `<div class="settings-sidebar-item disable-user-select" data-settings="language" style="background-image: url(${icons['language.svg']});">${i18n('language')}</div>`;
                 h += `<div class="settings-sidebar-item disable-user-select" data-settings="clock" style="background-image: url(${icons['clock.svg']});">${i18n('clock')}</div>`;
             h += `</div>`;
 
@@ -64,22 +64,6 @@ async function UIWindowSettings(options){
                         ${tab.html()}
                     </div>`;
             });
-
-                // Language
-                h += `<div class="settings-content" data-settings="language">`;
-                    h += `<h1>${i18n('language')}</h1>`;
-                    // search
-                    h += `<div class="search-container" style="margin-bottom: 10px;">`;
-                        h += `<input type="text" class="search" placeholder="Search">`;
-                    h += `</div>`;
-                    // list of languages
-                    const available_languages = listSupportedLanguages();
-                    h += `<div class="language-list">`;
-                        for (let lang of available_languages) {
-                            h += `<div class="language-item ${window.locale === lang.code ? 'active': ''}" data-lang="${lang.code}" data-english-name="${html_encode(lang.english_name)}">${lang.name}</div>`;
-                        }
-                    h += `</div>`;
-                h += `</div>`;
 
                 // Clock
                 h += `<div class="settings-content" data-settings="clock">`;
@@ -146,45 +130,13 @@ async function UIWindowSettings(options){
             // add active class to content
             $container.find('.settings-content').removeClass('active');
             $content.addClass('active');
-            // if language, focus on search
-            if(settings === 'language'){
-                $content.find('.search').first().focus();
-                // make sure all language items are visible
-                $content.find('.language-item').show();
-                // empty search
-                $content.find('.search').val('');
+
+            // Run on_show handlers
+            const tab = tabs.find((tab) => tab.id === settings);
+            if (tab.on_show) {
+                tab.on_show($content);
             }
         })
-
-        $(el_window).on('click', '.language-item', function(){
-            const $this = $(this);
-            const lang = $this.attr('data-lang');
-            changeLanguage(lang);
-            $this.siblings().removeClass('active');
-            $this.addClass('active');
-            // make sure all other language items are visible
-            $this.closest('.language-list').find('.language-item').show();
-        })
-        
-        $(el_window).on('input', '.search', function(){
-            const $this = $(this);
-            const search = $this.val().toLowerCase();
-            const $container = $this.closest('.settings').find('.settings-content-container');
-            const $content = $container.find('.settings-content.active');
-            const $list = $content.find('.language-list');
-            const $items = $list.find('.language-item');
-            $items.each(function(){
-                const $item = $(this);
-                const lang = $item.attr('data-lang');
-                const name = $item.text().toLowerCase();
-                const english_name = $item.attr('data-english-name').toLowerCase();
-                if(name.includes(search) || lang.includes(search) || english_name.includes(search)){
-                    $item.show();
-                }else{
-                    $item.hide();
-                }
-            })
-        });
 
         $(el_window).on('change', 'select.change-clock-visible', function(e){
             const $this = $(this);  

--- a/src/UI/Settings/UIWindowSettings.js
+++ b/src/UI/Settings/UIWindowSettings.js
@@ -28,6 +28,7 @@ import UsageTab from './UITabUsage.js';
 import AccountTab from './UITabAccount.js';
 import PersonalizationTab from './UITabPersonalization.js';
 import LanguageTab from './UITabLanguage.js';
+import ClockTab from './UITabClock.js';
 import UIWindowThemeDialog from '../UIWindowThemeDialog.js';
 import UIWindowManageSessions from '../UIWindowManageSessions.js';
 
@@ -41,7 +42,7 @@ async function UIWindowSettings(options){
             AccountTab,
             PersonalizationTab,
             LanguageTab,
-            // ClockTab,
+            ClockTab,
         ];
 
         let h = '';
@@ -53,7 +54,6 @@ async function UIWindowSettings(options){
             tabs.forEach((tab, i) => {
                 h += `<div class="settings-sidebar-item disable-user-select ${i === 0 ? 'active' : ''}" data-settings="${tab.id}" style="background-image: url(${icons[tab.icon]});">${i18n(tab.title_i18n_key)}</div>`;
             });
-                h += `<div class="settings-sidebar-item disable-user-select" data-settings="clock" style="background-image: url(${icons['clock.svg']});">${i18n('clock')}</div>`;
             h += `</div>`;
 
             // content
@@ -64,19 +64,6 @@ async function UIWindowSettings(options){
                         ${tab.html()}
                     </div>`;
             });
-
-                // Clock
-                h += `<div class="settings-content" data-settings="clock">`;
-                     h += `<h1>${i18n('clock')}</h1>`;
-                     h += `<div style="display: flex;align-items: center">`
-                        h += `<span>${i18n('visibility')}:</span>`
-                        h += `<select class="change-clock-visible" style="margin-left: 10px;flex: 1">`
-                            h += `<option value="auto">${i18n('clock_visible_auto')}</option>`
-                            h += `<option value="hide">${i18n('clock_visible_hide')}</option>`
-                            h += `<option value="show">${i18n('clock_visible_show')}</option>`
-                        h += `</select>`
-                     h += `</div>`
-                h += `</div>`;      
 
             h += `</div>`;
         h += `</div>`;
@@ -137,15 +124,6 @@ async function UIWindowSettings(options){
                 tab.on_show($content);
             }
         })
-
-        $(el_window).on('change', 'select.change-clock-visible', function(e){
-            const $this = $(this);  
-            const value = $this.val();
-
-            window.change_clock_visible(value);
-        })
-
-        window.change_clock_visible();
 
         resolve(el_window);
     });

--- a/src/UI/Settings/UIWindowSettings.js
+++ b/src/UI/Settings/UIWindowSettings.js
@@ -23,7 +23,7 @@ import UIWindowChangeEmail from './UIWindowChangeEmail.js'
 import UIWindowChangeUsername from '../UIWindowChangeUsername.js'
 import changeLanguage from "../../i18n/i18nChangeLanguage.js"
 import UIWindowConfirmUserDeletion from './UIWindowConfirmUserDeletion.js';
-import UITabAbout from './UITabAbout.js';
+import AboutTab from './UITabAbout.js';
 import UIWindowThemeDialog from '../UIWindowThemeDialog.js';
 import UIWindowManageSessions from '../UIWindowManageSessions.js';
 
@@ -31,13 +31,24 @@ async function UIWindowSettings(options){
     return new Promise(async (resolve) => {
         options = options ?? {};
 
+        const tabs = [
+            AboutTab,
+            // UsageTab,
+            // AccountTab,
+            // PersonalizationTab,
+            // LanguageTab,
+            // ClockTab,
+        ];
+
         let h = '';
 
         h += `<div class="settings-container">`;
         h += `<div class="settings">`;
             // side bar
             h += `<div class="settings-sidebar disable-user-select">`;
-                h += `<div class="settings-sidebar-item disable-user-select active" data-settings="about" style="background-image: url(${icons['logo-outline.svg']});">${i18n('about')}</div>`;
+            tabs.forEach((tab, i) => {
+                h += `<div class="settings-sidebar-item disable-user-select ${i === 0 ? 'active' : ''}" data-settings="${tab.id}" style="background-image: url(${icons[tab.icon]});">${i18n(tab.title_i18n_key)}</div>`;
+            });
                 h += `<div class="settings-sidebar-item disable-user-select" data-settings="usage" style="background-image: url(${icons['speedometer-outline.svg']});">${i18n('usage')}</div>`;
                 h += `<div class="settings-sidebar-item disable-user-select" data-settings="account" style="background-image: url(${icons['user.svg']});">${i18n('account')}</div>`;
                 h += `<div class="settings-sidebar-item disable-user-select" data-settings="personalization" style="background-image: url(${icons['palette-outline.svg']});">${i18n('personalization')}</div>`;
@@ -47,9 +58,12 @@ async function UIWindowSettings(options){
 
             // content
             h += `<div class="settings-content-container">`;
-            
-                // About
-                h += UITabAbout();
+
+            tabs.forEach((tab, i) => {
+                h += `<div class="settings-content ${i === 0 ? 'active' : ''}" data-settings="${tab.id}">
+                        ${tab.html()}
+                    </div>`;
+            });
 
                 // Usage
                 h += `<div class="settings-content" data-settings="usage">`;
@@ -202,6 +216,8 @@ async function UIWindowSettings(options){
                 overflow: 'auto'
             }
         });
+        const $el_window = $(el_window);
+        tabs.forEach(tab => tab.init($el_window));
 
         $.ajax({
             url: api_origin + "/drivers/usage",
@@ -298,36 +314,6 @@ async function UIWindowSettings(options){
                     });
                 }
             }
-        })
-
-        // version
-        $.ajax({
-            url: api_origin + "/version",
-            type: 'GET',
-            async: true,
-            contentType: "application/json",
-            headers: {
-                "Authorization": "Bearer " + auth_token
-            },
-            statusCode: {
-                401: function () {
-                    logout();
-                },
-            },
-            success: function (res) {
-                var d = new Date(0);
-                $('.version').html('Version: ' + res.version + ' &bull; ' + 'Server: ' + res.location + ' &bull; ' + 'Deployed: ' + new Date(res.deploy_timestamp));
-            }
-        })
-
-        $(el_window).find('.credits').on('click', function (e) {
-            if($(e.target).hasClass('credits')){
-                $('.credits').get(0).close();
-            }
-        });
-
-        $(el_window).find('.show-credits').on('click', function (e) {
-            $('.credits').get(0).showModal();
         })
 
         $(el_window).find('.change-password').on('click', function (e) {

--- a/src/UI/Settings/UIWindowSettings.js
+++ b/src/UI/Settings/UIWindowSettings.js
@@ -26,6 +26,7 @@ import UIWindowConfirmUserDeletion from './UIWindowConfirmUserDeletion.js';
 import AboutTab from './UITabAbout.js';
 import UsageTab from './UITabUsage.js';
 import AccountTab from './UITabAccount.js';
+import PersonalizationTab from './UITabPersonalization.js';
 import UIWindowThemeDialog from '../UIWindowThemeDialog.js';
 import UIWindowManageSessions from '../UIWindowManageSessions.js';
 
@@ -37,7 +38,7 @@ async function UIWindowSettings(options){
             AboutTab,
             UsageTab,
             AccountTab,
-            // PersonalizationTab,
+            PersonalizationTab,
             // LanguageTab,
             // ClockTab,
         ];
@@ -51,7 +52,6 @@ async function UIWindowSettings(options){
             tabs.forEach((tab, i) => {
                 h += `<div class="settings-sidebar-item disable-user-select ${i === 0 ? 'active' : ''}" data-settings="${tab.id}" style="background-image: url(${icons[tab.icon]});">${i18n(tab.title_i18n_key)}</div>`;
             });
-                h += `<div class="settings-sidebar-item disable-user-select" data-settings="personalization" style="background-image: url(${icons['palette-outline.svg']});">${i18n('personalization')}</div>`;
                 h += `<div class="settings-sidebar-item disable-user-select" data-settings="language" style="background-image: url(${icons['language.svg']});">${i18n('language')}</div>`;
                 h += `<div class="settings-sidebar-item disable-user-select" data-settings="clock" style="background-image: url(${icons['clock.svg']});">${i18n('clock')}</div>`;
             h += `</div>`;
@@ -64,18 +64,6 @@ async function UIWindowSettings(options){
                         ${tab.html()}
                     </div>`;
             });
-
-                // Personalization
-                h += `<div class="settings-content" data-settings="personalization">`;
-                    h += `<h1>${i18n('personalization')}</h1>`;
-                    // change password button
-                    h += `<div class="settings-card">`;
-                        h += `<strong>${i18n('ui_colors')}</strong>`;
-                        h += `<div style="flex-grow:1;">`;
-                            h += `<button class="button change-ui-colors" style="float:right;">${i18n('change_ui_colors')}</button>`;
-                        h += `</div>`;
-                    h += `</div>`;
-                h += `</div>`;
 
                 // Language
                 h += `<div class="settings-content" data-settings="language">`;
@@ -146,16 +134,6 @@ async function UIWindowSettings(options){
         });
         const $el_window = $(el_window);
         tabs.forEach(tab => tab.init($el_window));
-
-        $(el_window).find('.change-ui-colors').on('click', function (e) {
-            UIWindowThemeDialog({
-                window_options:{
-                    parent_uuid: $(el_window).attr('data-element_uuid'),
-                    disable_parent_window: true,
-                    parent_center: true,
-                }
-            });
-        })
 
         $(el_window).on('click', '.settings-sidebar-item', function(){
             const $this = $(this);

--- a/src/UI/Settings/UIWindowSettings.js
+++ b/src/UI/Settings/UIWindowSettings.js
@@ -25,6 +25,7 @@ import changeLanguage from "../../i18n/i18nChangeLanguage.js"
 import UIWindowConfirmUserDeletion from './UIWindowConfirmUserDeletion.js';
 import AboutTab from './UITabAbout.js';
 import UsageTab from './UITabUsage.js';
+import AccountTab from './UITabAccount.js';
 import UIWindowThemeDialog from '../UIWindowThemeDialog.js';
 import UIWindowManageSessions from '../UIWindowManageSessions.js';
 
@@ -35,7 +36,7 @@ async function UIWindowSettings(options){
         const tabs = [
             AboutTab,
             UsageTab,
-            // AccountTab,
+            AccountTab,
             // PersonalizationTab,
             // LanguageTab,
             // ClockTab,
@@ -50,7 +51,6 @@ async function UIWindowSettings(options){
             tabs.forEach((tab, i) => {
                 h += `<div class="settings-sidebar-item disable-user-select ${i === 0 ? 'active' : ''}" data-settings="${tab.id}" style="background-image: url(${icons[tab.icon]});">${i18n(tab.title_i18n_key)}</div>`;
             });
-                h += `<div class="settings-sidebar-item disable-user-select" data-settings="account" style="background-image: url(${icons['user.svg']});">${i18n('account')}</div>`;
                 h += `<div class="settings-sidebar-item disable-user-select" data-settings="personalization" style="background-image: url(${icons['palette-outline.svg']});">${i18n('personalization')}</div>`;
                 h += `<div class="settings-sidebar-item disable-user-select" data-settings="language" style="background-image: url(${icons['language.svg']});">${i18n('language')}</div>`;
                 h += `<div class="settings-sidebar-item disable-user-select" data-settings="clock" style="background-image: url(${icons['clock.svg']});">${i18n('clock')}</div>`;
@@ -64,59 +64,6 @@ async function UIWindowSettings(options){
                         ${tab.html()}
                     </div>`;
             });
-
-                // Account
-                h += `<div class="settings-content" data-settings="account">`;
-                    h += `<h1>${i18n('account')}</h1>`;
-                    // change password button
-                    h += `<div class="settings-card">`;
-                        h += `<strong>${i18n('password')}</strong>`;
-                        h += `<div style="flex-grow:1;">`;
-                            h += `<button class="button change-password" style="float:right;">${i18n('change_password')}</button>`;
-                        h += `</div>`;
-                    h += `</div>`;
-
-                    // change username button
-                    h += `<div class="settings-card">`;
-                        h += `<div>`;
-                            h += `<strong style="display:block;">${i18n('username')}</strong>`;
-                            h += `<span class="username" style="display:block; margin-top:5px;">${user.username}</span>`;
-                        h += `</div>`;
-                        h += `<div style="flex-grow:1;">`;
-                            h += `<button class="button change-username" style="float:right;">${i18n('change_username')}</button>`;
-                        h += `</div>`
-                    h += `</div>`;
-
-                    // change email button
-                    if(user.email){
-                        h += `<div class="settings-card">`;
-                            h += `<div>`;
-                                h += `<strong style="display:block;">${i18n('email')}</strong>`;
-                                h += `<span class="user-email" style="display:block; margin-top:5px;">${user.email}</span>`;
-                            h += `</div>`;
-                            h += `<div style="flex-grow:1;">`;
-                                h += `<button class="button change-email" style="margin-bottom: 10px; float:right;">${i18n('change_email')}</button>`;
-                            h += `</div>`;
-                        h += `</div>`;
-                    }
-
-                    // session manager
-                    h += `<div class="settings-card">`;
-                        h += `<strong>${i18n('sessions')}</strong>`;
-                        h += `<div style="flex-grow:1;">`;
-                            h += `<button class="button manage-sessions" style="float:right;">${i18n('manage_sessions')}</button>`;
-                        h += `</div>`;
-                    h += `</div>`;
-
-                    // 'Delete Account' button
-                    h += `<div class="settings-card settings-card-danger">`;
-                        h += `<strong style="display: inline-block;">${i18n("delete_account")}</strong>`;
-                        h += `<div style="flex-grow:1;">`;
-                            h += `<button class="button button-danger delete-account" style="float:right;">${i18n("delete_account")}</button>`;
-                        h += `</div>`;
-                    h += `</div>`;
-
-                h += `</div>`;
 
                 // Personalization
                 h += `<div class="settings-content" data-settings="personalization">`;
@@ -200,59 +147,8 @@ async function UIWindowSettings(options){
         const $el_window = $(el_window);
         tabs.forEach(tab => tab.init($el_window));
 
-        $(el_window).find('.change-password').on('click', function (e) {
-            UIWindowChangePassword({
-                window_options:{
-                    parent_uuid: $(el_window).attr('data-element_uuid'),
-                    disable_parent_window: true,
-                    parent_center: true,
-                }
-            });
-        })
-
-        $(el_window).find('.change-email').on('click', function (e) {
-            console.log('change email', $(el_window).attr('data-element_uuid'));
-            UIWindowChangeEmail({
-                window_options:{
-                    parent_uuid: $(el_window).attr('data-element_uuid'),
-                    disable_parent_window: true,
-                    parent_center: true,
-                }
-            });
-        })
-
-        $(el_window).find('.delete-account').on('click', function (e) {
-            UIWindowConfirmUserDeletion({
-                window_options:{
-                    parent_uuid: $(el_window).attr('data-element_uuid'),
-                    disable_parent_window: true,
-                    parent_center: true,
-                }
-            });
-        })
-
-        $(el_window).find('.change-username').on('click', function (e) {
-            UIWindowChangeUsername({
-                window_options:{
-                    parent_uuid: $(el_window).attr('data-element_uuid'),
-                    disable_parent_window: true,
-                    parent_center: true,
-                }
-            });
-        })
-
         $(el_window).find('.change-ui-colors').on('click', function (e) {
             UIWindowThemeDialog({
-                window_options:{
-                    parent_uuid: $(el_window).attr('data-element_uuid'),
-                    disable_parent_window: true,
-                    parent_center: true,
-                }
-            });
-        })
-
-        $(el_window).find('.manage-sessions').on('click', function (e) {
-            UIWindowManageSessions({
                 window_options:{
                     parent_uuid: $(el_window).attr('data-element_uuid'),
                     disable_parent_window: true,

--- a/src/UI/UIWindowDesktopBGSettings.js
+++ b/src/UI/UIWindowDesktopBGSettings.js
@@ -19,7 +19,9 @@
 
 import UIWindow from './UIWindow.js'
 
-async function UIWindowDesktopBGSettings(){
+async function UIWindowDesktopBGSettings(options){
+    options = options ?? {};
+
     return new Promise(async (resolve) => {
         let h = '';
         const original_background_css = $('body').attr('style');
@@ -103,7 +105,8 @@ async function UIWindowDesktopBGSettings(){
                 height: '100%',
                 'background-color': 'rgb(245 247 249)',
                 'backdrop-filter': 'blur(3px)',
-            }    
+            },
+            ...options.window_options,
         })
 
         if(window.desktop_bg_url !== undefined && window.desktop_bg_url !== null){


### PR DESCRIPTION
Keeping all the logic and data for each tab together should make it easier to understand and modify.

And then the point of this: Adding the desktop-background picker to the **Personalization** tab.

The `init()` calls could probably be passed their root element instead of the window element, but some of them do require the window itself for spawning child windows. So I left that for now.

Changes to the code are generally minor apart from moving things around, except where I got carried away. :sweat_smile: 