### PR TITLE
Implement stdio bridge for running apps from the terminal

### DIFF
--- a/packages/phoenix/packages/strataparse/parse_impls/StrUntilParserImpl.js
+++ b/packages/phoenix/packages/strataparse/parse_impls/StrUntilParserImpl.js
@@ -23,7 +23,6 @@ export default class StrUntilParserImpl {
     parse (lexer) {
         let text = '';
         for ( ;; ) {
-            console.log('B')
             let { done, value } = lexer.look();
 
             if ( done ) break;
@@ -40,8 +39,6 @@ export default class StrUntilParserImpl {
         }
 
         if ( text.length === 0 ) return;
-
-        console.log('test?', text)
 
         return { $: 'until', text };
     }

--- a/packages/phoenix/packages/strataparse/strata_impls/ContextSwitchingPStratumImpl.js
+++ b/packages/phoenix/packages/strataparse/strata_impls/ContextSwitchingPStratumImpl.js
@@ -22,7 +22,6 @@ export default class ContextSwitchingPStratumImpl {
     constructor ({ contexts, entry }) {
         this.contexts = { ...contexts };
         for ( const key in this.contexts ) {
-            console.log('parsers?', this.contexts[key]);
             const new_array = [];
             for ( const parser of this.contexts[key] ) {
                 if ( parser.hasOwnProperty('transition') ) {
@@ -44,7 +43,6 @@ export default class ContextSwitchingPStratumImpl {
         this.lastvalue = null;
     }
     get stack_top () {
-        console.log('stack top?', this.stack[this.stack.length - 1])
         return this.stack[this.stack.length - 1];
     }
     get current_context () {
@@ -55,7 +53,6 @@ export default class ContextSwitchingPStratumImpl {
         const lexer = api.delegate;
 
         const context = this.current_context;
-        console.log('context?', context);
         for ( const spec of context ) {
             {
                 const { done, value } = lexer.look();
@@ -64,7 +61,6 @@ export default class ContextSwitchingPStratumImpl {
                     throw new Error('infinite loop');
                 }
                 this.lastvalue = value;
-                console.log('last value?', value, done);
                 if ( done ) return { done };
             }
 
@@ -76,7 +72,6 @@ export default class ContextSwitchingPStratumImpl {
             }
 
             const subLexer = lexer.fork();
-            // console.log('spec?', spec);
             const result = parser.parse(subLexer);
             if ( result.status === ParseResult.UNRECOGNIZED ) {
                 continue;
@@ -84,11 +79,9 @@ export default class ContextSwitchingPStratumImpl {
             if ( result.status === ParseResult.INVALID ) {
                 return { done: true, value: result };
             }
-            console.log('RESULT', result, spec)
             if ( ! peek ) lexer.join(subLexer);
 
             if ( transition ) {
-                console.log('GOT A TRANSITION')
                 if ( transition.pop ) this.stack.pop();
                 if ( transition.to ) this.stack.push({
                     context_name: transition.to,
@@ -97,7 +90,6 @@ export default class ContextSwitchingPStratumImpl {
 
             if ( result.value.$discard || peek ) return this.next(api);
 
-            console.log('PROVIDING VALUE', result.value);
             return { done: false, value: result.value };
         }
 

--- a/packages/phoenix/src/ansi-shell/arg-parsers/simple-parser.js
+++ b/packages/phoenix/src/ansi-shell/arg-parsers/simple-parser.js
@@ -22,11 +22,6 @@ import { DEFAULT_OPTIONS } from '../../puter-shell/coreutils/coreutil_lib/help.j
 export default {
     name: 'simple-parser',
     async process (ctx, spec) {
-        console.log({
-            ...spec,
-            args: ctx.locals.args
-        });
-
         // Insert standard options
         spec.options = Object.assign(spec.options || {}, DEFAULT_OPTIONS);
 

--- a/packages/phoenix/src/ansi-shell/parsing/PuterShellParser.js
+++ b/packages/phoenix/src/ansi-shell/parsing/PuterShellParser.js
@@ -37,7 +37,6 @@ export class PuterShellParser {
         if ( sp.error ) {
             throw new Error(sp.error);
         }
-        console.log('PARSER RESULT', result);
         return result;
     }
     parseScript (input) {

--- a/packages/phoenix/src/ansi-shell/parsing/buildParserSecondHalf.js
+++ b/packages/phoenix/src/ansi-shell/parsing/buildParserSecondHalf.js
@@ -54,7 +54,6 @@ class ReducePrimitivesPStratumImpl {
             let text = '';
             for ( const item of contents.results ) {
                 if ( item.$ === 'string.segment' ) {
-                    // console.log('segment?', item.text)
                     text += item.text;
                     continue;
                 }
@@ -86,7 +85,6 @@ class ShellConstructsPStratumImpl {
                 node.commands = [];
             },
             exit ({ node }) {
-                console.log('!!!!!',this.stack_top.node)
                 if ( this.stack_top?.node?.$ === 'script' ) {
                     this.stack_top.node.statements.push(node);
                 }
@@ -96,7 +94,6 @@ class ShellConstructsPStratumImpl {
             },
             next ({ value, lexer }) {
                 if ( value.$ === 'op.line-terminator' ) {
-                    console.log('the stack??', this.stack)
                     this.pop();
                     return;
                 }
@@ -189,7 +186,6 @@ class ShellConstructsPStratumImpl {
             },
             next ({ value, lexer }) {
                 if ( value.$ === 'op.line-terminator' ) {
-                    console.log('well, got here')
                     this.pop();
                     return;
                 }
@@ -223,9 +219,7 @@ class ShellConstructsPStratumImpl {
                 this.stack_top.node.components.push(...node.components);
             },
             next ({ node, value, lexer }) {
-                console.log('WHAT THO', node)
                 if ( value.$ === 'op.line-terminator' && node.quote === null ) {
-                    console.log('well, got here')
                     this.pop();
                     return;
                 }
@@ -292,7 +286,6 @@ class ShellConstructsPStratumImpl {
 
         const lexer = api.delegate;
 
-        console.log('THE NODE', this.stack[0].node);
         // return { done: true, value: { $: 'test' } };
 
         for ( let i=0 ; i < 500 ; i++ ) {
@@ -306,15 +299,12 @@ class ShellConstructsPStratumImpl {
             }
 
             const { state, node } = this.stack_top;
-            console.log('value?', value, done)
-            console.log('state?', state.name);
 
             state.next.call(this, { lexer, value, node, state });
 
             // if ( done ) break;
         }
 
-        console.log('THE NODE', this.stack[0]);
 
         this.done_ = true;
         return { done: false, value: this.stack[0].node };
@@ -433,7 +423,6 @@ export const buildParserSecondHalf = (sp, { multiline } = {}) => {
 
     // sp.add(new ReducePrimitivesPStratumImpl());
     if ( multiline ) {
-        console.log('USING MULTILINE');
         sp.add(new MultilinePStratumImpl());
     } else {
         sp.add(new ShellConstructsPStratumImpl());

--- a/packages/phoenix/src/ansi-shell/pipeline/Pipeline.js
+++ b/packages/phoenix/src/ansi-shell/pipeline/Pipeline.js
@@ -202,6 +202,10 @@ export class PreparedCommand {
             in_ = new MemReader(response);
         }
 
+        const internal_input_pipe = new Pipe();
+        const valve = new Coupler(in_, internal_input_pipe.in);
+        in_ = internal_input_pipe.out;
+
         // simple naive implementation for now
         const sig = {
             listeners_: [],
@@ -297,6 +301,7 @@ export class PreparedCommand {
         let exit_code = 0;
         try {
             await execute(ctx);
+            valve.close();
         } catch (e) {
             if ( e instanceof Exit ) {
                 exit_code = e.code;

--- a/packages/phoenix/src/ansi-shell/pipeline/Pipeline.js
+++ b/packages/phoenix/src/ansi-shell/pipeline/Pipeline.js
@@ -38,11 +38,6 @@ class Token {
             throw new Error('expected token node');
         }
 
-        console.log('ast has cst?',
-            ast,
-            ast.components?.[0]?.$cst
-        )
-
         return new Token(ast);
     }
     constructor (ast) {
@@ -53,20 +48,15 @@ class Token {
         // If the only components are of type 'symbol' and 'string.segment'
         // then we can statically resolve the value of the token.
 
-        console.log('checking viability of static resolve', this.ast)
-
         const isStatic = this.ast.components.every(c => {
             return c.$ === 'symbol' || c.$ === 'string.segment';
         });
 
         if ( ! isStatic ) return;
 
-        console.log('doing static thing', this.ast)
-
         // TODO: Variables can also be statically resolved, I think...
         let value = '';
         for ( const component of this.ast.components ) {
-            console.log('component', component);
             value += component.text;
         }
 
@@ -113,7 +103,6 @@ export class PreparedCommand {
         
         // TODO: check that node for command name is of a
         //       supported type - maybe use adapt pattern
-        console.log('ast?', ast);
         const cmd = command_token.maybeStaticallyResolve(ctx);
 
         const { commands } = ctx.registries;
@@ -124,16 +113,13 @@ export class PreparedCommand {
             : command_token;
 
         if ( command === undefined ) {
-            console.log('command token?', command_token);
             throw new ConcreteSyntaxError(
                 `no command: ${JSON.stringify(cmd)}`,
                 command_token.$cst,
             );
-            throw new Error('no command: ' + JSON.stringify(cmd));
         }
 
         // TODO: test this
-        console.log('ast?', ast);
         const inputRedirect = ast.inputRedirects.length > 0 ? (() => {
             const token = Token.createFromAST(ctx, ast.inputRedirects[0]);
             return token.maybeStaticallyResolve(ctx) ?? token;
@@ -172,7 +158,6 @@ export class PreparedCommand {
         // command to run.
         if ( command instanceof Token ) {
             const cmd = await command.resolve(this.ctx);
-            console.log('RUNNING CMD?', cmd)
             const { commandProvider } = this.ctx.externs;
             command = await commandProvider.lookup(cmd, { ctx: this.ctx });
             if ( command === undefined ) {
@@ -327,23 +312,16 @@ export class PreparedCommand {
 
         // TODO: need write command from puter-shell before this can be done
         for ( let i=0 ; i < this.outputRedirects.length ; i++ ) {
-            console.log('output redirect??', this.outputRedirects[i]);
             const { filesystem } = this.ctx.platform;
             const outputRedirect = this.outputRedirects[i];
             const dest_path = outputRedirect instanceof Token
                 ? await outputRedirect.resolve(this.ctx)
                 : outputRedirect;
             const path = resolveRelativePath(ctx.vars, dest_path);
-            console.log('it should work?', {
-                path,
-                outputMemWriters,
-            })
             // TODO: error handling here
 
             await filesystem.write(path, outputMemWriters[i].getAsBlob());
         }
-
-        console.log('OUTPUT WRITERS', outputMemWriters);
     }
 }
 
@@ -405,7 +383,6 @@ export class Pipeline {
             commandPromises.push(command.execute());
         }
         await Promise.all(commandPromises);
-        console.log('PIPELINE DONE');
 
         await coupler.isDone;
     }

--- a/packages/phoenix/src/ansi-shell/readline/readline.js
+++ b/packages/phoenix/src/ansi-shell/readline/readline.js
@@ -96,7 +96,6 @@ const ReadlineProcessorBuilder = builder => builder
             externs.out.write(externs.prompt);
             externs.out.write(vars.result);
             const invCurPos = vars.result.length - vars.cursor;
-            console.log(invCurPos)
             if ( invCurPos !== 0 ) {
                 externs.out.write(`\x1B[${invCurPos}D`);
             }
@@ -111,8 +110,6 @@ const ReadlineProcessorBuilder = builder => builder
                 }
             }));
             // NEXT: get tab completer for input state
-            console.log('input state', inputState);
-            
             let completer = null;
             if ( inputState.$ === 'redirect' ) {
                 completer = new FileCompleter();
@@ -141,7 +138,6 @@ const ReadlineProcessorBuilder = builder => builder
             const applyCompletion = txt => {
                 const p1 = vars.result.slice(0, vars.cursor);
                 const p2 = vars.result.slice(vars.cursor);
-                console.log({ p1, p2 });
                 vars.result = p1 + txt + p2;
                 vars.cursor += txt.length;
                 externs.out.write(txt);

--- a/packages/phoenix/src/promise.js
+++ b/packages/phoenix/src/promise.js
@@ -1,0 +1,43 @@
+export class TeePromise {
+    static STATUS_PENDING = Symbol('pending');
+    static STATUS_RUNNING = {};
+    static STATUS_DONE = Symbol('done');
+    constructor () {
+        this.status_ = this.constructor.STATUS_PENDING;
+        this.donePromise = new Promise((resolve, reject) => {
+            this.doneResolve = resolve;
+            this.doneReject = reject;
+        });
+    }
+    get status () {
+        return this.status_;
+    }
+    set status (status) {
+        this.status_ = status;
+        if ( status === this.constructor.STATUS_DONE ) {
+            this.doneResolve();
+        }
+    }
+    resolve (value) {
+        this.status_ = this.constructor.STATUS_DONE;
+        this.doneResolve(value);
+    }
+    awaitDone () {
+        return this.donePromise;
+    }
+    then (fn, ...a) {
+        return this.donePromise.then(fn, ...a);
+    }
+
+    reject (err) {
+        this.status_ = this.constructor.STATUS_DONE;
+        this.doneReject(err);
+    }
+
+    /**
+     * @deprecated use then() instead
+     */
+    onComplete(fn) {
+        return this.then(fn);
+    }
+}

--- a/packages/phoenix/src/promise.js
+++ b/packages/phoenix/src/promise.js
@@ -41,3 +41,17 @@ export class TeePromise {
         return this.then(fn);
     }
 }
+
+/**
+ * raceCase is like Promise.race except it takes an object instead of
+ * an array, and returns the key of the promise that resolves first
+ * as well as the value that it resolved to.
+ * 
+ * @param {Object.<string, Promise>} promise_map 
+ * 
+ * @returns {Promise.<[string, any]>}
+ */
+export const raceCase = async (promise_map) => {
+    return Promise.race(Object.entries(promise_map).map(
+        ([key, promise]) => promise.then(value => [key, value])));
+};

--- a/packages/phoenix/src/pty/XDocumentPTT.js
+++ b/packages/phoenix/src/pty/XDocumentPTT.js
@@ -38,7 +38,7 @@ export class XDocumentPTT {
                     chunk = encoder.encode(chunk);
                 }
                 terminalConnection.postMessage({
-                    $: 'output',
+                    $: 'stdout',
                     data: chunk,
                 });
             }
@@ -52,7 +52,7 @@ export class XDocumentPTT {
                 this.emit('ioctl.set', message);
                 return;
             }
-            if (message.$ === 'input') {
+            if (message.$ === 'stdin') {
                 this.readController.enqueue(message.data);
                 return;
             }

--- a/packages/terminal/src/main.js
+++ b/packages/terminal/src/main.js
@@ -41,27 +41,14 @@ class XTermIO {
     }
 
     async handleKeyBeforeProcess (evt) {
-        console.log(
-            'right this event might be up or down so it\'s necessary to determine which',
-            evt,
-        );
         if ( evt.key === 'V' && evt.ctrlKey && evt.shiftKey && evt.type === 'keydown' ) {
             const clipboard = navigator.clipboard;
             const text = await clipboard.readText();
-            console.log(
-                'this is the relevant text for this thing that is the thing that is the one that is here',
-                text,
-            );
             this.pty.out.write(text);
         }
     }
 
     handleKey ({ key, domEvent }) {
-        console.log(
-            'key event happened',
-            key,
-            domEvent,
-        );
         const pty = this.pty;
 
         const handlers = {

--- a/packages/terminal/src/pty/XDocumentANSIShell.js
+++ b/packages/terminal/src/pty/XDocumentANSIShell.js
@@ -53,7 +53,7 @@ export class XDocumentANSIShell {
                 return;
             }
 
-            if (message.$ === 'output') {
+            if (message.$ === 'stdout') {
                 ptt.out.write(message.data);
                 return;
             }
@@ -69,7 +69,7 @@ export class XDocumentANSIShell {
             for ( ;; ) {
                 const chunk = (await ptt.in.read()).value;
                 shell.postMessage({
-                    $: 'input',
+                    $: 'stdin',
                     data: chunk,
                 });
             }

--- a/src/IPC.js
+++ b/src/IPC.js
@@ -74,14 +74,6 @@ window.addEventListener('message', async (event) => {
         return;
     }
 
-    const window_for_app_instance = (instance_id) => {
-        return $(`.window[data-element_uuid="${instance_id}"]`).get(0);
-    };
-
-    const iframe_for_app_instance = (instance_id) => {
-        return $(window_for_app_instance(instance_id)).find('.window-app-iframe').get(0);
-    };
-
     const $el_parent_window = $(window_for_app_instance(event.data.appInstanceID));
     const parent_window_id = $el_parent_window.attr('data-id');
     const $el_parent_disable_mask = $el_parent_window.find('.window-disable-mask');

--- a/src/IPC.js
+++ b/src/IPC.js
@@ -90,17 +90,7 @@ window.addEventListener('message', async (event) => {
         $(target_iframe).attr('data-appUsesSDK', 'true');
 
         // If we were waiting to launch this as a child app, report to the parent that it succeeded.
-        const child_launch_callback = window.child_launch_callbacks[event.data.appInstanceID];
-        if (child_launch_callback) {
-            const parent_iframe = iframe_for_app_instance(child_launch_callback.parent_instance_id);
-            // send confirmation to requester window
-            parent_iframe.contentWindow.postMessage({
-                msg: 'childAppLaunched',
-                original_msg_id: child_launch_callback.launch_msg_id,
-                child_instance_id: event.data.appInstanceID,
-            }, '*');
-            delete window.child_launch_callbacks[event.data.appInstanceID];
-        }
+        window.report_app_launched(event.data.appInstanceID, { uses_sdk: true });
 
         // Send any saved broadcasts to the new app
         globalThis.services.get('broadcast').sendSavedBroadcastsTo(event.data.appInstanceID);

--- a/src/UI/UIWindow.js
+++ b/src/UI/UIWindow.js
@@ -2853,27 +2853,7 @@ $.fn.close = async function(options) {
             $(`.window[data-parent_uuid="${window_uuid}"]`).close();
 
             // notify other apps that we're closing
-            if (app_uses_sdk) {
-                // notify parent app, if we have one, that we're closing
-                const parent_id = this.dataset['parent_instance_id'];
-                const parent = $(`.window[data-element_uuid="${parent_id}"] .window-app-iframe`).get(0);
-                if (parent) {
-                    parent.contentWindow.postMessage({
-                        msg: 'appClosed',
-                        appInstanceID: window_uuid,
-                    }, '*');
-                }
-
-                // notify child apps, if we have them, that we're closing
-                const children = $(`.window[data-parent_instance_id="${window_uuid}"] .window-app-iframe`);
-                children.each((_, child) => {
-                    child.contentWindow.postMessage({
-                        msg: 'appClosed',
-                        appInstanceID: window_uuid,
-                    }, '*');
-                });
-                // TODO: Once other AppConnections exist, those will need notifying too.
-            }
+            window.report_app_closed(window_uuid);
 
             // remove backdrop
             $(this).closest('.window-backdrop').remove();

--- a/src/UI/UIWindow.js
+++ b/src/UI/UIWindow.js
@@ -2773,7 +2773,6 @@ window.sidebar_item_droppable = (el_window)=>{
 // closes a window
 $.fn.close = async function(options) {
     options = options || {};
-    console.log(options);
     $(this).each(async function() {
         const el_iframe = $(this).find('.window-app-iframe');
         const app_uses_sdk = el_iframe.length > 0 && el_iframe.attr('data-appUsesSDK') === 'true';

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -3523,3 +3523,19 @@ window.window_for_app_instance = (instance_id) => {
 window.iframe_for_app_instance = (instance_id) => {
     return $(window_for_app_instance(instance_id)).find('.window-app-iframe').get(0);
 };
+
+// Run any callbacks to say that the app has launched
+window.report_app_launched = (instance_id, { uses_sdk = true }) => {
+    const child_launch_callback = window.child_launch_callbacks[instance_id];
+    if (child_launch_callback) {
+        const parent_iframe = iframe_for_app_instance(child_launch_callback.parent_instance_id);
+        // send confirmation to requester window
+        parent_iframe.contentWindow.postMessage({
+            msg: 'childAppLaunched',
+            original_msg_id: child_launch_callback.launch_msg_id,
+            child_instance_id: instance_id,
+            uses_sdk: uses_sdk,
+        }, '*');
+        delete window.child_launch_callbacks[instance_id];
+    }
+}

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -3513,3 +3513,13 @@ window.change_clock_visible = (clock_visible) => {
 
     $('select.change-clock-visible').val(window.user_preferences.clock_visible);
 }
+
+// Finds the `.window` element for the given app instance ID
+window.window_for_app_instance = (instance_id) => {
+    return $(`.window[data-element_uuid="${instance_id}"]`).get(0);
+};
+
+// Finds the `iframe` element for the given app instance ID
+window.iframe_for_app_instance = (instance_id) => {
+    return $(window_for_app_instance(instance_id)).find('.window-app-iframe').get(0);
+};

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1839,8 +1839,6 @@ window.launch_app = async (options)=>{
         // ...and finally append urm_source=puter.com to the URL
         iframe_url.searchParams.append('urm_source', 'puter.com');
 
-        console.log('backgrounded??', app_info.background);
-
         el_win = UIWindow({
             element_uuid: uuid,
             title: title,
@@ -1895,7 +1893,6 @@ window.launch_app = async (options)=>{
 
     (async () => {
         const el = await el_win;
-        console.log('RESOV', el);
         $(el).on('remove', () => {
             const svc_process = globalThis.services.get('process');
             svc_process.unregister(process.uuid);


### PR DESCRIPTION
After launching an app, if successful, we connect stdio streams to it, and wait for it to exit before we return to the prompt.

stdio is implemented as regular AppConnection messages:
- stdin:  `{ $: 'stdin',  data: Uint8Array }` from phoenix -> child
- stdout: `{ $: 'stdout', data: Uint8Array }` from child -> phoenix

SIGINT currently is not sent.