### PR TITLE
Add server info to the login page for issue #257

### DIFF
--- a/src/UI/Settings/UITabAbout.js
+++ b/src/UI/Settings/UITabAbout.js
@@ -17,6 +17,8 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+import { fetchServerInfo } from '../../services/VersionService.js';
+
 // About
 export default {
     id: 'about',
@@ -92,24 +94,15 @@ export default {
             </div>`;
     },
     init: ($el_window) => {
-        // version
-        $.ajax({
-            url: api_origin + "/version",
-            type: 'GET',
-            async: true,
-            contentType: "application/json",
-            headers: {
-                "Authorization": "Bearer " + auth_token
-            },
-            statusCode: {
-                401: function () {
-                    logout();
-                },
-            },
-            success: function (res) {
-                var d = new Date(0);
-                $el_window.find('.version').html('Version: ' + res.version + ' &bull; ' + 'Server: ' + res.location + ' &bull; ' + 'Deployed: ' + new Date(res.deploy_timestamp));
-            }
+        // server and version infomration
+        fetchServerInfo(api_origin, auth_token)
+        .then(res => {
+            const deployed_date = new Date(res.deployTimestamp).toLocaleString();
+            $el_window.find('.version').html(`Version: ${res.version} &bull; Server: ${res.location} &bull; Deployed: ${deployed_date}`);
+        })
+        .catch(error => {
+            console.error("Failed to fetch server info:", error);
+            $el_window.find('.version').html("Failed to load version information.");
         });
 
         $el_window.find('.credits').on('click', function (e) {

--- a/src/UI/UIWindowLogin.js
+++ b/src/UI/UIWindowLogin.js
@@ -20,6 +20,7 @@
 import UIWindow from './UIWindow.js'
 import UIWindowSignup from './UIWindowSignup.js'
 import UIWindowRecoverPassword from './UIWindowRecoverPassword.js'
+import { fetchServerInfo } from '../services/VersionService.js';
 
 async function UIWindowLogin(options){
     options = options ?? {};
@@ -59,6 +60,8 @@ async function UIWindowLogin(options){
                     h += `<button class="login-btn button button-primary button-block button-normal">${i18n('log_in')}</button>`;
                     // password recovery
                     h += `<p style="text-align:center; margin-bottom: 0;"><span class="forgot-password-link">${i18n('forgot_pass_c2a')}</span></p>`;
+                    // server and version info
+                    h += `<div id="version-placeholder" class="version" style="text-align:center;"></div>`;
                 h += `</form>`;
             h += `</div>`;
             // create account link
@@ -68,6 +71,16 @@ async function UIWindowLogin(options){
                 h += `</div>`;
             }
         h += `</div>`;
+
+        // server and version infomration
+        fetchServerInfo(api_origin, auth_token)
+        .then(res => {
+            const deployed_date = new Date(res.deployTimestamp).toLocaleString();
+            $("#version-placeholder").html(`Version: ${res.version} &bull; Server: ${res.location} &bull; Deployed: ${deployed_date}`);
+        })
+        .catch(() => {
+            $("#version-placeholder").html("Failed to load version or server information.");
+        });
         
         const el_window = await UIWindow({
             title: null,

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -3601,6 +3601,11 @@ label {
     height: 12px;
 }
 
+.version#version-placeholder {
+    margin-top: 10px;
+    margin-bottom: 0;
+}
+
 .version:hover {
     opacity: 1;
 }

--- a/src/services/VersionService.js
+++ b/src/services/VersionService.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright (C) 2024 Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+let server_info = null;
+
+export async function fetchServerInfo(api_origin, auth_token) {
+    if (server_info) return server_info;
+
+    try {
+        const res = await $.ajax({
+            url: api_origin + "/version",
+            type: 'GET',
+            contentType: "application/json",
+            headers: {
+                "Authorization": "Bearer " + auth_token
+            },
+            statusCode: {
+                401: function () {
+                    logout();
+                }
+            }
+        });
+        server_info = {
+            version: res.version,
+            location: res.location,
+            deployTimestamp: res.deploy_timestamp
+        };
+        return server_info;
+    } catch (error) {
+        console.error('Failed to fetch server info:', error);
+        throw error;
+    }
+}


### PR DESCRIPTION
Issue #257 suggests adding the server info to the login page, which has been done here.
## Summary

- The login page now fetches and displays the server information under the login button

- Added the VersionService.js module to make fetching the server version/information easier across scripts.

- The 'About' UI Tab in the settings now uses the VersionService.js module to fetch server info, rather than fetching by itself.

### Before
![before](https://github.com/HeyPuter/puter/assets/55029902/b939fff7-3115-4892-8358-109457468573)
### After
![After](https://github.com/HeyPuter/puter/assets/55029902/b73401c9-edc7-48ab-bb58-70af4c6049db)
