### PR TITLE
Update Docker CI

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -5,8 +5,13 @@ name: Docker Image CI
 # branch called `main`.
 on:
   push:
-    branches: ['release']
-  
+    tags:
+      - '*.*.*'
+    # branches:
+    #   - 'release'
+  pull_request:
+    branches:
+      - 'main'
 
 # Defines two custom environment variables for the workflow. These are used
 # for the Container registry domain, and a name for the Docker image that
@@ -40,8 +45,8 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-          
-      - name: Set up QEMU 
+
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
@@ -58,14 +63,8 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=schedule
-            type=ref,event=branch
-            type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
-            type=sha
-            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
 
       # This step uses the `docker/build-push-action` action to build the
       # image, based on your repository's `Dockerfile`. If the build succeeds,
@@ -81,6 +80,8 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64
           context: .
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
Pull request to have Docker run on tags instead of just on the Release branch and on Pull Requests to Main (can add more branches there if needed).

This should automatically create the corresponding Docker image when releasing a new version (as a tag).
The push to GHCR only happens when a tag is created, so that should only leave "stable" versions to be pushed to GHCR.

Also removed a bunch of metadata that was generated, as I'm not sure if that's needed per se.