### PR TITLE
fix: Add missing imports for APIError

### DIFF
--- a/packages/backend/src/api/filesystem/FlagParam.js
+++ b/packages/backend/src/api/filesystem/FlagParam.js
@@ -16,6 +16,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+const APIError = require('../../api/APIError');
+
 module.exports = class FlagParam {
     constructor (srckey, options) {
         this.srckey = srckey;

--- a/packages/backend/src/api/filesystem/StringParam.js
+++ b/packages/backend/src/api/filesystem/StringParam.js
@@ -16,6 +16,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+const APIError = require('../../api/APIError');
+
 module.exports = class StringParam {
     constructor (srckey, options) {
         this.srckey = srckey;

--- a/packages/backend/src/filesystem/hl_operations/hl_data_read.js
+++ b/packages/backend/src/filesystem/hl_operations/hl_data_read.js
@@ -18,6 +18,7 @@
  */
 const { stream_to_buffer } = require("../../util/streamutil");
 const { HLFilesystemOperation } = require("./definitions");
+const APIError = require('../../api/APIError');
 
 /**
  * HLDataRead reads a stream of objects from a file containing structured data.

--- a/packages/backend/src/filesystem/hl_operations/hl_stat.js
+++ b/packages/backend/src/filesystem/hl_operations/hl_stat.js
@@ -19,6 +19,7 @@
 const { chkperm } = require("../../helpers");
 const { Context } = require("../../util/context");
 const { HLFilesystemOperation } = require("./definitions");
+const APIError = require('../../api/APIError');
 
 class HLStat extends HLFilesystemOperation {
     static MODULES = {

--- a/packages/backend/src/routers/auth/list-permissions.js
+++ b/packages/backend/src/routers/auth/list-permissions.js
@@ -21,6 +21,7 @@ const { get_app, get_user } = require("../../helpers");
 const { UserActorType } = require("../../services/auth/Actor");
 const { DB_READ } = require("../../services/database/consts");
 const { Context } = require("../../util/context");
+const APIError = require('../../api/APIError');
 
 module.exports = eggspress('/auth/list-permissions', {
     subdomain: 'api',

--- a/packages/backend/src/routers/auth/list-sessions.js
+++ b/packages/backend/src/routers/auth/list-sessions.js
@@ -1,6 +1,7 @@
 const eggspress = require("../../api/eggspress");
 const { UserActorType } = require("../../services/auth/Actor");
 const { Context } = require("../../util/context");
+const APIError = require('../../api/APIError');
 
 module.exports = eggspress('/auth/list-sessions', {
     subdomain: 'api',

--- a/packages/backend/src/routers/auth/revoke-user-app.js
+++ b/packages/backend/src/routers/auth/revoke-user-app.js
@@ -19,6 +19,7 @@
 const eggspress = require("../../api/eggspress");
 const { UserActorType } = require("../../services/auth/Actor");
 const { Context } = require("../../util/context");
+const APIError = require('../../api/APIError');
 
 module.exports = eggspress('/auth/revoke-user-app', {
     subdomain: 'api',


### PR DESCRIPTION
This specifically was causing a crash when trying to stat a non-existent path, but I found all the other places that use APIError and added imports to those too.