### PR TITLE
fix: Make postinstall script work on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "start": "node run-selfhosted.js",
     "build": "node ./build.js",
     "check-translations": "node tools/check-translations.js",
-    "postinstall": "cd packages/phoenix && cd packages/contextlink && npm install && cd - && cd packages/strataparse && npm install && cd - && cd packages/pty && npm install"
+    "postinstall": "cd packages && cd phoenix && cd packages && cd contextlink && npm install && cd .. && cd strataparse && npm install && cd .. && cd pty && npm install"
   },
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
Split each `cd` call into one per directory so that we don't have any directory separators, because separators are different on Windows than Mac/Linux.

This is intended to fix the issue in #362 but I'm waiting for confirmation on that.