### PR TITLE
fix: Eliminates duplicate translation keys

### DIFF
--- a/src/i18n/translations/ru.js
+++ b/src/i18n/translations/ru.js
@@ -254,7 +254,6 @@ const ru = {
         yes_release_it: 'Да, освободить.',
         you_have_been_referred_to_puter_by_a_friend: "Вы были приглашены в Puter другом!",
         zip: "Заархивировать",
-        storage_puter_used: "использовано Puter",
     }
 };
 


### PR DESCRIPTION
` storage_puter_used: 'использовано Puter'`