### PR TITLE
fix(Terminal): Accept input from Chrome on Android 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4071,6 +4071,19 @@
         }
       }
     },
+    "node_modules/@xterm/addon-fit": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.10.0.tgz",
+      "integrity": "sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==",
+      "peerDependencies": {
+        "@xterm/xterm": "^5.0.0"
+      }
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
+      "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A=="
+    },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -11561,9 +11574,7 @@
         "fs-mode-to-string": "^0.0.2",
         "json-query": "^2.2.2",
         "path-browserify": "^1.0.1",
-        "sinon": "^17.0.1",
-        "xterm": "^5.1.0",
-        "xterm-addon-fit": "^0.7.0"
+        "sinon": "^17.0.1"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^24.1.0",
@@ -12131,17 +12142,6 @@
         "defaults": "^1.0.3"
       }
     },
-    "packages/phoenix/node_modules/xterm": {
-      "version": "5.1.0",
-      "license": "MIT"
-    },
-    "packages/phoenix/node_modules/xterm-addon-fit": {
-      "version": "0.7.0",
-      "license": "MIT",
-      "peerDependencies": {
-        "xterm": "^5.0.0"
-      }
-    },
     "packages/phoenix/packages/contextlink": {
       "version": "0.0.0",
       "extraneous": true,
@@ -12180,8 +12180,8 @@
       "version": "0.0.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "xterm": "^5.3.0",
-        "xterm-addon-fit": "^0.7.0"
+        "@xterm/addon-fit": "^0.10.0",
+        "@xterm/xterm": "^5.5.0"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^24.1.0",
@@ -12722,17 +12722,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "packages/terminal/node_modules/xterm": {
-      "version": "5.3.0",
-      "license": "MIT"
-    },
-    "packages/terminal/node_modules/xterm-addon-fit": {
-      "version": "0.7.0",
-      "license": "MIT",
-      "peerDependencies": {
-        "xterm": "^5.0.0"
       }
     }
   }

--- a/packages/phoenix/package-lock.json
+++ b/packages/phoenix/package-lock.json
@@ -22,9 +22,7 @@
         "fs-mode-to-string": "^0.0.2",
         "json-query": "^2.2.2",
         "path-browserify": "^1.0.1",
-        "sinon": "^17.0.1",
-        "xterm": "^5.1.0",
-        "xterm-addon-fit": "^0.7.0"
+        "sinon": "^17.0.1"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^24.1.0",
@@ -1795,19 +1793,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
-    },
-    "node_modules/xterm": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/xterm/-/xterm-5.1.0.tgz",
-      "integrity": "sha512-LovENH4WDzpwynj+OTkLyZgJPeDom9Gra4DMlGAgz6pZhIDCQ+YuO7yfwanY+gVbn/mmZIStNOnVRU/ikQuAEQ=="
-    },
-    "node_modules/xterm-addon-fit": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/xterm-addon-fit/-/xterm-addon-fit-0.7.0.tgz",
-      "integrity": "sha512-tQgHGoHqRTgeROPnvmtEJywLKoC/V9eNs4bLLz7iyJr1aW/QFzRwfd3MGiJ6odJd9xEfxcW36/xRU47JkD5NKQ==",
-      "peerDependencies": {
-        "xterm": "^5.0.0"
-      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/packages/phoenix/package.json
+++ b/packages/phoenix/package.json
@@ -26,9 +26,7 @@
     "fs-mode-to-string": "^0.0.2",
     "json-query": "^2.2.2",
     "path-browserify": "^1.0.1",
-    "sinon": "^17.0.1",
-    "xterm": "^5.1.0",
-    "xterm-addon-fit": "^0.7.0"
+    "sinon": "^17.0.1"
   },
   "optionalDependencies": {
     "node-pty": "^1.0.0"

--- a/packages/terminal/assets/xterm.css
+++ b/packages/terminal/assets/xterm.css
@@ -140,7 +140,7 @@
     cursor: crosshair;
 }
 
-.xterm .xterm-accessibility,
+.xterm .xterm-accessibility:not(.debug),
 .xterm .xterm-message {
     position: absolute;
     left: 0;
@@ -150,6 +150,15 @@
     z-index: 10;
     color: transparent;
     pointer-events: none;
+}
+
+.xterm .xterm-accessibility-tree:not(.debug) *::selection {
+    color: transparent;
+}
+
+.xterm .xterm-accessibility-tree {
+    user-select: text;
+    white-space: pre;
 }
 
 .xterm .live-region {
@@ -187,12 +196,12 @@
 }
 
 .xterm-screen .xterm-decoration-container .xterm-decoration {
-	z-index: 6;
-	position: absolute;
+    z-index: 6;
+    position: absolute;
 }
 
 .xterm-screen .xterm-decoration-container .xterm-decoration.xterm-decoration-top-layer {
-	z-index: 7;
+    z-index: 7;
 }
 
 .xterm-decoration-overview-ruler {

--- a/packages/terminal/package.json
+++ b/packages/terminal/package.json
@@ -19,7 +19,7 @@
     "rollup-plugin-copy": "^3.4.0"
   },
   "dependencies": {
-    "xterm": "^5.3.0",
-    "xterm-addon-fit": "^0.7.0"
+    "@xterm/xterm": "^5.5.0",
+    "@xterm/addon-fit": "^0.10.0"
   }
 }

--- a/packages/terminal/src/main.js
+++ b/packages/terminal/src/main.js
@@ -16,8 +16,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import { Terminal } from 'xterm';
-import { FitAddon } from 'xterm-addon-fit';
+import { Terminal } from '@xterm/xterm';
+import { FitAddon } from '@xterm/addon-fit';
 import { PTY } from './pty/PTY';
 import { XDocumentANSIShell } from './pty/XDocumentANSIShell';
 

--- a/packages/terminal/src/main.js
+++ b/packages/terminal/src/main.js
@@ -28,9 +28,7 @@ class XTermIO {
     }
 
     bind () {
-        this.term.onKey(this.handleKey.bind(this));
-
-        this.term.attachCustomKeyEventHandler(this.handleKeyBeforeProcess.bind(this));
+        this.term.onData(this.handleData.bind(this));
 
         (async () => {
             for ( ;; ) {
@@ -40,41 +38,8 @@ class XTermIO {
         })();
     }
 
-    async handleKeyBeforeProcess (evt) {
-        if ( evt.key === 'V' && evt.ctrlKey && evt.shiftKey && evt.type === 'keydown' ) {
-            const clipboard = navigator.clipboard;
-            const text = await clipboard.readText();
-            this.pty.out.write(text);
-        }
-    }
-
-    handleKey ({ key, domEvent }) {
-        const pty = this.pty;
-
-        const handlers = {
-            Enter: () => {
-                pty.out.write('\n');
-            },
-            // Backspace: () => {
-            //     pty.out.write('\x08');
-            // },
-            // Delete: () => {
-            //     pty.out.write('\x1B[3~');
-            // },
-            Home: () => {
-                pty.out.write('\x1B[H');
-            },
-            End: () => {
-                pty.out.write('\x1B[F');
-            }
-        }
-    
-        if ( handlers.hasOwnProperty(domEvent.key) ) {
-            const writeKey = handlers[domEvent.key]();
-            if ( ! writeKey ) return;
-        }
-
-        pty.out.write(key);
+    handleData ( data ) {
+        this.pty.out.write(data);
     }
 }
 


### PR DESCRIPTION
Fixes #217.

Xterm.js produces two kinds of events: `onKey` and `onData`. On a desktop, these are effectively the same, but on mobile, IME inputs produce data but not key presses. By listening to `onData` instead of `onKey`, we get that input.

With some experimentation, I also found that we don't need the code to handle enter, home, end, or Ctrl-Shift-V. All of these function as expected without that code, so we can remove it and simplify this further. :^)