### PR TITLE
fix: Correct APIError imports

### DIFF
--- a/packages/backend/src/api/filesystem/FlagParam.js
+++ b/packages/backend/src/api/filesystem/FlagParam.js
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-const { APIError } = require('../../api/APIError');
+const APIError = require('../../api/APIError');
 
 module.exports = class FlagParam {
     constructor (srckey, options) {

--- a/packages/backend/src/api/filesystem/StringParam.js
+++ b/packages/backend/src/api/filesystem/StringParam.js
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-const { APIError } = require('../../api/APIError');
+const APIError = require('../../api/APIError');
 
 module.exports = class StringParam {
     constructor (srckey, options) {

--- a/packages/backend/src/filesystem/hl_operations/hl_data_read.js
+++ b/packages/backend/src/filesystem/hl_operations/hl_data_read.js
@@ -20,7 +20,7 @@ const { stream_to_buffer } = require("../../util/streamutil");
 const { HLFilesystemOperation } = require("./definitions");
 const { chkperm } = require('../../helpers');
 const { LLRead } = require('../ll_operations/ll_read');
-const { APIError } = require('../../api/APIError');
+const APIError = require('../../api/APIError');
 
 /**
  * HLDataRead reads a stream of objects from a file containing structured data.

--- a/packages/backend/src/filesystem/hl_operations/hl_stat.js
+++ b/packages/backend/src/filesystem/hl_operations/hl_stat.js
@@ -19,7 +19,7 @@
 const { chkperm } = require("../../helpers");
 const { Context } = require("../../util/context");
 const { HLFilesystemOperation } = require("./definitions");
-const { APIError } = require('../../api/APIError');
+const APIError = require('../../api/APIError');
 
 class HLStat extends HLFilesystemOperation {
     static MODULES = {

--- a/packages/backend/src/filesystem/ll_operations/ll_rmnode.js
+++ b/packages/backend/src/filesystem/ll_operations/ll_rmnode.js
@@ -19,7 +19,7 @@
 const { Context } = require("../../util/context");
 const { ParallelTasks } = require("../../util/otelutil");
 const { LLFilesystemOperation } = require("./definitions");
-const { APIError } = require("../../api/APIError");
+const APIError = require("../../api/APIError");
 
 class LLRmNode extends LLFilesystemOperation {
     async _run () {

--- a/packages/backend/src/routers/auth/list-permissions.js
+++ b/packages/backend/src/routers/auth/list-permissions.js
@@ -21,7 +21,7 @@ const { get_app, get_user } = require("../../helpers");
 const { UserActorType } = require("../../services/auth/Actor");
 const { DB_READ } = require("../../services/database/consts");
 const { Context } = require("../../util/context");
-const { APIError } = require('../../api/APIError');
+const APIError = require('../../api/APIError');
 
 module.exports = eggspress('/auth/list-permissions', {
     subdomain: 'api',

--- a/packages/backend/src/routers/auth/list-sessions.js
+++ b/packages/backend/src/routers/auth/list-sessions.js
@@ -1,7 +1,7 @@
 const eggspress = require("../../api/eggspress");
 const { UserActorType } = require("../../services/auth/Actor");
 const { Context } = require("../../util/context");
-const { APIError } = require('../../api/APIError');
+const APIError = require('../../api/APIError');
 
 module.exports = eggspress('/auth/list-sessions', {
     subdomain: 'api',

--- a/packages/backend/src/routers/auth/revoke-user-app.js
+++ b/packages/backend/src/routers/auth/revoke-user-app.js
@@ -19,7 +19,7 @@
 const eggspress = require("../../api/eggspress");
 const { UserActorType } = require("../../services/auth/Actor");
 const { Context } = require("../../util/context");
-const { APIError } = require('../../api/APIError');
+const APIError = require('../../api/APIError');
 
 module.exports = eggspress('/auth/revoke-user-app', {
     subdomain: 'api',


### PR DESCRIPTION
APIError is the only thing exported from its file, so we must not wrap it in {}.

When I "corrected" these in the ESLint PR, I never had errors come up so I didn't realise that it was still broken. :sweat_smile: Works now though.