### PR TITLE
Explicitly reject invalid types for puter.fs.upload() and .write() payloads

### DIFF
--- a/packages/puter-js/src/modules/FileSystem/operations/upload.js
+++ b/packages/puter-js/src/modules/FileSystem/operations/upload.js
@@ -122,7 +122,11 @@ const upload = async function(items, dirPath, options = {}){
                 entries[i].filepath = entries[i].name;
                 entries[i].fullPath = entries[i].name;
             }
-        }       
+        }
+        // Anything else is invalid
+        else {
+            return error({ code: 'field_invalid', message: 'upload() items parameter is an invalid type' });
+        }
 
         // Will hold directories and files to be uploaded
         let dirs = [];

--- a/packages/puter-js/src/modules/FileSystem/operations/upload.js
+++ b/packages/puter-js/src/modules/FileSystem/operations/upload.js
@@ -15,16 +15,19 @@ const upload = async function(items, dirPath, options = {}){
             }
         }
 
+        const error = (e) => {
+            // if error callback is provided, call it
+            if(options.error && typeof options.error === 'function')
+                options.error(e);
+            return reject(e);
+        };
+
         // xhr object to be used for the upload
         let xhr = new XMLHttpRequest();
 
         // Can not write to root
-        if(dirPath === '/'){
-            // if error callback is provided, call it
-            if(options.error && typeof options.error === 'function')
-                options.error('Can not upload to root directory.');
-            return reject('Can not upload to root directory.');
-        }
+        if(dirPath === '/')
+            return error('Can not upload to root directory.');
 
         // If dirPath is not provided or it's not starting with a slash, it means it's a relative path
         // in that case, we need to prepend the app's root directory to it
@@ -145,10 +148,7 @@ const upload = async function(items, dirPath, options = {}){
 
         // Continue only if there are actually any files/directories to upload
         if(dirs.length === 0 && files.length === 0){
-            if(options.error && typeof options.error === 'function'){
-                options.error({code: 'EMPTY_UPLOAD', message: 'No files or directories to upload.'});
-            }
-            return reject({code: 'EMPTY_UPLOAD', message: 'No files or directories to upload.'});
+            return error({code: 'EMPTY_UPLOAD', message: 'No files or directories to upload.'});
         }
 
         // Check storage capacity.
@@ -163,10 +163,7 @@ const upload = async function(items, dirPath, options = {}){
             try{
                 storage = await this.space();
                 if(storage.capacity - storage.used < total_size){
-                    if(options.error && typeof options.error === 'function'){
-                        options.error({code: 'NOT_ENOUGH_SPACE', message: 'Not enough storage space available.'});
-                    }
-                    return reject({code: 'NOT_ENOUGH_SPACE', message: 'Not enough storage space available.'});
+                    return error({code: 'NOT_ENOUGH_SPACE', message: 'Not enough storage space available.'});
                 }
             }catch(e){
                 // Ignored
@@ -368,18 +365,10 @@ const upload = async function(items, dirPath, options = {}){
                                 break;
                             }
                         }
-                        // if error callback is provided, call it
-                        if(options.error && typeof options.error === 'function'){
-                            options.error(failed_operation);
-                        }
-                        return reject(failed_operation);
+                        return error(failed_operation);
                     }
 
-                    // if error callback is provided, call it
-                    if(options.error && typeof options.error === 'function'){
-                        options.error(resp);
-                    }
-                    return reject(resp);
+                    return error(resp);
                 }
                 // Success
                 else{

--- a/packages/puter-js/src/modules/FileSystem/operations/write.js
+++ b/packages/puter-js/src/modules/FileSystem/operations/write.js
@@ -46,6 +46,11 @@ const write = async function (targetPath, data, options = {}) {
     if(!data)
         data = new File([data ?? ''], filename);
 
+    // data should be a File now. If it's not, it's an unsupported type
+    if (!(data instanceof File)) {
+        throw new Error({ code: 'field_invalid', message: 'write() data parameter is an invalid type' });
+    }
+
     // perform upload
     return this.upload(data, parent, options);
 }


### PR DESCRIPTION
Previously, this would crash in upload() when trying to iterate the `entries` array, which is undefined when the `items` parameter is an unsupported type.

---

I did notice when looking at this too, that our [docs for `upload()`](https://docs.puter.com/FS/upload/) says:

> items can be an InputFileList, FileList, Array of File objects, or an Array of Blob objects.

but the code says (correctly as far as I can tell):

> 'items' could be a DataTransferItemList, FileList, File, or an array of any of these,

So that could be confusing for anyone trying to use this!