### PR TITLE
fix: Remove null or duplicate app entries from suggest_app_for_fsentry()

### DIFF
--- a/packages/backend/src/helpers.js
+++ b/packages/backend/src/helpers.js
@@ -1770,7 +1770,15 @@ async function suggest_app_for_fsentry(fsentry, options){
     monitor.end();
 
     // return list
-    return suggested_apps;
+    return suggested_apps.filter((suggested_app, pos, self) => {
+        // Remove any null values caused by calling `get_app()` for apps that don't exist.
+        // This happens on self-host because we don't include `code`, among others.
+        if (!suggested_app)
+            return false;
+
+        // Remove any duplicate entries
+        return self.indexOf(suggested_app) === pos;
+    });
 }
 
 function build_item_object(item){


### PR DESCRIPTION
I noticed when trying to open a file named `COMMIT_EDITMSG` that the suggested apps returned were:
- null
- Editor
- Editor again
- null

The weirdness is caused by:
- `get_app('code')` returning nothing on self-host, because the `code` app isn't available.
- Multiple checks matching this file

This fixes double-clicking on that file. However, it doesn't solve duplicates appearing in the Open With menu:
![image](https://github.com/HeyPuter/puter/assets/222642/0b63b865-81fc-4788-b87b-45ffe7340142)
I couldn't figure out what's different about that, and didn't want to spend too long on it.