### PR TITLE
updated the github links displayed in the Terminal welcome message, issue (#393)

### DIFF
--- a/packages/phoenix/src/puter-shell/main.js
+++ b/packages/phoenix/src/puter-shell/main.js
@@ -45,8 +45,8 @@ const decorator_registry = {
 };
 
 const GH_LINK = {
-    'terminal': 'https://github.com/HeyPuter/terminal',
-    'phoenix': 'https://github.com/HeyPuter/phoenix',
+    'terminal': 'https://github.com/HeyPuter/puter/tree/main/packages/terminal',
+    'phoenix': 'https://github.com/HeyPuter/puter/tree/main/packages/phoenix',
 };
 
 export const launchPuterShell = async (ctx) => {


### PR DESCRIPTION
#393 
## Description
> When Terminal starts, it shows a message

## Before changes 
This shell and Puter's Terminal Emulator are free software:
- phoenix: https://github.com/HeyPuter/phoenix
- terminal: https://github.com/HeyPuter/terminal

## After Changes
`const GH_LINK = {
    'terminal': 'https://github.com/HeyPuter/puter/tree/main/packages/terminal',
    'phoenix': 'https://github.com/HeyPuter/puter/tree/main/packages/phoenix',
};`

