### PR TITLE
refactor: Move PosixError class where it can be accessed outside of Phoenix

### DIFF
--- a/packages/phoenix/src/platform/node/filesystem.js
+++ b/packages/phoenix/src/platform/node/filesystem.js
@@ -22,29 +22,6 @@ import path_ from 'path';
 import modeString from 'fs-mode-to-string';
 import { ErrorCodes, PosixError } from '@heyputer/puter-js-common/src/PosixError.js';
 
-function convertNodeError(e) {
-    switch (e.code) {
-        case 'EACCES': return new PosixError(ErrorCodes.EACCES, e.message);
-        case 'EADDRINUSE': return new PosixError(ErrorCodes.EADDRINUSE, e.message);
-        case 'ECONNREFUSED': return new PosixError(ErrorCodes.ECONNREFUSED, e.message);
-        case 'ECONNRESET': return new PosixError(ErrorCodes.ECONNRESET, e.message);
-        case 'EEXIST': return new PosixError(ErrorCodes.EEXIST, e.message);
-        case 'EIO': return new PosixError(ErrorCodes.EIO, e.message);
-        case 'EISDIR': return new PosixError(ErrorCodes.EISDIR, e.message);
-        case 'EMFILE': return new PosixError(ErrorCodes.EMFILE, e.message);
-        case 'ENOENT': return new PosixError(ErrorCodes.ENOENT, e.message);
-        case 'ENOTDIR': return new PosixError(ErrorCodes.ENOTDIR, e.message);
-        case 'ENOTEMPTY': return new PosixError(ErrorCodes.ENOTEMPTY, e.message);
-        // ENOTFOUND is Node-specific. ECONNREFUSED is similar enough.
-        case 'ENOTFOUND': return new PosixError(ErrorCodes.ECONNREFUSED, e.message);
-        case 'EPERM': return new PosixError(ErrorCodes.EPERM, e.message);
-        case 'EPIPE': return new PosixError(ErrorCodes.EPIPE, e.message);
-        case 'ETIMEDOUT': return new PosixError(ErrorCodes.ETIMEDOUT, e.message);
-    }
-    // Some other kind of error
-    return e;
-}
-
 // DRY: Almost the same as puter/filesystem.js
 function wrapAPIs(apis) {
     for (const method in apis) {
@@ -56,7 +33,7 @@ function wrapAPIs(apis) {
             try {
                 return await original(...args);
             } catch (e) {
-                throw convertNodeError(e);
+                throw PosixError.fromNodeJSError(e);
             }
         };
     }

--- a/packages/phoenix/src/platform/node/filesystem.js
+++ b/packages/phoenix/src/platform/node/filesystem.js
@@ -20,7 +20,7 @@ import fs from 'fs';
 import path_ from 'path';
 
 import modeString from 'fs-mode-to-string';
-import { ErrorCodes, PosixError } from '../PosixError.js';
+import { ErrorCodes, PosixError } from '@heyputer/puter-js-common/src/PosixError.js';
 
 function convertNodeError(e) {
     switch (e.code) {

--- a/packages/phoenix/src/platform/puter/filesystem.js
+++ b/packages/phoenix/src/platform/puter/filesystem.js
@@ -18,106 +18,6 @@
  */
 import { ErrorCodes, PosixError } from '@heyputer/puter-js-common/src/PosixError.js';
 
-function convertPuterError(e) {
-    // Handle Puter SDK errors
-    switch (e.code) {
-        case 'item_with_same_name_exists': return new PosixError(ErrorCodes.EEXIST, e.message);
-        case 'cannot_move_item_into_itself': return new PosixError(ErrorCodes.EPERM, e.message);
-        case 'cannot_copy_item_into_itself': return new PosixError(ErrorCodes.EPERM, e.message);
-        case 'cannot_move_to_root': return new PosixError(ErrorCodes.EACCES, e.message);
-        case 'cannot_copy_to_root': return new PosixError(ErrorCodes.EACCES, e.message);
-        case 'cannot_write_to_root': return new PosixError(ErrorCodes.EACCES, e.message);
-        case 'cannot_overwrite_a_directory': return new PosixError(ErrorCodes.EPERM, e.message);
-        case 'cannot_read_a_directory': return new PosixError(ErrorCodes.EISDIR, e.message);
-        case 'source_and_dest_are_the_same': return new PosixError(ErrorCodes.EPERM, e.message);
-        case 'dest_is_not_a_directory': return new PosixError(ErrorCodes.ENOTDIR, e.message);
-        case 'dest_does_not_exist': return new PosixError(ErrorCodes.ENOENT, e.message);
-        case 'source_does_not_exist': return new PosixError(ErrorCodes.ENOENT, e.message);
-        case 'subject_does_not_exist': return new PosixError(ErrorCodes.ENOENT, e.message);
-        case 'shortcut_target_not_found': return new PosixError(ErrorCodes.ENOENT, e.message);
-        case 'shortcut_target_is_a_directory': return new PosixError(ErrorCodes.EISDIR, e.message);
-        case 'shortcut_target_is_a_file': return new PosixError(ErrorCodes.ENOTDIR, e.message);
-        case 'forbidden': return new PosixError(ErrorCodes.EPERM, e.message);
-        case 'immutable': return new PosixError(ErrorCodes.EACCES, e.message);
-        case 'field_empty': return new PosixError(ErrorCodes.EINVAL, e.message);
-        case 'field_missing': return new PosixError(ErrorCodes.EINVAL, e.message);
-        case 'xor_field_missing': return new PosixError(ErrorCodes.EINVAL, e.message);
-        case 'field_only_valid_with_other_field': return new PosixError(ErrorCodes.EINVAL, e.message);
-        case 'invalid_id': return new PosixError(ErrorCodes.EINVAL, e.message);
-        case 'field_invalid': return new PosixError(ErrorCodes.EINVAL, e.message);
-        case 'field_immutable': return new PosixError(ErrorCodes.EINVAL, e.message);
-        case 'field_too_long': return new PosixError(ErrorCodes.EINVAL, e.message);
-        case 'field_too_short': return new PosixError(ErrorCodes.EINVAL, e.message);
-        case 'already_in_use': return new PosixError(ErrorCodes.EINVAL, e.message); // Not sure what this one is
-        case 'invalid_file_name': return new PosixError(ErrorCodes.EINVAL, e.message);
-        case 'storage_limit_reached': return new PosixError(ErrorCodes.ENOSPC, e.message);
-        case 'internal_error': return new PosixError(ErrorCodes.ECONNRESET, e.message); // This isn't quite right
-        case 'response_timeout': return new PosixError(ErrorCodes.ETIMEDOUT, e.message);
-        case 'file_too_large': return new PosixError(ErrorCodes.EFBIG, e.message);
-        case 'thumbnail_too_large': return new PosixError(ErrorCodes.EFBIG, e.message);
-        case 'upload_failed': return new PosixError(ErrorCodes.ECONNRESET, e.message); // This isn't quite right
-        case 'missing_expected_metadata': return new PosixError(ErrorCodes.EINVAL, e.message);
-        case 'overwrite_and_dedupe_exclusive': return new PosixError(ErrorCodes.EINVAL, e.message);
-        case 'not_empty': return new PosixError(ErrorCodes.ENOTEMPTY, e.message);
-
-        // Write
-        case 'offset_without_existing_file': return new PosixError(ErrorCodes.ENOENT, e.message);
-        case 'offset_requires_overwrite': return new PosixError(ErrorCodes.EINVAL, e.message);
-        case 'offset_requires_stream': return new PosixError(ErrorCodes.EPERM, e.message);
-
-        // Batch
-        case 'batch_too_many_files': return new PosixError(ErrorCodes.EINVAL, e.message);
-        case 'batch_missing_file': return new PosixError(ErrorCodes.EINVAL, e.message);
-
-        // Open
-        case 'no_suitable_app': break;
-        case 'app_does_not_exist': break;
-
-        // Apps
-        case 'app_name_already_in_use': break;
-
-        // Subdomains
-        case 'subdomain_limit_reached': break;
-        case 'subdomain_reserved': break;
-
-        // Users
-        case 'email_already_in_use': break;
-        case 'username_already_in_use': break;
-        case 'too_many_username_changes': break;
-        case 'token_invalid': break;
-
-        // drivers
-        case 'interface_not_found': break;
-        case 'no_implementation_available': break;
-        case 'method_not_found': break;
-        case 'missing_required_argument': break;
-        case 'argument_consolidation_failed': break;
-
-        // SLA
-        case 'rate_limit_exceeded': break;
-        case 'monthly_limit_exceeded': break;
-        case 'server_rate_exceeded': break;
-
-        // auth
-        case 'token_missing': break;
-        case 'token_auth_failed': break;
-        case 'token_unsupported': break;
-        case 'account_suspended': break;
-        case 'permission_denied': break;
-        case 'access_token_empty_permissions': break;
-
-        // Object Mapping
-        case 'field_not_allowed_for_create': break;
-        case 'field_required_for_update': break;
-        case 'entity_not_found': break;
-
-        // Chat
-        case 'max_tokens_exceeded': break;
-    }
-    // Some other kind of error
-    return e;
-}
-
 // DRY: Almost the same as node/filesystem.js
 function wrapAPIs(apis) {
     for (const method in apis) {
@@ -129,7 +29,7 @@ function wrapAPIs(apis) {
             try {
                 return await original(...args);
             } catch (e) {
-                throw convertPuterError(e);
+                throw PosixError.fromPuterAPIError(e);
             }
         };
     }

--- a/packages/phoenix/src/platform/puter/filesystem.js
+++ b/packages/phoenix/src/platform/puter/filesystem.js
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import { ErrorCodes, PosixError } from '../PosixError.js';
+import { ErrorCodes, PosixError } from '@heyputer/puter-js-common/src/PosixError.js';
 
 function convertPuterError(e) {
     // Handle Puter SDK errors

--- a/packages/phoenix/src/puter-shell/coreutils/errno.js
+++ b/packages/phoenix/src/puter-shell/coreutils/errno.js
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import { ErrorCodes, ErrorMetadata, errorFromIntegerCode } from '../../platform/PosixError.js';
+import { ErrorCodes, ErrorMetadata, errorFromIntegerCode } from '@heyputer/puter-js-common/src/PosixError.js';
 import { Exit } from './coreutil_lib/exit.js';
 
 const maxErrorNameLength = Object.keys(ErrorCodes)

--- a/packages/phoenix/src/puter-shell/coreutils/touch.js
+++ b/packages/phoenix/src/puter-shell/coreutils/touch.js
@@ -18,7 +18,7 @@
  */
 import { Exit } from './coreutil_lib/exit.js';
 import { resolveRelativePath } from '../../util/path.js';
-import { ErrorCodes } from '../../platform/PosixError.js';
+import { ErrorCodes } from '@heyputer/puter-js-common/src/PosixError.js';
 
 export default {
     name: 'touch',

--- a/packages/phoenix/test/coreutils/errno.js
+++ b/packages/phoenix/test/coreutils/errno.js
@@ -100,7 +100,8 @@ export const runErrnoTests = () => {
                     'EADDRINUSE    98 Address already in use\n' +
                     'ECONNRESET   104 Connection reset\n' +
                     'ETIMEDOUT    110 Connection timed out\n' +
-                    'ECONNREFUSED 111 Connection refused\n',
+                    'ECONNREFUSED 111 Connection refused\n' +
+                    'EUNKNOWN      -1 Unknown error\n',
                 expectedStderr: '',
                 expectedFail: false,
             },

--- a/packages/phoenix/test/coreutils/errno.js
+++ b/packages/phoenix/test/coreutils/errno.js
@@ -19,7 +19,7 @@
 import assert from 'assert';
 import { MakeTestContext } from './harness.js'
 import builtins from '../../src/puter-shell/coreutils/__exports__.js';
-import { ErrorCodes, ErrorMetadata } from '../../src/platform/PosixError.js';
+import { ErrorCodes, ErrorMetadata } from '@heyputer/puter-js-common/src/PosixError.js';
 
 export const runErrnoTests = () => {
     describe('errno', function () {

--- a/packages/puter-js-common/src/PosixError.js
+++ b/packages/puter-js-common/src/PosixError.js
@@ -89,6 +89,7 @@ class PosixError extends Error {
 
         super(message ?? ErrorMetadata.get(posixCode).description);
         this.posixCode = posixCode;
+        this.code = posixCode.description;
     }
 
     static fromNodeJSError(e) {

--- a/packages/puter-js-common/src/PosixError.js
+++ b/packages/puter-js-common/src/PosixError.js
@@ -1,9 +1,9 @@
 /*
  * Copyright (C) 2024  Puter Technologies Inc.
  *
- * This file is part of Phoenix Shell.
+ * This file is part of Puter.
  *
- * Phoenix Shell is free software: you can redistribute it and/or modify
+ * Puter is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published
  * by the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-export const ErrorCodes = {
+const ErrorCodes = {
     EACCES: Symbol.for('EACCES'),
     EADDRINUSE: Symbol.for('EADDRINUSE'),
     ECONNREFUSED: Symbol.for('ECONNREFUSED'),
@@ -37,7 +37,7 @@ export const ErrorCodes = {
 };
 
 // Codes taken from `errno` on Linux.
-export const ErrorMetadata = new Map([
+const ErrorMetadata = new Map([
     [ErrorCodes.EPERM, { code: 1, description: 'Operation not permitted' }],
     [ErrorCodes.ENOENT, { code: 2, description: 'File or directory not found' }],
     [ErrorCodes.EIO, { code: 5, description: 'IO error' }],
@@ -57,7 +57,7 @@ export const ErrorMetadata = new Map([
     [ErrorCodes.ECONNREFUSED, { code: 111, description: 'Connection refused' }],
 ]);
 
-export const errorFromIntegerCode = (code) => {
+const errorFromIntegerCode = (code) => {
     for (const [errorCode, metadata] of ErrorMetadata) {
         if (metadata.code === code) {
             return errorCode;
@@ -66,7 +66,7 @@ export const errorFromIntegerCode = (code) => {
     return undefined;
 };
 
-export class PosixError extends Error {
+class PosixError extends Error {
     // posixErrorCode can be either a string, or one of the ErrorCodes above.
     // If message is undefined, a default message will be used.
     constructor(posixErrorCode, message) {
@@ -140,4 +140,11 @@ export class PosixError extends Error {
     static TimedOut({ message } = {}) {
         return new PosixError(ErrorCodes.ETIMEDOUT, message);
     }
+}
+
+module.exports = {
+    ErrorCodes,
+    ErrorMetadata,
+    errorFromIntegerCode,
+    PosixError,
 }


### PR DESCRIPTION
This class is generally useful if we want to convert between Puter and Node-style errors.
- Move PosixError from phoenix to puter-js-common package.
- Move Phoenix's functions for converting Node or Puter errors into PosixErrors, into the PosixError class itself.
- Store the posix error code's string name as PosixError.code, which is expected by some libraries that are used to Node errors.