### PR TITLE
feat: Display app icon and description in embeds

### DIFF
--- a/packages/backend/src/routers/_default.js
+++ b/packages/backend/src/routers/_default.js
@@ -265,7 +265,7 @@ router.all('*', async function(req, res, next) {
         // ------------------------
         else{
             let canonical_url = config.origin + path;
-            let app_name, app_title, description;
+            let app_name, app_title, app_description, app_icon;
             let launch_options = {
                 on_initialized: []
             };
@@ -283,7 +283,8 @@ router.all('*', async function(req, res, next) {
                 const app = await get_app({name: app_name});
                 if(app){
                     app_title = app.title;
-                    description = app.description;
+                    app_description = app.description;
+                    app_icon = app.icon;
                 }
                 // 404 - Not found!
                 else if(app_name){
@@ -319,10 +320,11 @@ router.all('*', async function(req, res, next) {
                 const svc_puterHomepage = Context.get('services').get('puter-homepage');
                 return svc_puterHomepage.send({ req, res }, {
                     title: app_title,
-                    description: description || config.short_description,
-                    short_description: config.short_description,
+                    description: app_description || config.short_description,
+                    short_description: app_description || config.short_description,
                     company: 'Puter Technologies Inc.',
                     canonical_url: canonical_url,
+                    icon: app_icon,
                 }, launch_options);
             }
 

--- a/packages/backend/src/services/PuterHomepageService.js
+++ b/packages/backend/src/services/PuterHomepageService.js
@@ -122,6 +122,7 @@ class PuterHomepageService extends BaseService {
             short_description,
             company,
             canonical_url,
+            icon,
         } = meta;
 
         gui_params = {
@@ -141,6 +142,8 @@ class PuterHomepageService extends BaseService {
 
         const bundled = env != 'dev' || use_bundled_gui;
 
+        const icon_url = icon || `${asset_dir}/images/screenshot.png`;
+
         const writeScriptTag = path =>
             `<script type="${
                 Array.isArray(path) ? 'text/javascirpt' : 'module'
@@ -158,19 +161,19 @@ class PuterHomepageService extends BaseService {
         <link rel="canonical" href="${e(canonical_url)}">
 
         <!-- Meta meta tags -->
-        <meta property="og:url" content="${app_origin}">
+        <meta property="og:url" content="${e(canonical_url)}">
         <meta property="og:type" content="website">
         <meta property="og:title" content="${e(title)}">
         <meta property="og:description" content="${e((short_description).replace(/\n/g, " "))}">
-        <meta property="og:image" content="${asset_dir}/images/screenshot.png">
+        <meta property="og:image" content="${e(icon_url)}">
 
         <!-- Twitter meta tags -->
         <meta name="twitter:card" content="summary_large_image">
         <meta property="twitter:domain" content="puter.com">
-        <meta property="twitter:url" content="${app_origin}">
+        <meta property="twitter:url" content="${e(canonical_url)}">
         <meta name="twitter:title" content="${e(title)}">
         <meta name="twitter:description" content="${e((short_description).replace(/\n/g, " "))}">
-        <meta name="twitter:image" content="${asset_dir}/images/screenshot.png">
+        <meta name="twitter:image" content="${e(icon_url)}">
 
         <!-- favicons -->
         <link rel="apple-touch-icon" sizes="57x57" href="${asset_dir}/favicons/apple-icon-57x57.png">


### PR DESCRIPTION
**I have NOT been able to test this** because the only tester tool I could find requires HTTPS and no `:port` in the URL, which I haven't figured out how to set up. :sweat_smile: 

Fixes #398 - turns out we don't actually do oembed, it's just OpenGraph and Twitter metadata that other sites like Discord also support. Maybe we should support oembed too?

I'm not sure what the distinction between `description` and `short_description` is in this code.

We might want to also insert a mention of what Puter is into the description somewhere.

As a side note we have ~~three~~*two* different places that generate the HTML for the Puter GUI:
- `generateDevHtml()` in `utils.js`, which is used by the old "run only the GUI locally" server, `npm run start=gui`. That seems to be broken.
- `html_head()` in `backend/src/html_head.js`, which is unused
- ~~`generate_puter_page_html()` in `backend/src/temp/puter_page_loader.js` which is what actually runs, but is in a `temp` directory~~

So that could use some figuring out. I got a bit confused. :sweat_smile: 