### PR TITLE
feat(backend): add script service

### DIFF
--- a/packages/backend/src/CoreModule.js
+++ b/packages/backend/src/CoreModule.js
@@ -228,6 +228,9 @@ const install = async ({ services, app }) => {
 
     const { DriverService } = require("./services/drivers/DriverService");
     services.registerService('driver', DriverService);
+
+    const { ScriptService } = require('./services/ScriptService');
+    services.registerService('script', ScriptService);
 }
 
 const install_legacy = async ({ services }) => {

--- a/packages/backend/src/services/ScriptService.js
+++ b/packages/backend/src/services/ScriptService.js
@@ -1,0 +1,47 @@
+const BaseService = require("./BaseService");
+
+class BackendScript {
+    constructor (name, fn) {
+        this.name = name;
+        this.fn = fn;
+    }
+
+    async run (ctx, args) {
+        return await this.fn(ctx, args);
+    }
+
+}
+
+class ScriptService extends BaseService {
+    _construct () {
+        this.scripts = [];
+    }
+
+    async _init () {
+        const svc_commands = this.services.get('commands');
+        svc_commands.registerCommands('script', [
+            {
+                id: 'run',
+                description: 'run a script',
+                handler: async (args, ctx) => {
+                    const script_name = args.shift();
+                    const script = this.scripts.find(s => s.name === script_name);
+                    if ( ! script ) {
+                        ctx.error(`script not found: ${script_name}`);
+                        return;
+                    }
+                    await script.run(ctx, args);
+                }
+            }
+        ]);
+    }
+
+    register (name, fn) {
+        this.scripts.push(new BackendScript(name, fn));
+    }
+}
+
+module.exports = {
+    ScriptService,
+    BackendScript,
+};


### PR DESCRIPTION
The script service allows other services to register re-runnable tasks called "scripts". These can be invoked via "script:run" in the console.