### PR TITLE
Docker CI - Update actions

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -4,17 +4,6 @@ name: Docker Image CI
 # Configures this workflow to run every time a change is pushed to the
 # branch called `main`.
 on:
-  # workflow_dispatch:
-  #   inputs:
-  #     version:
-  #       description: 'Version WITHOUT leading "v"'
-  #       required: true
-  #     major:
-  #       description: 'Major version component (redundant, but needed)'
-  #       required: true
-  #     minor:
-  #       description: 'Minor version component (redundant, but needed)'
-  #       required: true
   push:
     tags:
       - '*.*.*'
@@ -73,8 +62,6 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=ref,event=branch
-            # type=semver,pattern=${{github.event.inputs.version}}
-            # type=semver,pattern=${{github.event.inputs.major}}.${{github.event.inputs.minor}}
 
       # This step uses the `docker/build-push-action` action to build the
       # image, based on your repository's `Dockerfile`. If the build succeeds,

--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -4,17 +4,17 @@ name: Docker Image CI
 # Configures this workflow to run every time a change is pushed to the
 # branch called `main`.
 on:
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version WITHOUT leading "v"'
-        required: true
-      major:
-        description: 'Major version component (redundant, but needed)'
-        required: true
-      minor:
-        description: 'Minor version component (redundant, but needed)'
-        required: true
+  # workflow_dispatch:
+  #   inputs:
+  #     version:
+  #       description: 'Version WITHOUT leading "v"'
+  #       required: true
+  #     major:
+  #       description: 'Major version component (redundant, but needed)'
+  #       required: true
+  #     minor:
+  #       description: 'Minor version component (redundant, but needed)'
+  #       required: true
   push:
     tags:
       - '*.*.*'

--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -71,6 +71,7 @@ jobs:
         with:
           images: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
           tags: |
+            type=semver,pattern={{version}}
             type=semver,pattern=${{github.event.inputs.version}}
             type=semver,pattern=${{github.event.inputs.major}}.${{github.event.inputs.minor}}
 

--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -18,8 +18,8 @@ on:
   push:
     tags:
       - '*.*.*'
-    # branches:
-    #   - 'release'
+    branches:
+      - 'main'
 
 # Defines two custom environment variables for the workflow. These are used
 # for the Container registry domain, and a name for the Docker image that
@@ -72,6 +72,7 @@ jobs:
           images: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
           tags: |
             type=semver,pattern={{version}}
+            type=ref,event=branch
             # type=semver,pattern=${{github.event.inputs.version}}
             # type=semver,pattern=${{github.event.inputs.major}}.${{github.event.inputs.minor}}
 

--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -72,8 +72,8 @@ jobs:
           images: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
           tags: |
             type=semver,pattern={{version}}
-            type=semver,pattern=${{github.event.inputs.version}}
-            type=semver,pattern=${{github.event.inputs.major}}.${{github.event.inputs.minor}}
+            # type=semver,pattern=${{github.event.inputs.version}}
+            # type=semver,pattern=${{github.event.inputs.major}}.${{github.event.inputs.minor}}
 
       # This step uses the `docker/build-push-action` action to build the
       # image, based on your repository's `Dockerfile`. If the build succeeds,

--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -15,9 +15,9 @@ on:
       minor:
         description: 'Minor version component (redundant, but needed)'
         required: true
-  # push:
-    # tags:
-    #   - '*.*.*'
+  push:
+    tags:
+      - '*.*.*'
     # branches:
     #   - 'release'
 
@@ -58,7 +58,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about)
       # to extract tags and labels that will be applied to the specified image.


### PR DESCRIPTION
Allows to create Docker Image on creation of a Tag and when pushing something to main branch.
When a Release is created (with the corresponding tag), it will name the image `2.3.0`, based on the tag name. This will also be `:latest`
When pushing to main, an image is created that is name `:main`.

As discussed with @AtkinsSJ on Discord.