### PR TITLE
refactor: conditionally focus terminal if phoenix is active

### DIFF
--- a/packages/terminal/src/main.js
+++ b/packages/terminal/src/main.js
@@ -117,5 +117,7 @@ window.main_term = async () => {
     const ioController = new XTermIO({ term, pty });
     ioController.bind();
 
-    term.focus();
+    if (phoenix && phoenix.isActive()) {
+        term.focus();
+    }
 };


### PR DESCRIPTION
Issue #453
Added conditional statement that checks whether the variable phoenix exists and whether the phoenix application is active. If both conditions are met, it sets focus to the terminal window.