### PR TITLE
Mod interface for Puter

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -35,6 +35,8 @@ export default [
             globals: {
                 ...globals.node,
                 "kv": true,
+                "def": true,
+                "use": true,
             }
         }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "packages/*"
       ],
       "dependencies": {
-        "@xterm/xterm": "^5.5.0",
         "json-colorizer": "^3.0.1",
         "uuid": "^9.0.1"
       },
@@ -11423,6 +11422,10 @@
         "querystring": "0.2.0"
       }
     },
+    "node_modules/useapi": {
+      "resolved": "packages/useapi",
+      "link": true
+    },
     "node_modules/utif2": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/utif2/-/utif2-4.1.0.tgz",
@@ -12537,6 +12540,10 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "packages/useapi": {
+      "version": "1.0.0",
+      "license": "AGPL-3.0-only"
     }
   }
 }

--- a/packages/backend/src/CoreModule.js
+++ b/packages/backend/src/CoreModule.js
@@ -24,7 +24,8 @@ class CoreModule extends AdvancedBase {
     async install (context) {
         const services = context.get('services');
         const app = context.get('app');
-        await install({ services, app });
+        const useapi = context.get('useapi');
+        await install({ services, app, useapi });
     }
 
     // Some services were created before the BaseService
@@ -40,8 +41,15 @@ class CoreModule extends AdvancedBase {
 
 module.exports = CoreModule;
 
-const install = async ({ services, app }) => {
+const install = async ({ services, app, useapi }) => {
     const config = require('./config');
+
+    useapi.withuse(() => {
+        def('Service', require('./services/BaseService'));
+        def('Module', AdvancedBase);
+
+        def('puter.middlewares.auth', require('./middleware/auth2'));
+    });
 
     // /!\ IMPORTANT /!\
     // For new services, put the import immediate above the

--- a/packages/backend/src/services/WebServerService.js
+++ b/packages/backend/src/services/WebServerService.js
@@ -28,6 +28,7 @@ const fs = require('fs');
 const auth = require('../middleware/auth');
 const { osclink } = require('../util/strutil');
 const { surrounding_box, es_import_promise } = require('../fun/dev-console-ui-utils');
+const auth2 = require('../middleware/auth2.js');
 
 class WebServerService extends BaseService {
     static MODULES = {
@@ -393,6 +394,10 @@ class WebServerService extends BaseService {
         app.options('/*', (_, res) => {
             return res.sendStatus(200);
         });
+
+        this.router_user = express.Router();
+        this.router_user.use(auth2);
+        app.use(this.router_user);
     }
 
     _register_commands (commands) {

--- a/packages/backend/src/services/database/BaseDatabaseAccessService.js
+++ b/packages/backend/src/services/database/BaseDatabaseAccessService.js
@@ -18,8 +18,11 @@
  */
 const { AdvancedBase } = require("@heyputer/puter-js-common");
 const BaseService = require("../BaseService");
+const { DB_WRITE, DB_READ } = require("./consts");
 
 class BaseDatabaseAccessService extends BaseService {
+    static DB_WRITE = DB_WRITE;
+    static DB_READ = DB_READ;
     case ( choices ) {
         const engine_name = this.constructor.ENGINE_NAME;
         if ( choices.hasOwnProperty(engine_name) ) {

--- a/packages/useapi/main.js
+++ b/packages/useapi/main.js
@@ -1,0 +1,100 @@
+const globalwith = (vars, fn) => {
+    const original_values = {};
+    const keys = Object.keys(vars);
+
+    for ( const key of keys ) {
+        if ( key in globalThis ) {
+            original_values[key] = globalThis[key];
+        }
+        globalThis[key] = vars[key];
+    }
+
+    try {
+        return fn();
+    } finally {
+        for ( const key of keys ) {
+            if ( key in original_values ) {
+                globalThis[key] = original_values[key];
+            } else {
+                delete globalThis[key];
+            }
+        }
+    }
+};
+
+const aglobalwith = async (vars, fn) => {
+    const original_values = {};
+    const keys = Object.keys(vars);
+
+    for ( const key of keys ) {
+        if ( key in globalThis ) {
+            original_values[key] = globalThis[key];
+        }
+        globalThis[key] = vars[key];
+    }
+
+    try {
+        return await fn();
+    } finally {
+        for ( const key of keys ) {
+            if ( key in original_values ) {
+                globalThis[key] = original_values[key];
+            } else {
+                delete globalThis[key];
+            }
+        }
+    }
+};
+
+let default_fn = () => {
+    const use = name => {
+        const parts = name.split('.');
+        let obj = use;
+        for ( const part of parts ) {
+            if ( ! obj[part] ) {
+                obj[part] = {};
+            }
+            obj = obj[part];
+        }
+
+        return obj;
+    };
+    const library = {
+        use,
+        def: (name, value) => {
+            const parts = name.split('.');
+            let obj = use;
+            for ( const part of parts.slice(0, -1) ) {
+                if ( ! obj[part] ) {
+                    obj[part] = {};
+                }
+                obj = obj[part];
+            }
+
+            obj[parts[parts.length - 1]] = value;
+        },
+        withuse: fn => {
+            return globalwith({
+                use,
+                def: library.def,
+            }, fn);
+        },
+        awithuse: async fn => {
+            return await aglobalwith({
+                use,
+                def: library.def,
+            }, fn);
+        }
+    };
+
+    return library;
+};
+
+const useapi = function useapi () {
+    return default_fn();
+};
+
+// We export some things on the function itself
+useapi.globalwith = globalwith;
+
+module.exports = useapi;

--- a/packages/useapi/package.json
+++ b/packages/useapi/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "useapi",
+    "version": "1.0.0",
+    "author": "Puter Technologies Inc.",
+    "license": "AGPL-3.0-only",
+    "description": "Dynamic import interface for Puter mods",
+    "main": "main.js"
+}


### PR DESCRIPTION
A package called "useapi" is introduced to provide a dynamic import system. This import system, rather than relying on the state of the filesystem, is populated as modules are installed into Puter's kernel.

The "useapi" package is then used to add support for loading external mod directories as Puter kernel modules, making it possible to mod puter without any tooling.