### PR TITLE
fix: Make polyfilled import.meta.filename getter a valid function

### DIFF
--- a/run-selfhosted.js
+++ b/run-selfhosted.js
@@ -55,7 +55,7 @@ const surrounding_box = (col, lines) => {
 // Annoying polyfill for inconsistency in different node versions
 if ( ! import.meta.filename ) {
     Object.defineProperty(import.meta, 'filename', {
-        get: import.meta.url.slice('file://'.length),
+        get: () => import.meta.url.slice('file://'.length),
     })
 }
 


### PR DESCRIPTION
Fixes issue when trying to run on Node v18, which doesn't have `import.meta.filename`:

```
file:///home/sam/Projects/HeyPuter/puter/run-selfhosted.js:57
    Object.defineProperty(import.meta, 'filename', {
           ^

TypeError: Getter must be a function: /home/sam/Projects/HeyPuter/puter/run-selfhosted.js
    at Function.defineProperty (<anonymous>)
    at file:///home/sam/Projects/HeyPuter/puter/run-selfhosted.js:57:12
    at ModuleJob.run (node:internal/modules/esm/module_job:222:25)
    at async ModuleLoader.import (node:internal/modules/esm/loader:323:24)
    at async loadESM (node:internal/process/esm_loader:28:7)
    at async handleMainPromise (node:internal/modules/run_main:120:12)
```