### PR TITLE
fix: Throw an error when readdir is called on a non-directory

### DIFF
--- a/packages/backend/src/api/APIError.js
+++ b/packages/backend/src/api/APIError.js
@@ -236,6 +236,10 @@ module.exports = class APIError {
             status: 422,
             message: 'Directory is not empty.',
         },
+        'readdir_of_non_directory': {
+            status: 422,
+            message: 'Readdir target must be a directory.',
+        },
 
         // Write
         'offset_without_existing_file': {

--- a/packages/backend/src/filesystem/hl_operations/hl_readdir.js
+++ b/packages/backend/src/filesystem/hl_operations/hl_readdir.js
@@ -38,7 +38,7 @@ class HLReadDir extends HLFilesystemOperation {
             if ( ! await svc_acl.check(actor, subject, 'see') ) {
                 throw await svc_acl.get_safe_acl_error(actor, subject, 'see');
             }
-            return [await subject.getSafeEntry()];
+            throw APIError.create('readdir_of_non_directory');
         }
         
         let children;

--- a/packages/puter-js-common/src/PosixError.js
+++ b/packages/puter-js-common/src/PosixError.js
@@ -156,6 +156,7 @@ class PosixError extends Error {
             case 'missing_expected_metadata': return new PosixError(ErrorCodes.EINVAL, e.message);
             case 'overwrite_and_dedupe_exclusive': return new PosixError(ErrorCodes.EINVAL, e.message);
             case 'not_empty': return new PosixError(ErrorCodes.ENOTEMPTY, e.message);
+            case 'readdir_of_non_directory': return new PosixError(ErrorCodes.ENOTDIR, e.message);
 
             // Write
             case 'offset_without_existing_file': return new PosixError(ErrorCodes.ENOENT, e.message);


### PR DESCRIPTION
This replaces a72ec9799ac3bd76ceafa22cce149e373a13f3b9 as a fix for #417.

That change meant that calling readdir on a file path would return a single stat entry, for that file. The problem is, to callers that looks like the file is a directory containing itself. This was causing problems in isomorphic-git, as it would readdir `foo.txt`, receive the listing of `[ {path: foo.txt', ... } ]`, and then try to read `foo.txt/foo.txt` and get confused that the file doesn't exist.

This change instead returns an error equivalent to ENOTDIR to the caller, which matches the behaviour of Node.js and Posix.

cc @KernelDeimos 