### PR TITLE
Fix eslint issues

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -28,6 +28,7 @@ export default [
         // Back end
         files: [
             "packages/backend/**/*.js",
+            "mods/**/*.js",
             "dev-server.js",
             "utils.js",
         ],
@@ -85,6 +86,21 @@ export default [
                 "logout": true,
                 "is_email": true,
                 "select_ctxmenu_item": true,
+            }
+        }
+    },
+    {
+        // Mods
+        // NOTE: Mods have backend and frontend parts, so this just includes the globals for both.
+        files: [
+            "mods/**/*.js",
+        ],
+        languageOptions: {
+            globals: {
+                ...globals.node,
+                "use": true,
+                "window": true,
+                "puter": true,
             }
         }
     },

--- a/src/UI/Settings/UITabPersonalization.js
+++ b/src/UI/Settings/UITabPersonalization.js
@@ -108,7 +108,7 @@ export default {
                 puter.kv.set('menubar_style', value);
                 
                 if(value === 'system'){
-                    if(detectHostOS() === 'macos')
+                    if(window.detectHostOS() === 'macos')
                         value = 'desktop';
                     else
                         value = 'window';

--- a/src/UI/UIDesktop.js
+++ b/src/UI/UIDesktop.js
@@ -571,11 +571,11 @@ async function UIDesktop(options){
             window.menubar_style = 'system';
         }
 
-        if(menubar_style === 'system'){
+        if(window.menubar_style === 'system'){
             if(window.detectHostOS() === 'macos')
-                menubar_style = 'desktop';
+                window.menubar_style = 'desktop';
             else
-                menubar_style = 'window';
+                window.menubar_style = 'window';
         }
 
         // set menubar style class to body

--- a/src/UI/UIWindow.js
+++ b/src/UI/UIWindow.js
@@ -1392,7 +1392,7 @@ async function UIWindow(options) {
             // if this is the home directory of another user, show the sharing dialog
             // --------------------------------------------------------
             let cur_path = $(el_window).attr('data-path');
-            if(countSubstr(cur_path, '/') === 1 && cur_path !== '/'+window.user.username){
+            if(window.countSubstr(cur_path, '/') === 1 && cur_path !== '/'+window.user.username){
                 let username = cur_path.split('/')[1];
 
                 const items_to_share = []


### PR DESCRIPTION
The issues with `mods/` were just because that directory wasn't registered in the eslint config, so it didn't know what globals were allowed.

The others were just missing `window.` in places.

It's probably worth either using an IDE plugin for eslint so these show up while writing code, or disabling the `no-undef` lint error. I think it's useful but I seem to be in a minority, while you two just get frustrated by it. :sweat_smile: 

cc @jelveh @KernelDeimos 