### PR TITLE
feat(phoenix): Make `clear` clear scrollback unless `-x` is given

### DIFF
--- a/packages/phoenix/src/puter-shell/coreutils/clear.js
+++ b/packages/phoenix/src/puter-shell/coreutils/clear.js
@@ -21,11 +21,19 @@ export default {
     usage: 'clear',
     description: 'Clear the terminal output.',
     args: {
-        // TODO: add 'none-parser'
         $: 'simple-parser',
-        allowPositionals: false
+        allowPositionals: false,
+        options: {
+            'keep-scrollback': {
+                description: 'Only clear the visible portion of the screen, and keep the scrollback.',
+                type: 'boolean',
+                short: 'x',
+            }
+        },
     },
     execute: async ctx => {
         await ctx.externs.out.write('\x1B[H\x1B[2J');
+        if (!ctx.locals.values['keep-scrollback'])
+            await ctx.externs.out.write('\x1B[H\x1B[3J');
     }
 };


### PR DESCRIPTION
From what I understand, we shouldn't need both `\x1B[2J` and `\x1B[3J` sequences to clear everything, but xterm.js would not correctly clear the visible region with only `\x1B[3J`. So, we have both.