### PR TITLE
Add tab-completion to server console commands

### DIFF
--- a/packages/backend/src/services/CommandService.js
+++ b/packages/backend/src/services/CommandService.js
@@ -37,6 +37,13 @@ class Command {
             log.error(err.stack);
         }
     }
+
+    completeArgument(args) {
+        const completer = this.spec_.completer;
+        if ( completer )
+            return completer(args);
+        return [];
+    }
 }
 
 class CommandService extends BaseService {
@@ -86,6 +93,10 @@ class CommandService extends BaseService {
 
     get commandNames() {
         return this.commands_.map(command => command.id);
+    }
+
+    getCommand(id) {
+        return this.commands_.find(command => command.id === id);
     }
 }
 

--- a/packages/backend/src/services/CommandService.js
+++ b/packages/backend/src/services/CommandService.js
@@ -23,6 +23,10 @@ class Command {
         this.spec_ = spec;
     }
 
+    get id() {
+        return this.spec_.id;
+    }
+
     async execute(args, log) {
         log = log ?? console;
         const { id, name, description, handler } = this.spec_;
@@ -78,6 +82,10 @@ class CommandService extends BaseService {
         // TODO: add obvious-json as a tokenizer
         const args = text.split(/\s+/);
         await this.executeCommand(args, log);
+    }
+
+    get commandNames() {
+        return this.commands_.map(command => command.id);
     }
 }
 

--- a/packages/backend/src/services/DevConsoleService.js
+++ b/packages/backend/src/services/DevConsoleService.js
@@ -132,9 +132,13 @@ class DevConsoleService extends BaseService {
             prompt: 'puter> ',
             terminal: true,
             completer: line => {
-                // We only complete service and command names
-                if ( line.includes(' ') )
-                    return;
+                if ( line.includes(' ') ) {
+                    const [ commandName, ...args ] = line.split(/\s+/);
+                    const command = commands.getCommand(commandName);
+                    if (!command)
+                        return;
+                    return [ command.completeArgument(args), args[args.length - 1] ];
+                }
 
                 const results = commands.commandNames
                     .filter(name => name.startsWith(line))

--- a/packages/backend/src/services/DevConsoleService.js
+++ b/packages/backend/src/services/DevConsoleService.js
@@ -131,6 +131,16 @@ class DevConsoleService extends BaseService {
             output: process.stdout,
             prompt: 'puter> ',
             terminal: true,
+            completer: line => {
+                // We only complete service and command names
+                if ( line.includes(' ') )
+                    return;
+
+                const results = commands.commandNames
+                    .filter(name => name.startsWith(line))
+                    .map(name => `${name} `); // Add a space after to make typing arguments more convenient
+                return [ results, line ];
+            },
         });
         rl.on('line', async (input) => {
             this._before_cmd();

--- a/packages/backend/src/services/ParameterService.js
+++ b/packages/backend/src/services/ParameterService.js
@@ -68,6 +68,17 @@ class ParameterService extends BaseService {
     }
 
     _registerCommands (commands) {
+        const completeParameterName = (args) => {
+            // The parameter name is the first argument, so return no results if we're on the second or later.
+            if (args.length > 1)
+                return;
+            const lastArg = args[args.length - 1];
+
+            return this.parameters_
+                .map(parameter => parameter.spec_.id)
+                .filter(parameterName => parameterName.startsWith(lastArg));
+        };
+
         commands.registerCommands('params', [
             {
                 id: 'get',
@@ -76,7 +87,8 @@ class ParameterService extends BaseService {
                     const [name] = args;
                     const value = await this.get(name);
                     log.log(value);
-                }
+                },
+                completer: completeParameterName,
             },
             {
                 id: 'set',
@@ -86,7 +98,8 @@ class ParameterService extends BaseService {
                     const parameter = this._get_param(name);
                     parameter.set(value);
                     log.log(value);
-                }
+                },
+                completer: completeParameterName,
             },
             {
                 id: 'list',

--- a/packages/backend/src/services/ScriptService.js
+++ b/packages/backend/src/services/ScriptService.js
@@ -31,6 +31,16 @@ class ScriptService extends BaseService {
                         return;
                     }
                     await script.run(ctx, args);
+                },
+                completer: (args) => {
+                    // The script name is the first argument, so return no results if we're on the second or later.
+                    if (args.length > 1)
+                        return;
+                    const scriptName = args[args.length - 1];
+
+                    return this.scripts
+                        .filter(script => scriptName.startsWith(scriptName))
+                        .map(script => script.name);
                 }
             }
         ]);

--- a/packages/backend/src/services/runtime-analysis/AlarmService.js
+++ b/packages/backend/src/services/runtime-analysis/AlarmService.js
@@ -308,6 +308,24 @@ class AlarmService extends BaseService {
     }
 
     _register_commands (commands) {
+        const completeAlarmID = (args) => {
+            // The alarm ID is the first argument, so return no results if we're on the second or later.
+            if (args.length > 1)
+                return;
+            const lastArg = args[args.length - 1];
+
+            const results = [];
+            for ( const alarm of Object.values(this.alarms) ) {
+                if ( alarm.id.startsWith(lastArg) ) {
+                    results.push(alarm.id);
+                }
+                if ( alarm.short_id?.startsWith(lastArg) ) {
+                    results.push(alarm.short_id);
+                }
+            }
+            return results;
+        };
+
         commands.registerCommands('alarm', [
             {
                 id: 'list',
@@ -341,7 +359,8 @@ class AlarmService extends BaseService {
                     for ( const [key, value] of Object.entries(alarm.fields) ) {
                         log.log(`- ${key}: ${util.inspect(value)}`);
                     }
-                }
+                },
+                completer: completeAlarmID,
             },
             {
                 id: 'clear',
@@ -356,7 +375,8 @@ class AlarmService extends BaseService {
                         );
                     }
                     this.clear(id);
-                }
+                },
+                completer: completeAlarmID,
             },
             {
                 id: 'clear-all',
@@ -397,7 +417,8 @@ class AlarmService extends BaseService {
                         log.log("┃ " + stringify_log_entry(lg));
                     }
                     log.log(`┗━━ Logs before: ${alarm.id_string} ━━━━`);
-                }
+                },
+                completer: completeAlarmID,
             },
         ]);
     }


### PR DESCRIPTION
Pressing `<tab>` will now auto-complete command names, and for some commands, also their arguments. This makes it a lot easier to inspect an alarm, because both `alarm:info` and the alarm IDs are completable.

I've wanted this for a while but never got around to it, so consider this a parting gift, @KernelDeimos! :grin: 