### PR TITLE
feat: add some default groups

### DIFF
--- a/src/backend/src/services/database/SqliteDatabaseAccessService.js
+++ b/src/backend/src/services/database/SqliteDatabaseAccessService.js
@@ -42,7 +42,7 @@ class SqliteDatabaseAccessService extends BaseDatabaseAccessService {
         this.db = new Database(this.config.path);
 
         // Database upgrade logic
-        const TARGET_VERSION = 21;
+        const TARGET_VERSION = 22;
 
         if ( do_setup ) {
             this.log.noticeme(`SETUP: creating database at ${this.config.path}`);
@@ -70,6 +70,7 @@ class SqliteDatabaseAccessService extends BaseDatabaseAccessService {
                 '0021_app-owner-id.sql',
                 '0022_dev-center-max.sql',
                 '0023_fix-kv.sql',
+                '0024_default-groups.sql',
             ].map(p => path_.join(__dirname, 'sqlite_setup', p));
             const fs = require('fs');
             for ( const filename of sql_files ) {
@@ -168,6 +169,10 @@ class SqliteDatabaseAccessService extends BaseDatabaseAccessService {
 
         if ( user_version <= 20 ) {
             upgrade_files.push('0023_fix-kv.sql');
+        }
+
+        if ( user_version <= 21 ) {
+            upgrade_files.push('0024_default-groups.sql');
         }
 
         if ( upgrade_files.length > 0 ) {

--- a/src/backend/src/services/database/sqlite_setup/0024_default-groups.sql
+++ b/src/backend/src/services/database/sqlite_setup/0024_default-groups.sql
@@ -1,0 +1,34 @@
+INSERT INTO `group` (
+    `uid`,
+    `owner_user_id`,
+    `extra`,
+    `metadata`
+) VALUES
+    ('26bfb1fb-421f-45bc-9aa4-d81ea569e7a5', 1,
+        '{"critical": true, "type": "default", "name": "system"}',
+        '{"title": "System", "color": "#000000"}'),
+    ('ca342a5e-b13d-4dee-9048-58b11a57cc55', 1,
+        '{"critical": true, "type": "default", "name": "admin"}',
+        '{"title": "Admin", "color": "#a83232"}'),
+    ('78b1b1dd-c959-44d2-b02c-8735671f9997', 1,
+        '{"critical": true, "type": "default", "name": "user"}',
+        '{"title": "User", "color": "#3254a8"}'),
+    ('3c2dfff7-d22a-41aa-a193-59a61dac4b64', 1,
+        '{"type": "default", "name": "moderator"}',
+        '{"title": "Moderator", "color": "#a432a8"}'),
+    ('5e8f251d-3382-4b0d-932c-7bb82f48652f', 1,
+        '{"type": "default", "name": "developer"}',
+        '{"title": "Developer", "color": "#32a852"}')
+    ;
+
+INSERT INTO `jct_user_group` (
+    `user_id`,
+    `group_id`,
+    `extra`,
+    `metadata`
+) VALUES (
+    1,
+    (SELECT `id` FROM `group` WHERE uid='ca342a5e-b13d-4dee-9048-58b11a57cc55'),
+    '{}',
+    '{"default": true}'
+);


### PR DESCRIPTION
With this update, Puter now has the following default groups:
- System
- Admin
- User
- Moderator
- Developer

The groups `System`, `Admin`, and `User` have planned functionality. The `User` group will be applied to all users retroactively in an upcoming update. `System` is reserved for use by the backend; do not add regular users to this group. `Admin` will be the default group of the default user, `default_user`.