### PR TITLE
Add an option to disable temp user

### DIFF
--- a/src/backend/src/config.js
+++ b/src/backend/src/config.js
@@ -25,6 +25,9 @@ let config = {};
 // Static defaults
 config.servers = [];
 
+// Will disable the auto-generated temp users. If a user lands on the site, they will be required to sign up or log in.
+config.disable_temp_users = false;
+
 config.max_file_size = 100_000_000_000,
 config.max_thumb_size = 1_000,
 config.max_fsentry_name_length = 767,
@@ -130,7 +133,6 @@ const config_pointer = {};
     config_pointer.__proto__ = config;
     config_to_export = config_pointer;
 }
-
 
 // We have some methods that can be called on `config`
 {

--- a/src/backend/src/routers/signup.js
+++ b/src/backend/src/routers/signup.js
@@ -100,10 +100,12 @@ module.exports = eggspress(['/signup'], {
     }
 
     // temporary user
-    if(req.body.is_temp){
+    if(req.body.is_temp && !config.disable_temp_users){
         req.body.username = await generate_random_username();
         req.body.email = req.body.username + '@gmail.com';
         req.body.password = 'sadasdfasdfsadfsa';
+    }else if(config.disable_temp_users){
+        return res.status(400).send('Temp users are disabled.');
     }
 
     // send_confirmation_code

--- a/src/backend/src/services/PuterHomepageService.js
+++ b/src/backend/src/services/PuterHomepageService.js
@@ -108,6 +108,7 @@ class PuterHomepageService extends BaseService {
                 require_email_verification_to_publish_website: config.require_email_verification_to_publish_website,
                 short_description: config.short_description,
                 long_description: config.long_description,
+                disable_temp_users: config.disable_temp_users,
             },
         }));
     }

--- a/src/gui/src/index.js
+++ b/src/gui/src/index.js
@@ -31,6 +31,7 @@ window.puter_gui_enabled = true;
  * @param {string} [options.api_origin='https://api.puter.com'] - The origin URL for the API.
  * @param {number} [options.max_item_name_length=500] - Maximum allowed length for an item name.
  * @param {boolean} [options.require_email_verification_to_publish_website=true] - Flag to decide whether email verification is required to publish a website.
+ * @param {boolean} [options.disable_temp_users=false] - Flag to disable auto-generated temporary users.
  *
  * @property {string} [options.app_domain] - Extracted domain name from gui_origin. It's derived automatically if not provided.
  * @property {string} [window.gui_env] - The environment in which the GUI is running (e.g., "dev" or "prod").
@@ -54,6 +55,7 @@ window.gui = async function(options){
     window.api_origin = options.api_origin ?? "https://api.puter.com";
     window.max_item_name_length = options.max_item_name_length ?? 500;
     window.require_email_verification_to_publish_website = options.require_email_verification_to_publish_website ?? true;
+    window.disable_temp_users = options.disable_temp_users ?? false;
 
     // DEV: Load the initgui.js file if we are in development mode
     if(!window.gui_env || window.gui_env === "dev"){
@@ -73,6 +75,7 @@ window.gui = async function(options){
 
     // 🚀 Launch the GUI 🚀
     window.initgui(options);
+
 }
 
 /**

--- a/src/gui/src/initgui.js
+++ b/src/gui/src/initgui.js
@@ -831,7 +831,7 @@ window.initgui = async function(options){
     // -------------------------------------------------------------------------------------
     // Un-authed but not first visit -> try to log in/sign up
     // -------------------------------------------------------------------------------------
-    if(!window.is_auth() && !window.first_visit_ever){
+    if(!window.is_auth() && (!window.first_visit_ever || window.disable_temp_users)){
         if(window.logged_in_users.length > 0){
             UIWindowSessionList();
         }
@@ -849,7 +849,7 @@ window.initgui = async function(options){
     // -------------------------------------------------------------------------------------
     // Un-authed and first visit ever -> create temp user
     // -------------------------------------------------------------------------------------
-    else if(!window.is_auth() && window.first_visit_ever){
+    else if(!window.is_auth() && window.first_visit_ever && !window.disable_temp_users){
         let referrer;
         try{
             referrer = new URL(window.location.href).pathname;


### PR DESCRIPTION
Introduces a `disable_temp_users` flag to `config` that when set to `true` will disallow auto-generated temp users. 

This flag is also sent to the GUI and GUI will adjust its behaviour based on the value.

Will close #262 