### PR TITLE
i18n: Retain 'confirm' keyword for account deletion across languages

### DIFF
--- a/src/gui/src/i18n/translations/ar.js
+++ b/src/gui/src/i18n/translations/ar.js
@@ -295,7 +295,7 @@ const ar = {
 	    two_factor_disabled: "تم تعطيل المصادقة الثنائية",
 	    two_factor_enabled: "تم تمكين المصادقة الثنائية",
         type: "نوع",
-	    type_confirm_to_delete_account: "اكتب 'تأكيد' لحذف حسابك.",
+	    type_confirm_to_delete_account: "اكتب 'confirm' لحذف حسابك.",
 	    ui_colors: "ألوان واجهة المستخدم",
 	    ui_manage_sessions: "مدير الجلسات",
 	    ui_revoke: "إلغاء",

--- a/src/gui/src/i18n/translations/bn.js
+++ b/src/gui/src/i18n/translations/bn.js
@@ -298,7 +298,7 @@ const bn = {
     two_factor_disabled: "2FA অক্ষম",
     two_factor_enabled: "2FA সক্ষম",
     type: "ধরণ",
-    type_confirm_to_delete_account: "অ্যাকাউন্ট মোছার জন্য 'অনুমোদন' টাইপ করুন।",
+    type_confirm_to_delete_account: "অ্যাকাউন্ট মোছার জন্য 'confirm' টাইপ করুন।",
     ui_colors: "ইউআই রঙ",
     ui_manage_sessions: "সেশন ম্যানেজার",
     ui_revoke: "প্রত্যাহার করুন",

--- a/src/gui/src/i18n/translations/es.js
+++ b/src/gui/src/i18n/translations/es.js
@@ -302,7 +302,7 @@ const es = {
         two_factor_disabled: '2FA Deshabilitadp',
         two_factor_enabled: '2FA Habilitado',
         type: 'Tipo',
-        type_confirm_to_delete_account: "Ingrese 'Confirmar' para borrar esta cuenta.",
+        type_confirm_to_delete_account: "Ingrese 'confirm' para borrar esta cuenta.",
         ui_colors: "Colores de interfaz",
         ui_manage_sessions: "Administrador de sesión",
         ui_revoke: "Revocar",

--- a/src/gui/src/i18n/translations/hi.js
+++ b/src/gui/src/i18n/translations/hi.js
@@ -295,7 +295,7 @@ const hi = {
         two_factor_disabled: '2एफए अक्षम',
         two_factor_enabled: '2एफए सक्षम',
         type: 'प्रकार',
-        type_confirm_to_delete_account: "अपना खाता हटाने के लिए 'पुष्टि करें' टाइप करें।",
+        type_confirm_to_delete_account: "अपना खाता हटाने के लिए 'confirm' टाइप करें।",
         ui_colors: "यूआई रंग",
         ui_manage_sessions: "सत्र प्रबंधक",
         ui_revoke: "रद्द",

--- a/src/gui/src/i18n/translations/hu.js
+++ b/src/gui/src/i18n/translations/hu.js
@@ -291,7 +291,7 @@ const hu = {
                         two_factor_disabled: "2FA letiltva",
                         two_factor_enabled: "2FA engedélyezve",
                         type: "Típus",
-                        type_confirm_to_delete_account: "Írd be, hogy 'megerősít' a fiók törléséhez.",
+                        type_confirm_to_delete_account: "Írd be, hogy 'confirm' a fiók törléséhez.",
                         ui_colors: "UI színek",
                         ui_manage_sessions: "Munkamenetkezelő",
                         ui_revoke: "Visszavonás",

--- a/src/gui/src/i18n/translations/ig.js
+++ b/src/gui/src/i18n/translations/ig.js
@@ -231,7 +231,7 @@ const ig = {
         transparency: "nghọta",
         trash: 'ahịhịa',
         type: 'Ụdị',
-        type_confirm_to_delete_account: "Pịnye 'kwenye' ka ihichapụ akaụntụ gị.",
+        type_confirm_to_delete_account: "Pịnye 'confirm' ka ihichapụ akaụntụ gị.",
         ui_colors: "Agba UI",
         ui_manage_sessions: "Onye njikwa oge",
         ui_revoke: "Kagbuo",

--- a/src/gui/src/i18n/translations/it.js
+++ b/src/gui/src/i18n/translations/it.js
@@ -295,7 +295,7 @@ const it = {
         two_factor_disabled: '2FA Disabilitata',
         two_factor_enabled: '2FA Abilitata',
         type: 'Tipo',
-        type_confirm_to_delete_account: "Scrivi 'conferma' per eliminare il tuo account.",
+        type_confirm_to_delete_account: "Scrivi 'confirm' per eliminare il tuo account.",
         ui_colors: "Colori dell'interfaccia",
         ui_manage_sessions: "Session Manager",
         ui_revoke: "Revoca",

--- a/src/gui/src/i18n/translations/nl.js
+++ b/src/gui/src/i18n/translations/nl.js
@@ -188,7 +188,7 @@ const nl = {
 		tos_fineprint: `Door te klikken op 'Maak Gratis Account' gaat u akkoord met Puter's {{link=terms}}Gebruiksvoorwaarden{{/link}} en {{link=privacy}}Privacybeleid{{/link}}.`,
 		trash: 'Prullenbak',
 		type: 'Type',
-		type_confirm_to_delete_account: "Type 'bevestig' om uw account te verwijderen.",
+		type_confirm_to_delete_account: "Type 'confirm' om uw account te verwijderen.",
 		undo: 'Ongedaan maken',
 		unlimited: 'Onbeperkt',
 		unzip: "Uitpakken",

--- a/src/gui/src/i18n/translations/pl.js
+++ b/src/gui/src/i18n/translations/pl.js
@@ -295,7 +295,7 @@ const pl = {
         two_factor_disabled: 'Uwierzytelnianie dwuetapowe zablokowane',
         two_factor_enabled: 'Uwierzytelnianie dwuetapowe odblokowane',
         type: 'Wpisz',
-        type_confirm_to_delete_account: "Wpisz 'potwierdzam', aby skasować swoje konto.",
+        type_confirm_to_delete_account: "Wpisz 'confirm', aby skasować swoje konto.",
         ui_colors: "Kolory interfejsu użytkownika",
         ui_manage_sessions: "Menedżer sesji",
         ui_revoke: "Unieważnij",

--- a/src/gui/src/i18n/translations/ru.js
+++ b/src/gui/src/i18n/translations/ru.js
@@ -296,7 +296,7 @@ const ru = {
         two_factor_disabled: 'Двухфакторная аутентификация отключена',
         two_factor_enabled: 'Двухфакторная аутентификация включена',
         type: 'Тип',
-        type_confirm_to_delete_account: "Введите 'подтвердить', чтобы удалить учетную запись.",
+        type_confirm_to_delete_account: "Введите 'confirm', чтобы удалить учетную запись.",
         ui_colors: "Цвета пользовательского интерфейса",
         ui_manage_sessions: "Менеджер Сеансов",
         ui_revoke: "Отозвать",

--- a/src/gui/src/i18n/translations/ta.js
+++ b/src/gui/src/i18n/translations/ta.js
@@ -294,7 +294,7 @@ const ta = {
         two_factor_disabled: '2FA முடக்கப்பட்டது',
         two_factor_enabled: '2FA இயக்கப்பட்டது',
         type: 'வகை',
-        type_confirm_to_delete_account: "உங்கள் கணக்கை நீக்க, 'உறுதிப்படுத்து' என தட்டச்சு செய்யவும்.",
+        type_confirm_to_delete_account: "உங்கள் கணக்கை நீக்க, 'confirm' என தட்டச்சு செய்யவும்.",
         ui_colors: "UI நிறங்கள்",
         ui_manage_sessions: "அமர்வு மேலாளர்",
         ui_revoke: "திரும்பப் பெறு",

--- a/src/gui/src/i18n/translations/tr.js
+++ b/src/gui/src/i18n/translations/tr.js
@@ -295,7 +295,7 @@ const tr = {
         two_factor_disabled: "İki Faktörlü Doğrulama Devre Dışı",
         two_factor_enabled: "İki Faktörlü Doğrulama Etkin",
         type: "Tür",
-        type_confirm_to_delete_account: "Hesabınızı silmek için 'onayla' yazın.",
+        type_confirm_to_delete_account: "Hesabınızı silmek için 'confirm' yazın.",
         ui_colors: "Arayüz Renkleri",
         ui_manage_sessions: "Oturum Yöneticisi",
         ui_revoke: "Sonlandır",

--- a/src/gui/src/i18n/translations/ua.js
+++ b/src/gui/src/i18n/translations/ua.js
@@ -292,7 +292,7 @@ const ua = {
         two_factor_disabled: "Двофакторна аутентифікація вимкнена",
         two_factor_enabled:"Двофакторна аутентифікація увімкнена",
         type: 'Тип',
-        type_confirm_to_delete_account: "Введіть 'Підтвердити', щоб видалити обліковий запис.",
+        type_confirm_to_delete_account: "Введіть 'confirm', щоб видалити обліковий запис.",
         ui_colors: "Кольори UI",
         ui_manage_sessions: "Менеджер Сеансів",
         ui_revoke: "Відкликати",

--- a/src/gui/src/i18n/translations/ur.js
+++ b/src/gui/src/i18n/translations/ur.js
@@ -302,7 +302,7 @@ const ur = {
     two_factor_enabled: "2FA فعال",
     type: "لکہنا",
     type_confirm_to_delete_account:
-      "اپنا اکاؤنٹ حذف کرنے کے لیے 'تصدیق' ٹائپ کریں۔",
+      "اپنا اکاؤنٹ حذف کرنے کے لیے 'confirm' ٹائپ کریں۔",
     ui_colors: "UI رنگ",
     ui_manage_sessions: "سیشن مینیجر",
     ui_revoke: "منسوخ کرنا",

--- a/src/gui/src/i18n/translations/zh.js
+++ b/src/gui/src/i18n/translations/zh.js
@@ -296,7 +296,7 @@ const zh = {
         two_factor_disabled: '关闭二次身份验证',
         two_factor_enabled: '启用二次身份验证',
         type: '类型',
-        type_confirm_to_delete_account: "请输入 confirm 以确认删除账号.",
+        type_confirm_to_delete_account: "请输入「confirm」以确认删除账号.",
         ui_colors: "界面颜色",
         ui_manage_sessions: "会话管理",
         ui_revoke: "取消",


### PR DESCRIPTION
## Changes

- Reviewed and updated all language files to ensure the word `'confirm'` is used consistently for account deletion confirmation.
- Updated the `type_confirm_to_delete_account` string to retain `'confirm'` in all languages.
- Ensured that the surrounding text is properly translated while keeping `'confirm'` as is.

## Rationale
- Keeping `'confirm'` as a universal keyword across all languages serves several purposes:
- Maintains a consistent user experience across different locales.
- Reduces the risk of accidental account deletions due to misunderstandings in translation.
- Aligns with common practices in software internationalization for critical actions.