### PR TITLE
Create config.yml to add Puter Discord to the issue screen

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Puter Discord
+    url: https://discord.gg/PQcx7Teh8u
+    about: Chat on Puter's Discord, find help, share your apps, etc...


### PR DESCRIPTION
This adds a config file which will show the Puter Discord Server in the issue menu, allowing users to quickly ask help on the Puter Discord.

Also, the if `true` of `blank_issues_enabled: true` is replaced with `false`, users will be forced to use a template, and won't be able to create a custom issue.