### PR TITLE
[WIP] Puter client-side filesystem caching

### DIFF
--- a/src/puter-js/src/index.js
+++ b/src/puter-js/src/index.js
@@ -1,5 +1,5 @@
 import OS from './modules/OS.js';
-import FileSystem from './modules/FileSystem/index.js';
+import { PuterJSFileSystemModule } from './modules/FileSystem/index.js';
 import Hosting from './modules/Hosting.js';
 import Email from './modules/Email.js';
 import Apps from './modules/Apps.js';
@@ -203,7 +203,7 @@ window.puter = (function() {
                              new OS(this.authToken, this.APIOrigin, this.appID, this.env));
             // FileSystem
             this.registerModule('fs',
-                             new FileSystem(this.authToken, this.APIOrigin, this.appID, this.env));
+                             new PuterJSFileSystemModule(this.authToken, this.APIOrigin, this.appID, this.env));
             // UI
             this.registerModule('ui',
                              new UI(this.appInstanceID, this.parentInstanceID, this.appID, this.env, this.util));

--- a/src/puter-js/src/modules/FileSystem/CacheFS.js
+++ b/src/puter-js/src/modules/FileSystem/CacheFS.js
@@ -1,0 +1,124 @@
+import putility from "@heyputer/putility";
+import { RWLock } from "@heyputer/putility/src/libs/promise";
+import { ProxyFilesystem, TFilesystem } from "./definitions";
+
+export const ROOT_UUID = '00000000-0000-0000-0000-000000000000';
+
+export class CacheFS extends putility.AdvancedBase {
+    static PROPERTIES = {
+        // 'internal_uuid' maps a path or external UUID to
+        // the respective cache entry UUID
+        // (which for now is the same as the public UUID)
+        internal_uuid: () => ({}),
+        entries: () => ({}),
+    };
+
+    get_entry_ei (external_identifier) {
+        const internal_identifier = this.internal_uuid[external_identifier];
+        if ( ! internal_identifier ) {
+            return;
+        }
+        return this.entries[internal_identifier];
+    }
+
+    add_entry ({
+        external_identifiers,
+        internal_identifier,
+    }) {
+        const entry = {
+            stat_has: {},
+            stat_exp: 0,
+            locks: {
+                stat: new RWLock(),
+            },
+        };
+        for ( const ident of external_identifiers ) {
+            this.internal_uuid[ident] = internal_identifier;
+        }
+        this.entries[internal_identifier] = entry;
+        console.log('cREATED ENTRY', this.internal_uuid, this.entries);
+        return entry;
+    }
+}
+
+export class CachedFilesystem extends ProxyFilesystem {
+    constructor (o) {
+        super(o);
+        // this.cacheFS = cacheFS;
+        this.cacheFS = new CacheFS();
+    }
+    static IMPLEMENTS = {
+        [TFilesystem]: {
+            stat: async function (o) {
+                let cent = this.cacheFS.get_entry_ei(o.path ?? o.uid);
+
+                const modifiers = [
+                    'subdomains',
+                    'permissions',
+                    'versions',
+                    'size',
+                ];
+
+                let values_requested = {};
+                for ( const mod of modifiers ) {
+                    const optionsKey = 'return' +
+                        mod.charAt(0).toUpperCase() +
+                        mod.slice(1);
+                    if ( ! o[optionsKey] ) continue;
+                    values_requested[mod] = true;
+                }
+
+                const satisfactory_cache = cent => {
+                    for ( const mod of modifiers ) {
+                        if ( ! values_requested[mod] ) continue;
+                        if ( ! cent.stat_has[mod] ) {
+                            return false;
+                        }
+                    }
+                    return true;
+                }
+                
+                let cached_stat;
+                if ( cent && cent.stat && cent.stat_exp > Date.now() ) {
+                    const l = await cent.locks.stat.rlock();
+                    if ( satisfactory_cache(cent) ) {
+                        cached_stat = cent.stat;
+                    }
+                    l.unlock();
+                }
+
+                if ( cached_stat ) {
+                    console.log('CACHE HIT');
+                    return cached_stat;
+                }
+                console.log('CACHE MISS');
+
+                let l;
+                if ( cent ) {
+                    l = await cent.locks.stat.wlock();
+                }
+
+                console.log('DOING THE STAT', o);
+                const entry = await this.delegate.stat(o);
+
+                if ( ! cent ) {
+                    cent = this.cacheFS.add_entry({
+                        external_identifiers: [entry.path, entry.uid],
+                        internal_identifier: entry.uid,
+                    });
+                    l = await cent.locks.stat.wlock();
+                }
+
+                cent.stat = entry;
+                cent.stat_has = { ...values_requested };
+                // TODO: increase cache TTL once invalidation works
+                cent.stat_exp = Date.now() + 1000*3;
+
+                l.unlock();
+
+                console.log('RETRUNING THE ENTRY', entry);
+                return entry;
+            }
+        }
+    }
+}

--- a/src/puter-js/src/modules/FileSystem/definitions.js
+++ b/src/puter-js/src/modules/FileSystem/definitions.js
@@ -1,0 +1,107 @@
+import * as utils from '../../lib/utils.js';
+import putility from "@heyputer/putility";
+import { TeePromise } from "@heyputer/putility/src/libs/promise";
+import getAbsolutePathForApp from './utils/getAbsolutePathForApp.js';
+
+export const TFilesystem = 'TFilesystem';
+
+// TODO: UNUSED (eventually putility will support these definitions)
+//       This is here so that the idea is not forgotten.
+export const IFilesystem = {
+    methods: {
+        stat: {
+            parameters: {
+                path: {
+                    alias: 'uid',
+                }
+            }
+        }
+    }
+
+};
+
+export class PuterAPIFilesystem extends putility.AdvancedBase {
+    constructor ({ api_info }) {
+        super();
+        this.api_info = api_info;
+    }
+
+    static IMPLEMENTS = {
+        [TFilesystem]: {
+            stat: async function (options) {
+                this.ensure_auth_();
+                const tp = new TeePromise();
+
+                const xhr = new utils.initXhr('/stat', this.api_info.APIOrigin, this.api_info.authToken);
+                utils.setupXhrEventHandlers(xhr, undefined, undefined,
+                    tp.resolve.bind(tp),
+                    tp.reject.bind(tp),
+                );
+
+                let dataToSend = {};
+                if (options.uid !== undefined) {
+                    dataToSend.uid = options.uid;
+                } else if (options.path !== undefined) {
+                    // If dirPath is not provided or it's not starting with a slash, it means it's a relative path
+                    // in that case, we need to prepend the app's root directory to it
+                    dataToSend.path = getAbsolutePathForApp(options.path);
+                }
+
+                dataToSend.return_subdomains = options.returnSubdomains;
+                dataToSend.return_permissions = options.returnPermissions;
+                dataToSend.return_versions = options.returnVersions;
+                dataToSend.return_size = options.returnSize;
+
+                xhr.send(JSON.stringify(dataToSend));
+
+                return await tp;
+            },
+            readdir: async function (options) {
+                this.ensure_auth_();
+                const tp = new TeePromise();
+
+                const xhr = new utils.initXhr('/readdir', this.api_info.APIOrigin, this.api_info.authToken);
+                utils.setupXhrEventHandlers(xhr, undefined, undefined,
+                    tp.resolve.bind(tp),
+                    tp.reject.bind(tp),
+                );
+
+                xhr.send(JSON.stringify({path: getAbsolutePathForApp(options.path)}));
+
+                return await tp;
+            },
+        }
+    }
+
+    ensure_auth_ () {
+        // TODO: remove reference to global 'puter'; get 'env' via context
+        if ( ! this.api_info.authToken && puter.env === 'web' ) {
+            try {
+                this.ui.authenticateWithPuter();
+            } catch (e) {
+                throw new Error('Authentication failed.');
+            }
+        }
+    }
+}
+
+export class ProxyFilesystem extends putility.AdvancedBase {
+    static PROPERTIES = {
+        delegate: () => {}, 
+    }
+    // TODO: constructor implied by properties
+    constructor ({ delegate }) {
+        super();
+        this.delegate = delegate;
+    }
+    static IMPLEMENTS = {
+        [TFilesystem]: {
+            stat: async function (o) {
+                return this.delegate.stat(o);
+            },
+            readdir: async function (o) {
+                return this.delegate.readdir(o);
+            }
+        }
+    }
+}

--- a/src/puter-js/src/modules/FileSystem/index.js
+++ b/src/puter-js/src/modules/FileSystem/index.js
@@ -77,10 +77,18 @@ export class PuterJSFileSystemModule extends AdvancedBase {
         });
 
         // Construct the decorator chain for the client-side filesystem.
-        let fs = new PuterAPIFilesystem({ api_info }).as(TFilesystem);
-        fs = new CachedFilesystem({ delegate: fs }).as(TFilesystem);
-        fs = new ProxyFilesystem({ delegate: fs }).as(TFilesystem);
-        this.filesystem = fs;
+        this.fs_nocache_ = new PuterAPIFilesystem({ api_info }).as(TFilesystem);
+        this.fs_cache_ = new CachedFilesystem({ delegate: this.fs_nocache_ }).as(TFilesystem);
+        // this.filesystem = this.fs_nocache;
+        this.fs_proxy_ = new ProxyFilesystem({ delegate: this.fs_nocache_ });
+        this.filesystem = this.fs_proxy_.as(TFilesystem);
+    }
+
+    cache_on () {
+        this.fs_proxy_.delegate = this.fs_cache_;
+    }
+    cache_off () {
+        this.fs_proxy_.delegate = this.fs_nocache_;
     }
 
 

--- a/src/puter-js/src/modules/FileSystem/index.js
+++ b/src/puter-js/src/modules/FileSystem/index.js
@@ -15,6 +15,7 @@ import sign from "./operations/sign.js";
 import deleteFSEntry from "./operations/deleteFSEntry.js";
 import { ProxyFilesystem, PuterAPIFilesystem, TFilesystem } from './definitions.js';
 import { AdvancedBase } from '../../../../putility/index.js';
+import { CachedFilesystem } from './CacheFS.js';
 
 export class PuterJSFileSystemModule extends AdvancedBase {
 
@@ -34,12 +35,14 @@ export class PuterJSFileSystemModule extends AdvancedBase {
     static NARI_METHODS = {
         stat: {
             positional: ['path'],
-            fn (parameters) {
+            firstarg_options: true,
+            async fn (parameters) {
                 return this.filesystem.stat(parameters);
             }
         },
         readdir: {
             positional: ['path'],
+            firstarg_options: true,
             fn (parameters) {
                 return this.filesystem.readdir(parameters);
             }
@@ -75,6 +78,7 @@ export class PuterJSFileSystemModule extends AdvancedBase {
 
         // Construct the decorator chain for the client-side filesystem.
         let fs = new PuterAPIFilesystem({ api_info }).as(TFilesystem);
+        fs = new CachedFilesystem({ delegate: fs }).as(TFilesystem);
         fs = new ProxyFilesystem({ delegate: fs }).as(TFilesystem);
         this.filesystem = fs;
     }

--- a/src/putility/src/AdvancedBase.js
+++ b/src/putility/src/AdvancedBase.js
@@ -26,6 +26,7 @@ class AdvancedBase extends FeatureBase {
         require('./features/NodeModuleDIFeature'),
         require('./features/PropertiesFeature'),
         require('./features/TraitsFeature'),
+        require('./features/NariMethodsFeature'),
     ]
 }
 

--- a/src/putility/src/features/NariMethodsFeature.js
+++ b/src/putility/src/features/NariMethodsFeature.js
@@ -52,7 +52,14 @@ module.exports = {
             instance._.nariMethods[method_name] = bound_fn;
 
             instance[method_name] = async (...args) => {
-                const endArgsIndex = spec.positional.length;
+                const endArgsIndex = (() => {
+                    if ( spec.firstarg_options ) {
+                        if ( typeof args[0] === 'object' ) {
+                            return 0;
+                        }
+                    }
+                    return spec.positional.length;
+                })();
                 const posArgs = args.slice(0, endArgsIndex);
                 const endArgs = args.slice(endArgsIndex);
 
@@ -71,11 +78,15 @@ module.exports = {
                 if ( typeof endArgs[0] === 'function' ) {
                     callbacks.success = endArgs[0];
                     endArgs.shift();
+                } else if ( options.success ) {
+                    callbacks.success = options.success;
                 }
 
                 if ( typeof endArgs[0] === 'function' ) {
                     callbacks.error = endArgs[0];
                     endArgs.shift();
+                } else if ( options.error ) {
+                    callbacks.error = options.error;
                 }
 
                 if ( spec.separate_options ) {

--- a/src/putility/src/features/NariMethodsFeature.js
+++ b/src/putility/src/features/NariMethodsFeature.js
@@ -1,0 +1,108 @@
+module.exports = {
+    readme: `
+        Normalized Asynchronous Request Invocation (NARI) Methods Feature
+
+        This feature allows a class to define "Nari methods", which are methods
+        that support both async/await and callback-style invocation, have
+        positional arguments, and an options argument.
+
+        "the expected interface for methods in puter.js"
+
+        The underlying method will receive parameters as an object, with the
+        positional arguments as keys in the object. The options argument will
+        be merged into the parameters object unless the method spec specifies
+        \`separate_options: true\`.
+
+        Example:
+
+        \`\`\`
+        class MyClass extends AdvancedBase {
+            static NARI_METHODS = {
+                myMethod: {
+                    positional: ['param1', 'param2'],
+                    fn: ({ param1, param2 }) => {
+                        return param1 + param2;
+                    }
+                }
+            }
+        }
+
+        const instance = new MyClass();
+        const result = instance.myMethod(1, 2); // returns 3
+        \`\`\`
+
+        The method can also be called with options and callbacks:
+
+        \`\`\`
+        instance.myMethod(1, 2, { option1: 'value' }, (result) => {
+            console.log('success', result);
+        }, (error) => {
+            console.error('error', error);
+        });
+        \`\`\`
+    `,
+    install_in_instance: (instance) => {
+        const nariMethodSpecs = instance._get_merged_static_object('NARI_METHODS');
+
+        instance._.nariMethods = {};
+
+        for ( const method_name in nariMethodSpecs ) {
+            const spec = nariMethodSpecs[method_name];
+            const bound_fn = spec.fn.bind(instance);
+            instance._.nariMethods[method_name] = bound_fn;
+
+            instance[method_name] = async (...args) => {
+                const endArgsIndex = spec.positional.length;
+                const posArgs = args.slice(0, endArgsIndex);
+                const endArgs = args.slice(endArgsIndex);
+
+                const parameters = {};
+                const options = {};
+                const callbacks = {};
+                for ( const [index, arg] of posArgs.entries() ) {
+                    parameters[spec.positional[index]] = arg;
+                }
+                
+                if ( typeof endArgs[0] === 'object' ) {
+                    Object.assign(options, endArgs[0]);
+                    endArgs.shift();
+                }
+
+                if ( typeof endArgs[0] === 'function' ) {
+                    callbacks.success = endArgs[0];
+                    endArgs.shift();
+                }
+
+                if ( typeof endArgs[0] === 'function' ) {
+                    callbacks.error = endArgs[0];
+                    endArgs.shift();
+                }
+
+                if ( spec.separate_options ) {
+                    parameters.options = options;
+                } else {
+                    Object.assign(parameters, options);
+                }
+
+                console.log('parameters being passed', parameters);
+
+                let retval;
+                try {
+                    retval = await bound_fn(parameters);
+                } catch (e) {
+                    if ( callbacks.error ) {
+                        callbacks.error(e);
+                    } else {
+                        throw e;
+                    }
+                }
+
+                if ( callbacks.success ) {
+                    callbacks.success(retval);
+                }
+
+                return retval;
+            };
+        }
+    }
+};

--- a/src/putility/test/traits.test.js
+++ b/src/putility/test/traits.test.js
@@ -1,0 +1,49 @@
+const { expect } = require('chai');
+const { AdvancedBase } = require("../src/AdvancedBase");
+
+class TestClass extends AdvancedBase {
+    static IMPLEMENTS = {
+        test_trait: {
+            test_method: () => 'A'
+        },
+        override_trait: {
+            preserved_method: () => 'B',
+            override_method: () => 'C',
+        },
+    }
+}
+
+class TestSubClass extends TestClass {
+    static IMPLEMENTS = {
+        override_trait: {
+            override_method: () => 'D',
+        }
+    }
+}
+
+describe('traits', () => {
+    it('instance.as', () => {
+        const o = new TestClass();
+        expect(o.as).to.be.a('function');
+        const ot = o.as('test_trait');
+        expect(ot.test_method).to.be.a('function');
+        expect(ot.test_method()).to.equal('A');
+    });
+    it('traits of parent', () => {
+        const o = new TestSubClass();
+        console.log(o._get_merged_static_object('IMPLEMENTS'))
+        expect(o.as).to.be.a('function');
+        const ot = o.as('test_trait');
+        expect(ot.test_method).to.be.a('function');
+        expect(ot.test_method()).to.equal('A');
+    })
+    it('trait method overrides', () => {
+        const o = new TestSubClass();
+        expect(o.as).to.be.a('function');
+        const ot = o.as('override_trait');
+        expect(ot.preserved_method).to.be.a('function');
+        expect(ot.override_method).to.be.a('function');
+        expect (ot.preserved_method()).to.equal('B');
+        expect (ot.override_method()).to.equal('D');
+    })
+});


### PR DESCRIPTION
This draft PR will track the progress of implementing client-side filesystem caching.

- [x] Prepare puter.js Filesystem module for decorator pattern
- [x] Implement stat caching
- [ ] Implement directory tree caching

Read caching and write-back caching are tentatively considered out-of-scope for this PR.