### PR TITLE
Preparation for adding a service manager to puter.js

### DIFF
--- a/src/putility/index.js
+++ b/src/putility/index.js
@@ -19,6 +19,7 @@
 const { AdvancedBase } = require('./src/AdvancedBase');
 const { Service } = require('./src/concepts/Service');
 const { ServiceManager } = require('./src/system/ServiceManager');
+const { TTopics } = require('./src/traits/traits');
 
 module.exports = {
     AdvancedBase,
@@ -28,8 +29,12 @@ module.exports = {
     libs: {
         promise: require('./src/libs/promise'),
         context: require('./src/libs/context'),
+        listener: require('./src/libs/listener'),
     },
     concepts: {
         Service,
+    },
+    traits: {
+        TTopics,
     },
 };

--- a/src/putility/index.js
+++ b/src/putility/index.js
@@ -18,9 +18,13 @@
  */
 const { AdvancedBase } = require('./src/AdvancedBase');
 const { Service } = require('./src/concepts/Service');
+const { ServiceManager } = require('./src/system/ServiceManager');
 
 module.exports = {
     AdvancedBase,
+    system: {
+        ServiceManager,
+    },
     libs: {
         promise: require('./src/libs/promise'),
         context: require('./src/libs/context'),

--- a/src/putility/src/AdvancedBase.js
+++ b/src/putility/src/AdvancedBase.js
@@ -27,6 +27,7 @@ class AdvancedBase extends FeatureBase {
         require('./features/PropertiesFeature'),
         require('./features/TraitsFeature'),
         require('./features/NariMethodsFeature'),
+        require('./features/TopicsFeature'),
     ]
 }
 

--- a/src/putility/src/concepts/Service.js
+++ b/src/putility/src/concepts/Service.js
@@ -2,6 +2,9 @@ const { AdvancedBase } = require("../AdvancedBase");
 
 const NOOP = async () => {};
 
+/** Service trait */
+const TService = Symbol('TService');
+
 /**
  * Service will be incrementally updated to consolidate
  * BaseService in Puter's backend with Service in Puter's frontend,
@@ -23,23 +26,27 @@ class Service extends AdvancedBase {
     static create ({ parameters, context }) {
         const ins = new this();
         ins._.context = context;
-        ins.construct(parameters);
+        ins.as(TService).construct(parameters);
         return ins;
     }
 
-    init (...a) {
-        if ( ! this._init ) return;
-        return this._init(...a);
-    }
-
-    construct (o) {
-        this.$parameters = {};
-        for ( const k in o ) this.$parameters[k] = o[k];
-        if ( ! this._construct ) return;
-        return this._construct(o);
+    static IMPLEMENTS = {
+        [TService]: {
+            init (...a) {
+                if ( ! this._init ) return;
+                return this._init(...a);
+            },
+            construct (o) {
+                this.$parameters = {};
+                for ( const k in o ) this.$parameters[k] = o[k];
+                if ( ! this._construct ) return;
+                return this._construct(o);
+            }
+        }
     }
 }
 
 module.exports = {
+    TService,
     Service,
 };

--- a/src/putility/src/concepts/Service.js
+++ b/src/putility/src/concepts/Service.js
@@ -19,6 +19,25 @@ class Service extends AdvancedBase {
             || this.constructor[`__on_${id}`]?.bind?.(this.constructor)
             || NOOP;
     }
+
+    static create ({ parameters, context }) {
+        const ins = new this();
+        ins._.context = context;
+        ins.construct(parameters);
+        return ins;
+    }
+
+    init (...a) {
+        if ( ! this._init ) return;
+        return this._init(...a);
+    }
+
+    construct (o) {
+        this.$parameters = {};
+        for ( const k in o ) this.$parameters[k] = o[k];
+        if ( ! this._construct ) return;
+        return this._construct(o);
+    }
 }
 
 module.exports = {

--- a/src/putility/src/features/PropertiesFeature.js
+++ b/src/putility/src/features/PropertiesFeature.js
@@ -18,14 +18,15 @@
  */
 module.exports = {
     name: 'Properties',
+    depends: ['Listeners'],
     install_in_instance: (instance) => {
         const properties = instance._get_merged_static_object('PROPERTIES');
 
         instance.onchange = (name, callback) => {
-            instance.__properties[name].listeners.push(callback);
+            instance._.properties[name].listeners.push(callback);
         };
 
-        instance.__properties = {};
+        instance._.properties = {};
 
         for ( const k in properties ) {
             const state = {
@@ -33,7 +34,7 @@ module.exports = {
                 listeners: [],
                 value: undefined,
             };
-            instance.__properties[k] = state;
+            instance._.properties[k] = state;
 
             if ( typeof properties[k] === 'object' ) {
                 // This will be supported in the future.
@@ -54,7 +55,7 @@ module.exports = {
                     return state.value;
                 },
                 set: (value) => {
-                    for ( const listener of instance.__properties[k].listeners ) {
+                    for ( const listener of instance._.properties[k].listeners ) {
                         listener(value, {
                             old_value: instance[k],
                         });

--- a/src/putility/src/features/TraitsFeature.js
+++ b/src/putility/src/features/TraitsFeature.js
@@ -30,7 +30,11 @@ module.exports = {
         for ( const cls of chain ) {
             const cls_traits = cls.IMPLEMENTS;
             if ( ! cls_traits ) continue;
-            for ( const trait_name in cls_traits ) {
+            const trait_keys = [
+                ...Object.getOwnPropertySymbols(cls_traits),
+                ...Object.keys(cls_traits),
+            ];
+            for ( const trait_name of trait_keys ) {
                 const impl = instance._.impls[trait_name] ??
                     (instance._.impls[trait_name] = {});
                 const cls_impl = cls_traits[trait_name];

--- a/src/putility/src/features/TraitsFeature.js
+++ b/src/putility/src/features/TraitsFeature.js
@@ -26,6 +26,7 @@ module.exports = {
         
         instance.as = trait_name => instance._.impls[trait_name];
         instance.list_traits = () => Object.keys(instance._.impls);
+        instance.mixin = (name, impl) => instance._.impls[name] = impl;
 
         for ( const cls of chain ) {
             const cls_traits = cls.IMPLEMENTS;

--- a/src/putility/src/system/ServiceManager.js
+++ b/src/putility/src/system/ServiceManager.js
@@ -1,0 +1,120 @@
+const { AdvancedBase } = require("../AdvancedBase");
+
+const mkstatus = name => {
+    const c = class {
+        get label () { return name }
+        describe () { return name }
+    }
+    c.name = `Status${
+        name[0].toUpperCase() + name.slice(1)
+    }`
+    return c;
+}
+
+class ServiceManager extends AdvancedBase {
+    static StatusRegistering = mkstatus('registering');
+    static StatusPending = class StatusPending {
+        constructor ({ waiting_for }) {
+            this.waiting_for = waiting_for;
+        }
+        get label () { return 'waiting'; }
+        // TODO: trait?
+        describe () {
+            return `waiting for: ${this.waiting_for.join(', ')}`
+        }
+    }
+    static StatusInitializing = mkstatus('initializing');
+    static StatusRunning = class StatusRunning {
+        constructor ({ start_ts }) {
+            this.start_ts = start_ts;
+        }
+        get label () { return 'running'; }
+        describe () {
+            return `running (since ${this.start_ts})`;
+        }
+    }
+    constructor () {
+        super();
+
+        this.services_l_ = [];
+        this.services_m_ = {};
+        this.service_infos_ = {};
+
+        this.init_listeners_ = {};
+        // services which are waiting for dependency servicces to be
+        // initialized; mapped like: waiting_[dependency] = Set(dependents)
+        this.waiting_ = {};
+    }
+    async register (name, factory, options = {}) {
+        const ins = factory.create({
+            parameters: options.parameters ?? {},
+        });
+        const entry = {
+            name,
+            instance: ins,
+            status: new this.constructor.StatusRegistering(),
+        };
+        this.services_l_.push(entry);
+        this.services_m_[name] = entry;
+
+        await this.maybe_init_(name);
+    }
+    info (name) {
+        return this.services_m_[name];
+    }
+
+    async maybe_init_ (name) {
+        const entry = this.services_m_[name];
+        const depends = entry.instance.get_depends();
+        const waiting_for = [];
+        for ( const depend of depends ) {
+            const depend_entry = this.services_m_[depend];
+            if ( ! depend_entry ) {
+                waiting_for.push(depend);
+                continue;
+            }
+            if ( ! (depend_entry.status instanceof this.constructor.StatusRunning) ) {
+                waiting_for.push(depend);
+            }
+        }
+
+        if ( waiting_for.length === 0 ) {
+            await this.init_service_(name);
+            return;
+        }
+
+        for ( const dependency of waiting_for ) {
+            /** @type Set */
+            const waiting_set = this.waiting_[dependency] ||
+                (this.waiting_[dependency] = new Set());
+            waiting_set.add(name);
+        }
+
+        entry.status = new this.constructor.StatusPending(
+            { waiting_for });
+    }
+
+    // called when a service has all of its dependencies initialized
+    // and is ready to be initialized itself
+    async init_service_ (name) {
+        const entry = this.services_m_[name];
+        entry.status = new this.constructor.StatusInitializing();
+        await entry.instance.init();
+        entry.status = new this.constructor.StatusRunning({
+            start_ts: new Date(),
+        });
+        /** @type Set */
+        const maybe_ready_set = this.waiting_[name];
+        const promises = [];
+        if ( maybe_ready_set ) {
+            for ( const dependent of maybe_ready_set.values() ) {
+                promises.push(this.maybe_init_(dependent));
+            }
+        }
+        await Promise.all(promises);
+    }
+}
+
+module.exports = {
+    ServiceManager,
+};

--- a/src/putility/src/system/ServiceManager.js
+++ b/src/putility/src/system/ServiceManager.js
@@ -1,4 +1,5 @@
 const { AdvancedBase } = require("../AdvancedBase");
+const { TService } = require("../concepts/Service");
 
 const mkstatus = name => {
     const c = class {
@@ -99,7 +100,9 @@ class ServiceManager extends AdvancedBase {
     async init_service_ (name) {
         const entry = this.services_m_[name];
         entry.status = new this.constructor.StatusInitializing();
-        await entry.instance.init();
+
+        const service_impl = entry.instance.as(TService);
+        await service_impl.init();
         entry.status = new this.constructor.StatusRunning({
             start_ts: new Date(),
         });

--- a/src/putility/src/traits/traits.js
+++ b/src/putility/src/traits/traits.js
@@ -1,0 +1,4 @@
+module.exports = {
+    TTopics: Symbol('TTopics'),
+    TDetachable: Symbol('TDetachable'),
+};

--- a/src/putility/test/ServiceManager.test.js
+++ b/src/putility/test/ServiceManager.test.js
@@ -1,0 +1,65 @@
+const { expect } = require('chai');
+const { Service } = require('../src/concepts/Service.js');
+const { ServiceManager } = require('../src/system/ServiceManager.js');
+
+class TestService extends Service {
+    _construct ({ name, depends }) {
+        this.name_ = name;
+        this.depends_ = depends;
+        this.initialized_ = false;
+    }
+    get_depends () {
+        return this.depends_;
+    }
+    async _init () {
+        // to ensure init is correctly awaited in tests
+        await new Promise(rslv => setTimeout(rslv, 0));
+
+        this.initialized_ = true;
+    }
+}
+
+describe('ServiceManager', () => {
+    it('handles dependencies', async () => {
+        const serviceMgr = new ServiceManager();
+
+        // register a service with two depends; it will start last
+        await serviceMgr.register('a', TestService, {
+            parameters: {
+                name: 'a',
+                depends: ['b', 'c'],
+            },
+        });
+
+        let a_info = serviceMgr.info('a');
+        expect(a_info.status.describe()).to.equal('waiting for: b, c');
+
+        // register a service with no depends; should start right away
+        await serviceMgr.register('b', TestService, {
+            parameters: {
+                name: 'b',
+                depends: []
+            }
+        });
+
+        let b_info = serviceMgr.info('b');
+        expect(b_info.status.label).to.equal('running');
+
+        a_info = serviceMgr.info('a');
+        expect(a_info.status.describe()).to.equal('waiting for: c');
+
+        await serviceMgr.register('c', TestService, {
+            parameters: {
+                name: 'c',
+                depends: ['b']
+            }
+        });
+
+        let c_info = serviceMgr.info('c');
+        expect(c_info.status.label).to.equal('running');
+        a_info = serviceMgr.info('a');
+        expect(a_info.status.label).to.equal('running');
+        b_info = serviceMgr.info('b');
+        expect(b_info.status.label).to.equal('running');
+    });
+});

--- a/src/putility/test/listener.test.js
+++ b/src/putility/test/listener.test.js
@@ -1,0 +1,24 @@
+const { RemoveFromArrayDetachable } = require("../src/libs/listener");
+const { expect } = require('chai');
+const { TDetachable } = require("../src/traits/traits");
+
+describe('RemoveFromArrayDetachable', () => {
+    it ('does the thing', () => {
+        const someArray = [];
+
+        const add_listener = (key, lis) => {
+            someArray.push(lis);
+            return new RemoveFromArrayDetachable(someArray, lis);
+        }
+
+        const det = add_listener('test', () => {
+            console.log('i am test func');
+        });
+
+        expect(someArray.length).to.equal(1);
+
+        det.as(TDetachable).detach();
+
+        expect(someArray.length).to.equal(0);
+    })
+})

--- a/src/putility/test/topics.test.js
+++ b/src/putility/test/topics.test.js
@@ -1,0 +1,48 @@
+const { AdvancedBase } = require("../src/AdvancedBase");
+const { TTopics, TDetachable } = require("../src/traits/traits");
+
+describe('topics', () => {
+    it ('works', () => {
+        // A trait for something that's "punchable"
+        const TPunchable = Symbol('punchable');
+
+        class SomeClassWithTopics extends AdvancedBase {
+            // We can "listen on punched"
+            static TOPICS = ['punched']
+
+            // Punchable trait implementation
+            static IMPLEMENTS = {
+                [TPunchable]: {
+                    punch () {
+                        this.as(TTopics).pub('punched!', {
+                            information: 'about the punch',
+                            in_whatever: 'format you desire',
+                        });
+                    }
+                }
+            }
+        }
+
+        const thingy = new SomeClassWithTopics();
+        
+        // Register the first listener, which we expect to be called both times
+        let first_listener_called = false;
+        thingy.as(TTopics).sub('punched', () => {
+            first_listener_called = true;
+        });
+
+        // Register the second listener, which we expect to be called once,
+        // and then we're gonna detach it and make sure detach works
+        let second_listener_call_count = 0;
+        const det = thingy.as(TTopics).sub('punched', () => {
+            second_listener_call_count++;
+        });
+
+        thingy.as(TPunchable).punch();
+        det.as(TDetachable).detach();
+        thingy.as(TPunchable).punch();
+
+        expect(first_listener_called).to.equal(true);
+        expect(second_listener_call_count).to.equal(1);
+    })
+});


### PR DESCRIPTION
The service pattern has proven incredibly useful. This implements a new services registry into puter.js, putting a lot of common functionality into `putility` where it can also be used in backend. Also in this PR is an implementation of a generic way to provide listenable events on a class, that lack of which has been a pain point up until now.

These additions in `putility` also further established how traits are used. Using traits instead of imaginary interfaces will improve readability (specifically the ability to find what files/classes are involved in a particular behavior) as well as make name collisions with methods impossible. `.mixin()` is also now provided by TraitsFeature, which is effectively an implementation of mixins without the drawback of name collisions because it's working on top of traits.