### PR TITLE
Added a chime to play on user's first interaction

### DIFF
--- a/src/gui/src/initgui.js
+++ b/src/gui/src/initgui.js
@@ -150,6 +150,11 @@ if(jQuery){
     };
 }
 
+window.playStartUpChime = ()=>{
+    let audio = new Audio('/src/audio/puter_chime.mp3');
+    audio.play();
+}
+
 window.initgui = async function(options){
     let url = new URL(window.location);
     url = url.href;

--- a/src/gui/src/initgui.js
+++ b/src/gui/src/initgui.js
@@ -153,7 +153,6 @@ if(jQuery){
 window.playStartUpChime = ()=>{
     let audio = new Audio('/src/audio/puter_chime.mp3');
     audio.play();
-    document.removeEventListener("click", window.playStartUpChime);
 }
 
 document.addEventListener("click", window.playStartUpChime);

--- a/src/gui/src/initgui.js
+++ b/src/gui/src/initgui.js
@@ -153,7 +153,10 @@ if(jQuery){
 window.playStartUpChime = ()=>{
     let audio = new Audio('/src/audio/puter_chime.mp3');
     audio.play();
+    document.removeEventListener("click", window.playStartUpChime);
 }
+
+document.addEventListener("click", window.playStartUpChime);
 
 window.initgui = async function(options){
     let url = new URL(window.location);

--- a/src/gui/src/initgui.js
+++ b/src/gui/src/initgui.js
@@ -153,6 +153,7 @@ if(jQuery){
 window.playStartUpChime = ()=>{
     let audio = new Audio('/src/audio/puter_chime.mp3');
     audio.play();
+    document.removeEventListener("click", window.playStartUpChime);
 }
 
 document.addEventListener("click", window.playStartUpChime);


### PR DESCRIPTION
This PR solves the issue : #783 

The idea is to have a global chime playback function that can be called at any moment.
In this particular PR, the global chime playback is called upon on user's first interaction, this is to mimc the boot up of an OS.
Once the playback is through, the event listener will be deactivated so as to not play back the chime on subsequent clicks.
