### PR TITLE
Update Swedish translations in sv.js

### DIFF
--- a/src/gui/src/i18n/translations/sv.js
+++ b/src/gui/src/i18n/translations/sv.js
@@ -347,9 +347,6 @@ const sv = {
         login2fa_recovery_back: "Tillbaka",
         login2fa_recovery_placeholder: "XXXXXXXX",
 
-		// ***********************************
-		// Missing translations
-		// ***********************************
         "change": "Ändra", // In English: "Change"
 	"clock_visibility": "Klocksynlighet", // In English: "Clock Visibility"
 	"plural_suffix": "", // In English: "s" (Plural suffix is context dependent in Swedish, it can be "or", "ar", "er", "en" or just no suffix)

--- a/src/gui/src/i18n/translations/sv.js
+++ b/src/gui/src/i18n/translations/sv.js
@@ -350,21 +350,22 @@ const sv = {
 		// ***********************************
 		// Missing translations
 		// ***********************************
-        "change": undefined, // In English: "Change"
-        "clock_visibility": undefined, // In English: "Clock Visibility"
-        "plural_suffix": undefined, // In English: "s"
-        "reading": undefined, // In English: "Reading %strong%"
-        "writing": undefined, // In English: "Writing %strong%"
-        "unzipping": undefined, // In English: "Unzipping %strong%"
-        "sequencing": undefined, // In English: "Sequencing %strong%"
-        "zipping": undefined, // In English: "Zipping %strong%"
-        "Editor": undefined, // In English: "Editor"
-        "Viewer": undefined, // In English: "Viewer"
-        "People with access": undefined, // In English: "People with access"
-        "Share With…": undefined, // In English: "Share With…"
-        "Owner": undefined, // In English: "Owner"
-        "You can't share with yourself.": undefined, // In English: "You can't share with yourself."
-        "This user already has access to this item": undefined, // In English: "This user already has access to this item"
+        "change": "Ändra", // In English: "Change"
+	"clock_visibility": "Klocksynlighet", // In English: "Clock Visibility"
+	"plural_suffix": "", // In English: "s" (Plural suffix is context dependent in Swedish, it can be "or", "ar", "er", "en" or just no suffix)
+	"reading": "Läser %strong%", // In English: "Reading %strong%"
+	"writing": "Skriver %strong%", // In English: "Writing %strong%"
+	"unzipping": "Packar upp %strong%", // In English: "Unzipping %strong%"
+	"sequencing": "Sekvenserar %strong%", // In English: "Sequencing %strong%"
+	"zipping": "Komprimerar %strong%", // In English: "Zipping %strong%"
+	"Editor": "Redigerare", // In English: "Editor"
+	"Viewer": "Granskare", // In English: "Viewer"
+	"People with access": "Personer med åtkomst", // In English: "People with access"
+	"Share With…": "Dela med…", // In English: "Share With…"
+	"Owner": "Ägare", // In English: "Owner"
+	"You can't share with yourself.": "Du kan inte dela med dig själv.", // In English: "You can't share with yourself."
+	"This user already has access to this item":
+	"Den här användaren har redan åtkomst till det här objektet", // In English: "This user already has access to this item"
 
     }
 };


### PR DESCRIPTION
This pull request adds missing Swedish translations to the sv.js file as outlined in Issue #852.

**Changes Made:**

- Replaced all undefined values with accurate Swedish translations.
- Verified that the translations are culturally appropriate and match the intended meaning of the English text.
- Preserved placeholders like %strong% in the translated text.
- For the plural_suffix key, left the value as an empty string ("") because Swedish pluralization is context-dependent and varies (e.g., "or", "ar", "er", "en", or no suffix). This requires contextual handling elsewhere in the application.

Closes #852