### PR TITLE
Enable Save button in Dev Center only when settings change and add a Reset button

### DIFF
--- a/src/dev-center/css/style.css
+++ b/src/dev-center/css/style.css
@@ -951,6 +951,12 @@ ol li:before {
     margin-top: 20px; 
     margin-bottom: 20px;
 }
+.edit-app-reset-btn{
+    float: right; 
+    margin-top: 20px; 
+    margin-bottom: 20px;
+    margin-right: 10px;
+}
 input:read-only {
     background-color: rgb(242 242 242);
 }

--- a/src/dev-center/js/dev-center.js
+++ b/src/dev-center/js/dev-center.js
@@ -628,10 +628,10 @@ function trackOriginalValues(){
         name: $('#edit-app-name').val(),
         indexURL: $('#edit-app-index-url').val(),
         description: $('#edit-app-description').val(),
-        icon: $('#edit-app-icon').attr('data-url') || $('#edit-app-icon').attr('data-base64'),
+        icon: $('#edit-app-icon').attr('data-base64'),
         fileAssociations: $('#edit-app-filetype-associations').val(),
         category: $('#edit-app-category').val(),
-        socialImage: $('#edit-app-social-image').attr('data-url') || $('#edit-app-social-image').attr('data-base64'),
+        socialImage: $('#edit-app-social-image').attr('data-base64'),
         windowSettings: {
             width: $('#edit-app-window-width').val(),
             height: $('#edit-app-window-height').val(),
@@ -652,15 +652,26 @@ function trackOriginalValues(){
 
 /* This function compares for all fields and checks if anything has changed from before editting*/
 function hasChanges() {
+    // is icon changed
+    if($('#edit-app-icon').attr('data-base64') !== originalValues.icon){
+        return true;
+    }
+
+    // if social image is changed
+    if($('#edit-app-social-image').attr('data-base64') !== originalValues.socialImage){
+        return true;
+    }
+
+    // if any of the fields have changed
     return(
         $('#edit-app-title').val() !== originalValues.title ||
         $('#edit-app-name').val() !== originalValues.name ||
         $('#edit-app-index-url').val() !== originalValues.indexURL ||
         $('#edit-app-description').val() !== originalValues.description ||
-        ($('#edit-app-icon').attr('data-url') || $('#edit-app-icon').attr('data-base64')) !== originalValues.icon ||
+        $('#edit-app-icon').attr('data-base64') !== originalValues.icon ||
         $('#edit-app-filetype-associations').val() !== originalValues.fileAssociations ||
         $('#edit-app-category').val() !== originalValues.category ||
-        ($('#edit-app-social-image').attr('data-url') || $('#edit-app-social-image').attr('data-base64')) !== originalValues.socialImage ||
+        $('#edit-app-social-image').attr('data-base64') !== originalValues.socialImage ||
         $('#edit-app-window-width').val() !== originalValues.windowSettings.width ||
         $('#edit-app-window-height').val() !== originalValues.windowSettings.height ||
         $('#edit-app-window-top').val() !== originalValues.windowSettings.top ||
@@ -1334,6 +1345,9 @@ $(document).on('click', '#edit-app-icon-delete', async function (e) {
     $('#edit-app-icon').removeAttr('data-url');
     $('#edit-app-icon').removeAttr('data-base64');
     $('#edit-app-icon-delete').hide();
+
+    toggleSaveButton();
+    toggleResetButton();
 })
 
 $(document).on('click', '#edit-app-icon', async function (e) {
@@ -1360,6 +1374,9 @@ $(document).on('click', '#edit-app-icon', async function (e) {
         $('#edit-app-icon').css('background-image', `url(${image})`);
         $('#edit-app-icon').attr('data-base64', image);
         $('#edit-app-icon-delete').show();
+
+        toggleSaveButton();
+        toggleResetButton();
     }
 })
 
@@ -2505,6 +2522,9 @@ $(document).on('click', '#edit-app-social-image', async function(e) {
         $('#edit-app-social-image').css('background-image', `url(${image})`);
         $('#edit-app-social-image').attr('data-base64', image);
         $('#edit-app-social-image-delete').show();
+
+        toggleSaveButton();
+        toggleResetButton();
     }
 });
 

--- a/src/dev-center/js/dev-center.js
+++ b/src/dev-center/js/dev-center.js
@@ -537,7 +537,7 @@ function generate_edit_app_section(app) {
                 <input type="text" style="width: 362px;" class="app-uid" value="${html_encode(app.uid)}" readonly>
 
                 <label for="edit-app-icon">Icon</label>
-                <div id="edit-app-icon" style="background-image:url(${!app.icon ? './img/app.svg' : html_encode(app.icon)});" ${app.icon ? 'data-url="' + html_encode(app.icon) + '"' : ''}>
+                <div id="edit-app-icon" style="background-image:url(${!app.icon ? './img/app.svg' : html_encode(app.icon)});" ${app.icon ? 'data-url="' + html_encode(app.icon) + '"' : ''}  ${app.icon ? 'data-base64="' + html_encode(app.icon) + '"' : ''} >
                     <div id="change-app-icon">Change App Icon</div>
                 </div>
                 <span id="edit-app-icon-delete" style="${app.icon ? 'display:block;' : ''}">Remove icon</span>
@@ -727,6 +727,7 @@ function resetToOriginalValues() {
     if (originalValues.icon) {
         $('#edit-app-icon').css('background-image', `url(${originalValues.icon})`);
         $('#edit-app-icon').attr('data-url', originalValues.icon);
+        $('#edit-app-icon').attr('data-base64', originalValues.icon);
         $('#edit-app-icon-delete').show();
     } else {
         $('#edit-app-icon').css('background-image', '');
@@ -738,6 +739,7 @@ function resetToOriginalValues() {
     if (originalValues.socialImage) {
         $('#edit-app-social-image').css('background-image', `url(${originalValues.socialImage})`);
         $('#edit-app-social-image').attr('data-url', originalValues.socialImage);
+        $('#edit-app-social-image').attr('data-base64', originalValues.socialImage);
     } else {
         $('#edit-app-social-image').css('background-image', '');
         $('#edit-app-social-image').removeAttr('data-url');
@@ -2491,7 +2493,7 @@ async function initializeAssetsDirectory() {
 function generateSocialImageSection(app) {
     return `
         <label for="edit-app-social-image">Social Graph Image (1200×630 strongly recommended)</label>
-        <div id="edit-app-social-image" class="social-image-preview" ${app.metadata?.social_image ? `style="background-image:url(${html_encode(app.metadata.social_image)})" data-url="${html_encode(app.metadata.social_image)}"` : ''}>
+        <div id="edit-app-social-image" class="social-image-preview" ${app.metadata?.social_image ? `style="background-image:url(${html_encode(app.metadata.social_image)})" data-url="${html_encode(app.metadata.social_image)}" data-base64="${html_encode(app.metadata.social_image)}"` : ''}>
             <div id="change-social-image">Change Social Image</div>
         </div>
         <span id="edit-app-social-image-delete" style="${app.metadata?.social_image ? 'display:block;' : ''}">Remove social image</span>

--- a/src/dev-center/js/dev-center.js
+++ b/src/dev-center/js/dev-center.js
@@ -684,6 +684,15 @@ function toggleSaveButton() {
     }
 }
 
+/* This function enables or disables the reset button if there are any changes made */
+function toggleResetButton() {
+    if (hasChanges()) {
+        $('.edit-app-reset-btn').prop('disabled', false);
+    } else {
+        $('.edit-app-reset-btn').prop('disabled', true);
+    }
+}
+
 /* This function revers the changes made back to the original values of the edit form */
 function resetToOriginalValues() {
     $('#edit-app-title').val(originalValues.title);
@@ -737,6 +746,7 @@ async function edit_app_section(cur_app_name) {
     $('#edit-app').html(generate_edit_app_section(cur_app));
     trackOriginalValues();  // Track initial field values
     toggleSaveButton();  // Ensure Save button is initially disabled
+    toggleResetButton();  // Ensure Reset button is initially disabled
     $('#edit-app').show();
 
     // --------------------------------------------------------
@@ -1133,6 +1143,7 @@ $(document).on('click', '.edit-app-save-btn', async function (e) {
         currently_editing_app = app;
         trackOriginalValues();  // Update original values after save
         toggleSaveButton();  //Disable Save Button after succesful save
+        toggleResetButton();  //DIsable Reset Button after succesful save
         $('#edit-app-error').hide();
         $('#edit-app-success').show();
         document.body.scrollTop = document.documentElement.scrollTop = 0;
@@ -1163,11 +1174,13 @@ $(document).on('click', '.edit-app-save-btn', async function (e) {
 
 $(document).on('input change', '#edit-app input, #edit-app textarea, #edit-app select', () => {
     toggleSaveButton();
+    toggleResetButton();
 });
 
 $(document).on('click', '.edit-app-reset-btn', function () {
     resetToOriginalValues();
     toggleSaveButton();   // Disable Save button since values are reverted to original
+    toggleResetButton();  //Disable Reset button since values are reverted to original
 });
 
 $(document).on('click', '.open-app-btn', async function (e) {

--- a/src/dev-center/js/dev-center.js
+++ b/src/dev-center/js/dev-center.js
@@ -614,6 +614,7 @@ function generate_edit_app_section(app) {
 
                 <hr style="margin-top: 40px;">
                 <button type="button" class="edit-app-save-btn button button-primary">Save</button>
+                <button type="button" class="edit-app-reset-btn button button-secondary">Reset</button>
             </form>
         </div>
     `
@@ -680,6 +681,47 @@ function toggleSaveButton() {
         $('.edit-app-save-btn').prop('disabled', false);
     } else {
         $('.edit-app-save-btn').prop('disabled', true);
+    }
+}
+
+/* This function revers the changes made back to the original values of the edit form */
+function resetToOriginalValues() {
+    $('#edit-app-title').val(originalValues.title);
+    $('#edit-app-name').val(originalValues.name);
+    $('#edit-app-index-url').val(originalValues.indexURL);
+    $('#edit-app-description').val(originalValues.description);
+    $('#edit-app-filetype-associations').val(originalValues.fileAssociations);
+    $('#edit-app-category').val(originalValues.category);
+    $('#edit-app-window-width').val(originalValues.windowSettings.width);
+    $('#edit-app-window-height').val(originalValues.windowSettings.height);
+    $('#edit-app-window-top').val(originalValues.windowSettings.top);
+    $('#edit-app-window-left').val(originalValues.windowSettings.left);
+    $('#edit-app-maximize-on-start').prop('checked', originalValues.checkboxes.maximizeOnStart);
+    $('#edit-app-background').prop('checked', originalValues.checkboxes.background);
+    $('#edit-app-window-resizable').prop('checked', originalValues.checkboxes.resizableWindow);
+    $('#edit-app-hide-titlebar').prop('checked', originalValues.checkboxes.hideTitleBar);
+    $('#edit-app-locked').prop('checked', originalValues.checkboxes.locked);
+    $('#edit-app-credentialless').prop('checked', originalValues.checkboxes.credentialless);
+    $('#edit-app-fullpage-on-landing').prop('checked', originalValues.checkboxes.fullPageOnLanding);
+
+    if (originalValues.icon) {
+        $('#edit-app-icon').css('background-image', `url(${originalValues.icon})`);
+        $('#edit-app-icon').attr('data-url', originalValues.icon);
+        $('#edit-app-icon-delete').show();
+    } else {
+        $('#edit-app-icon').css('background-image', '');
+        $('#edit-app-icon').removeAttr('data-url');
+        $('#edit-app-icon').removeAttr('data-base64');
+        $('#edit-app-icon-delete').hide();
+    }
+
+    if (originalValues.socialImage) {
+        $('#edit-app-social-image').css('background-image', `url(${originalValues.socialImage})`);
+        $('#edit-app-social-image').attr('data-url', originalValues.socialImage);
+    } else {
+        $('#edit-app-social-image').css('background-image', '');
+        $('#edit-app-social-image').removeAttr('data-url');
+        $('#edit-app-social-image').removeAttr('data-base64');
     }
 }
 
@@ -1121,6 +1163,11 @@ $(document).on('click', '.edit-app-save-btn', async function (e) {
 
 $(document).on('input change', '#edit-app input, #edit-app textarea, #edit-app select', () => {
     toggleSaveButton();
+});
+
+$(document).on('click', '.edit-app-reset-btn', function () {
+    resetToOriginalValues();
+    toggleSaveButton();   // Disable Save button since values are reverted to original
 });
 
 $(document).on('click', '.open-app-btn', async function (e) {


### PR DESCRIPTION
Issue: #880 

Files changed: `src/dev-center/js/dev-center.js` and `src/dev-center/css/style.css`

Now all original fields (input, checkbox, etc.) on the settings form is tracked, and also added a Reset button. The Save button and Reset button are only enabled if and only if there is a change in the form from the original. 
- Save and Reset buttons are disabled upon first opening settings form (since no changes initially)
- if user changes anything (eg. title from "My-App" to "My-App-2") -> Save button is enabled. Reset button is enabled
- if user clicks on Reset button, it reverts all the form changes to the original values before editing.
- if user changes back to original (eg. title back from "My-App-2" to "My-App") -> Save button is disabled. Reset button is disabled.

**Before any changes**
![before-any-changes](https://github.com/user-attachments/assets/62744669-e0e5-4550-912c-a2a192c16f55)
**After any changes**
![after-any-changes](https://github.com/user-attachments/assets/3e78dd76-81a8-4197-8db0-79ed2e267827)

Manual tests carried out on locally deployed frontend to ensure everything works as expected.
