### PR TITLE
sync(i18n): add Polish translations for billing-related terms

### DIFF
--- a/src/gui/src/i18n/translations/pl.js
+++ b/src/gui/src/i18n/translations/pl.js
@@ -362,56 +362,53 @@ const pl = {
         "You can't share with yourself.": 'Nie możesz dzielić się z samym sobą',
         "This user already has access to this item": 'Ten użytkownik ma już dostęp do tego elementu',
 
-        // ----------------------------------------
-        // Missing translations:
-        // ----------------------------------------
-        "plural_suffix": undefined, // In English: "s"
-        "billing.change_payment_method": undefined, // In English: "Change"
-        "billing.cancel": undefined, // In English: "Cancel"
-        "billing.download_invoice": undefined, // In English: "Download"
-        "billing.payment_method": undefined, // In English: "Payment Method"
-        "billing.payment_method_updated": undefined, // In English: "Payment method updated!"
-        "billing.confirm_payment_method": undefined, // In English: "Confirm Payment Method"
-        "billing.payment_history": undefined, // In English: "Payment History"
-        "billing.refunded": undefined, // In English: "Refunded"
-        "billing.paid": undefined, // In English: "Paid"
-        "billing.ok": undefined, // In English: "OK"
-        "billing.resume_subscription": undefined, // In English: "Resume Subscription"
-        "billing.subscription_cancelled": undefined, // In English: "Your subscription has been canceled."
-        "billing.subscription_cancelled_description": undefined, // In English: "You will still have access to your subscription until the end of this billing period."
-        "billing.offering.free": undefined, // In English: "Free"
-        "billing.offering.pro": undefined, // In English: "Professional"
-        "billing.offering.business": undefined, // In English: "Business"
-        "billing.cloud_storage": undefined, // In English: "Cloud Storage"
-        "billing.ai_access": undefined, // In English: "AI Access"
-        "billing.bandwidth": undefined, // In English: "Bandwidth"
-        "billing.apps_and_games": undefined, // In English: "Apps & Games"
-        "billing.upgrade_to_pro": undefined, // In English: "Upgrade to %strong%"
-        "billing.switch_to": undefined, // In English: "Switch to %strong%"
-        "billing.payment_setup": undefined, // In English: "Payment Setup"
-        "billing.back": undefined, // In English: "Back"
-        "billing.you_are_now_subscribed_to": undefined, // In English: "You are now subscribed to %strong% tier."
-        "billing.you_are_now_subscribed_to_without_tier": undefined, // In English: "You are now subscribed"
-        "billing.subscription_cancellation_confirmation": undefined, // In English: "Are you sure you want to cancel your subscription?"
-        "billing.subscription_setup": undefined, // In English: "Subscription Setup"
-        "billing.cancel_it": undefined, // In English: "Cancel It"
-        "billing.keep_it": undefined, // In English: "Keep It"
-        "billing.subscription_resumed": undefined, // In English: "Your %strong% subscription has been resumed!"
-        "billing.upgrade_now": undefined, // In English: "Upgrade Now"
-        "billing.upgrade": undefined, // In English: "Upgrade"
-        "billing.currently_on_free_plan": undefined, // In English: "You are currently on the free plan."
-        "billing.download_receipt": undefined, // In English: "Download Receipt"
-        "billing.subscription_check_error": undefined, // In English: "A problem occurred while checking your subscription status."
-        "billing.email_confirmation_needed": undefined, // In English: "Your email has not been confirmed. We'll send you a code to confirm it now."
-        "billing.sub_cancelled_but_valid_until": undefined, // In English: "You have cancelled your subscription and it will automatically switch to the free tier at the end of the billing period. You will not be charged again unless you re-subscribe."
-        "billing.current_plan_until_end_of_period": undefined, // In English: "Your current plan until the end of this billing period."
-        "billing.current_plan": undefined, // In English: "Current plan"
-        "billing.cancelled_subscription_tier": undefined, // In English: "Cancelled Subscription (%%)"
-        "billing.manage": undefined, // In English: "Manage"
-        "billing.limited": undefined, // In English: "Limited"
-        "billing.expanded": undefined, // In English: "Expanded"
-        "billing.accelerated": undefined, // In English: "Accelerated"
-        "billing.enjoy_msg": undefined, // In English: "Enjoy %% of Cloud Storage plus other benefits."
+        "plural_suffix": '', // Leaving it empty, as the previous translator did
+        "billing.change_payment_method": 'Zmień',
+        "billing.cancel": 'Anuluj',
+        "billing.download_invoice": 'Pobierz',
+        "billing.payment_method": 'Metoda Płatności',
+        "billing.payment_method_updated": 'Metoda płatności została zaktualizowana!',
+        "billing.confirm_payment_method": 'Potwierdź Metodę Płatności',
+        "billing.payment_history": 'Historia Płatności',
+        "billing.refunded": 'Zwrócono',
+        "billing.paid": 'Opłacono',
+        "billing.ok": 'OK',
+        "billing.resume_subscription": 'Wznów Subskrypcję',
+        "billing.subscription_cancelled": 'Twoja subskrypcja została anulowana',
+        "billing.subscription_cancelled_description": 'Dostęp do Twojej subskrypcji będzie możliwy do końca tego okresu rozliczeniowego.',
+        "billing.offering.free": 'Darmowy',
+        "billing.offering.pro": 'Pro',
+        "billing.offering.business": 'Dla Firm',
+        "billing.cloud_storage": 'Pamięć w Chmurze',
+        "billing.ai_access": 'Możliwość Dostępu do AI',
+        "billing.bandwidth": 'Przepustowość',
+        "billing.apps_and_games": 'Aplikacji i Gier', // "1000s of Apps & Games"
+        "billing.upgrade_to_pro": 'Rozszerz na plan %strong%',
+        "billing.switch_to": 'Zmień na plan %strong%',
+        "billing.payment_setup": 'Ustawienia Płatności',
+        "billing.back": 'Wstecz',
+        "billing.you_are_now_subscribed_to": 'Obecnie subskrybujesz plan %strong%',
+        "billing.you_are_now_subscribed_to_without_tier": 'Jesteś teraz subskrybentem',
+        "billing.subscription_cancellation_confirmation": 'Czy na pewno chcesz anulować subskrypcję?',
+        "billing.subscription_setup": 'Ustawienia Subskrypcji',
+        "billing.cancel_it": 'Anuluj To',
+        "billing.keep_it": 'Zachowaj To',
+        "billing.subscription_resumed": 'Twoja subskrypcja obejmująca plan %strong% została wznowiona',
+        "billing.upgrade_now": 'Ulepsz Teraz',
+        "billing.upgrade": 'Ulepsz',
+        "billing.currently_on_free_plan": 'Obecnie korzystasz z darmowego planu.',
+        "billing.download_receipt": 'Pobierz Potwierdzenie',
+        "billing.subscription_check_error": 'Wystąpił błąd podczas sprawdzania stanu Twojej subskrypcji.',
+        "billing.email_confirmation_needed": 'Twój adres e-mail nie został potwierdzony. Wyślemy Ci kod, aby potwierdzić go teraz.',
+        "billing.sub_cancelled_but_valid_until": 'Twoja subskrypcja została anulowana i po zakończeniu okresu rozliczeniowego zostanie automatycznie zmieniona na plan darmowy. Opłata nie zostanie naliczona ponownie, dopóki nie dokonasz ponownej subskrypcji.',
+        "billing.current_plan_until_end_of_period": 'Twój obecny plan do końca tego okresu rozliczeniowego.',
+        "billing.current_plan": 'Twój obecny plan',
+        "billing.cancelled_subscription_tier": 'Anulowana Subskrypcja (%%)',
+        "billing.manage": 'Zarządzaj',
+        "billing.limited": 'Ograniczona',       // \
+        "billing.expanded": 'Rozszerzona',      //  -> These adjectives are used to describe the "AI Access" and/or "Bandwidth"
+        "billing.accelerated": 'Przyspieszona', // /
+        "billing.enjoy_msg": 'Ciesz się pakietem %% pamięci w chmurze i innymi benefitami',
     }
 };
 


### PR DESCRIPTION
This PR adds missing Polish translations for billing-related terms and phrases in the project, ensuring they are contextually accurate and appropriate.

Updated file: [`src/gui/src/i18n/translations/pl.js`](https://github.com/HeyPuter/puter/tree/main/src/gui/src/i18n/translations/pl.js)
Related issue: #964
