### PR TITLE
Update ro.js

### DIFF
--- a/src/gui/src/i18n/translations/ro.js
+++ b/src/gui/src/i18n/translations/ro.js
@@ -359,56 +359,52 @@ const ro = {
         "You can't share with yourself.": "Nu poți partaja cu tine însuți.", // In English: "You can't share with yourself."
         "This user already has access to this item": "Acest utilizator are deja acces la acest element",
 
-        // ----------------------------------------
-        // Missing translations:
-        // ----------------------------------------
-        "billing.change_payment_method": undefined, // In English: "Change"
-        "billing.cancel": undefined, // In English: "Cancel"
-        "billing.download_invoice": undefined, // In English: "Download"
-        "billing.payment_method": undefined, // In English: "Payment Method"
-        "billing.payment_method_updated": undefined, // In English: "Payment method updated!"
-        "billing.confirm_payment_method": undefined, // In English: "Confirm Payment Method"
-        "billing.payment_history": undefined, // In English: "Payment History"
-        "billing.refunded": undefined, // In English: "Refunded"
-        "billing.paid": undefined, // In English: "Paid"
-        "billing.ok": undefined, // In English: "OK"
-        "billing.resume_subscription": undefined, // In English: "Resume Subscription"
-        "billing.subscription_cancelled": undefined, // In English: "Your subscription has been canceled."
-        "billing.subscription_cancelled_description": undefined, // In English: "You will still have access to your subscription until the end of this billing period."
-        "billing.offering.free": undefined, // In English: "Free"
-        "billing.offering.pro": undefined, // In English: "Professional"
-        "billing.offering.business": undefined, // In English: "Business"
-        "billing.cloud_storage": undefined, // In English: "Cloud Storage"
-        "billing.ai_access": undefined, // In English: "AI Access"
-        "billing.bandwidth": undefined, // In English: "Bandwidth"
-        "billing.apps_and_games": undefined, // In English: "Apps & Games"
-        "billing.upgrade_to_pro": undefined, // In English: "Upgrade to %strong%"
-        "billing.switch_to": undefined, // In English: "Switch to %strong%"
-        "billing.payment_setup": undefined, // In English: "Payment Setup"
-        "billing.back": undefined, // In English: "Back"
-        "billing.you_are_now_subscribed_to": undefined, // In English: "You are now subscribed to %strong% tier."
-        "billing.you_are_now_subscribed_to_without_tier": undefined, // In English: "You are now subscribed"
-        "billing.subscription_cancellation_confirmation": undefined, // In English: "Are you sure you want to cancel your subscription?"
-        "billing.subscription_setup": undefined, // In English: "Subscription Setup"
-        "billing.cancel_it": undefined, // In English: "Cancel It"
-        "billing.keep_it": undefined, // In English: "Keep It"
-        "billing.subscription_resumed": undefined, // In English: "Your %strong% subscription has been resumed!"
-        "billing.upgrade_now": undefined, // In English: "Upgrade Now"
-        "billing.upgrade": undefined, // In English: "Upgrade"
-        "billing.currently_on_free_plan": undefined, // In English: "You are currently on the free plan."
-        "billing.download_receipt": undefined, // In English: "Download Receipt"
-        "billing.subscription_check_error": undefined, // In English: "A problem occurred while checking your subscription status."
-        "billing.email_confirmation_needed": undefined, // In English: "Your email has not been confirmed. We'll send you a code to confirm it now."
-        "billing.sub_cancelled_but_valid_until": undefined, // In English: "You have cancelled your subscription and it will automatically switch to the free tier at the end of the billing period. You will not be charged again unless you re-subscribe."
-        "billing.current_plan_until_end_of_period": undefined, // In English: "Your current plan until the end of this billing period."
-        "billing.current_plan": undefined, // In English: "Current plan"
-        "billing.cancelled_subscription_tier": undefined, // In English: "Cancelled Subscription (%%)"
-        "billing.manage": undefined, // In English: "Manage"
-        "billing.limited": undefined, // In English: "Limited"
-        "billing.expanded": undefined, // In English: "Expanded"
-        "billing.accelerated": undefined, // In English: "Accelerated"
-        "billing.enjoy_msg": undefined, // In English: "Enjoy %% of Cloud Storage plus other benefits."
-
+       "billing.change_payment_method": "Schimbă", 
+        "billing.cancel": "Anulează",
+        "billing.download_invoice": "Descarcă",
+        "billing.payment_method": "Metodă de plată",
+        "billing.payment_method_updated": "Metoda de plată a fost actualizată!",
+        "billing.confirm_payment_method": "Confirmă metoda de plată",
+        "billing.payment_history": "Istoric plăți",
+        "billing.refunded": "Rambursat",
+        "billing.paid": "Plătit",
+        "billing.ok": "OK",
+        "billing.resume_subscription": "Reactivează abonamentul",
+        "billing.subscription_cancelled": "Abonamentul tău a fost anulat.",
+        "billing.subscription_cancelled_description": "Vei avea în continuare acces la abonament până la sfârșitul perioadei de facturare actuale.",
+        "billing.offering.free": "Gratis",
+        "billing.offering.pro": "Profesional", 
+        "billing.offering.business": "Business", // Keeping "Business" as it's commonly used in Romanian
+        "billing.cloud_storage": "Stocare în cloud",
+        "billing.ai_access": "Acces AI",
+        "billing.bandwidth": "Lățime de bandă",
+        "billing.apps_and_games": "Aplicații și jocuri",
+        "billing.upgrade_to_pro": "Actualizează la %strong%",
+        "billing.switch_to": "Schimbă la %strong%",
+        "billing.payment_setup": "Configurare plată",
+        "billing.back": "Înapoi",
+        "billing.you_are_now_subscribed_to": "Acum ești abonat la nivelul %strong%.",
+        "billing.you_are_now_subscribed_to_without_tier": "Acum ești abonat",
+        "billing.subscription_cancellation_confirmation": "Ești sigur că vrei să anulezi abonamentul?",
+        "billing.subscription_setup": "Configurare abonament",
+        "billing.cancel_it": "Anulează-l",
+        "billing.keep_it": "Păstrează-l",
+        "billing.subscription_resumed": "Abonamentul tău %strong% a fost reactivat!",
+        "billing.upgrade_now": "Actualizează acum",
+        "billing.upgrade": "Actualizează",
+        "billing.currently_on_free_plan": "În prezent folosești planul gratuit.",
+        "billing.download_receipt": "Descarcă chitanța",
+        "billing.subscription_check_error": "A apărut o problemă la verificarea abonamentului.",
+        "billing.email_confirmation_needed": "E-mailul tău nu a fost confirmat. Îți vom trimite acum un cod de confirmare.",
+        "billing.sub_cancelled_but_valid_until": "Ți-ai anulat abonamentul și va trece automat la planul gratuit la sfârșitul perioadei de facturare. Nu vei mai fi taxat decât dacă te reabonezi.",
+        "billing.current_plan_until_end_of_period": "Planul tău actual până la sfârșitul perioadei de facturare actuale.",
+        "billing.current_plan": "Plan actual",
+        "billing.cancelled_subscription_tier": "Abonament anulat (%%)",
+        "billing.manage": "Administrează",
+        "billing.limited": "Limitat",
+        "billing.expanded": "Extins",
+        "billing.accelerated": "Accelerat",
+        "billing.enjoy_msg": "Bucură-te de %% spațiu de stocare în cloud plus alte beneficii.",
     }
 }
 


### PR DESCRIPTION
Updated the romanian translations.

I kept the terms "Professional" and "Business" in English as they are commonly used this way in Romanian in IT services context

I adapted the forms of address to second person singular ("tu") instead of formal ("dumneavoastră") to maintain a friendly and modern tone

I maintained consistency with existing translations in the file Placeholders (%strong%, %%) were kept in grammatically correct positions for Romanian language