### PR TITLE
Fix: drag-and-drop issue: files not appearing on desktop automatically

### DIFF
--- a/src/gui/src/helpers.js
+++ b/src/gui/src/helpers.js
@@ -1808,6 +1808,7 @@ window.upload_items = async function(items, dest_path){
                 })
                 // remove from active_uploads
                 delete window.active_uploads[opid];
+                window.location.reload();
             },
             // error
             error: async function(err){


### PR DESCRIPTION
# Fix: Drag-and-drop files not appearing automatically on desktop

## Description
This pull request resolves an issue where files dragged and dropped onto the desktop do not appear automatically. Users previously needed to manually refresh to see the files.

## Changes Made
- Added functionality to trigger an automatic UI refresh after a drag-and-drop operation.
- Tested the solution to ensure no regressions or additional errors were introduced.

## Testing
- Verified that files now appear immediately after being dragged and dropped.
- Confirmed there are no errors in the browser, console, or terminal related to this functionality.

Let me know if you need further adjustments or additional information!
