### PR TITLE
fix: resolve issue #983 - Stuck on Creating new app loading screen

### DIFF
--- a/src/dev-center/js/dev-center.js
+++ b/src/dev-center/js/dev-center.js
@@ -288,6 +288,8 @@ async function create_app(title, source_path = null, items = null) {
     
         })
         .then(async (app) => {
+            $('.new-app-modal').get(0).close();
+                window.location.reload();
             let app_dir;
             // ----------------------------------------------------
             // Create app directory in AppData
@@ -313,6 +315,8 @@ async function create_app(title, source_path = null, items = null) {
                 maximizeOnStart: false,
                 background: false,
             }).then(async (app) => {
+                $('.new-app-modal').get(0).close();
+                window.location.reload();
                 // refresh app list
                 puter.apps.list().then(async (resp) => {
                     apps = resp;


### PR DESCRIPTION
fix: resolve issue #983 - Stuck on Creating new app loading screen

Issue Description:
- When creating a new app in the dev center, the loading modal gets stuck.
- After reloading the page, the modal disappears and the user is redirected to the "My apps" page.

Steps to reproduce:
1. Go to dev center.
2. Create a new app.

Expected behavior:
- The page should redirect directly to the "My apps" page without being stuck on the loading modal.

