### PR TITLE
Add Feature Flags to Disable Temporary Users and User Signup

### DIFF
--- a/src/backend/src/config.js
+++ b/src/backend/src/config.js
@@ -25,10 +25,11 @@ let config = {};
 // Static defaults
 config.servers = [];
 
+config.disable_user_signup = false;
+config.default_user_group = '78b1b1dd-c959-44d2-b02c-8735671f9997';
+
 // Will disable the auto-generated temp users. If a user lands on the site, they will be required to sign up or log in.
 config.disable_temp_users = false;
-
-config.default_user_group = '78b1b1dd-c959-44d2-b02c-8735671f9997';
 config.default_temp_group = 'b7220104-7905-4985-b996-649fdcdb3c8f';
 
 config.max_file_size = 100_000_000_000;

--- a/src/backend/src/helpers.js
+++ b/src/backend/src/helpers.js
@@ -78,6 +78,24 @@ async function is_shared_with(fsentry_id, recipient_user_id){
     return false;
 }
 
+/**
+ * Checks to see if temp_users is disabled and return a boolean
+ * @returns {boolean}
+ */
+async function is_temp_users_disabled() {
+    const svc_feature_flag = await services.get("feature-flag");
+    return await svc_feature_flag.check("temp-users-disabled");
+}
+
+/**
+ * Checks to see if user_signup is disabled and return a boolean
+ * @returns {boolean}
+ */
+async function is_user_signup_disabled() {
+    const svc_feature_flag = await services.get("feature-flag");
+    return await svc_feature_flag.check("user-signup-disabled");
+}
+
 const chkperm = spanify('chkperm', async (target_fsentry, requester_user_id, action) => {
     // basic cases where false is the default response
     if(!target_fsentry)
@@ -1661,6 +1679,8 @@ module.exports = {
     is_valid_uuid4,
     is_valid_uuid,
     is_specifically_uuidv4,
+    is_temp_users_disabled,
+    is_user_signup_disabled,
     is_valid_url,
     jwt_auth,
     mv,

--- a/src/backend/src/routers/signup.js
+++ b/src/backend/src/routers/signup.js
@@ -23,6 +23,8 @@ const eggspress = require('../api/eggspress');
 const { Context } = require('../util/context');
 const { DB_WRITE } = require('../services/database/consts');
 const { generate_identifier } = require('../util/identifier');
+const { is_temp_users_disabled: lazy_temp_users, 
+        is_user_signup_disabled: lazy_user_signup } = require("../helpers")
 
 async function generate_random_username () {
     let username;
@@ -133,15 +135,26 @@ module.exports = eggspress(['/signup'], {
         }
     }
 
-    // temporary user
-    if(req.body.is_temp && !config.disable_temp_users){
-        req.body.username = await generate_random_username();
-        req.body.email = req.body.username + '@gmail.com';
-        req.body.password = 'sadasdfasdfsadfsa';
-    }else if(config.disable_temp_users){
-        return res.status(400).send('Temp users are disabled.');
+    const is_temp_users_disabled = await lazy_temp_users();
+    const is_user_signup_disabled = await lazy_user_signup();
+
+    if (is_temp_users_disabled && is_user_signup_disabled) {
+        return res.status(403).send('User signup and Temporary users are disabled.');
     }
 
+    if (!req.body.is_temp && is_user_signup_disabled) {
+        return res.status(403).send('User signup is disabled.');
+    } 
+
+    if (req.body.is_temp && is_temp_users_disabled) {
+        return res.status(403).send('Temporary users are disabled.');
+    }
+
+    // Create temp user data
+    req.body.username = req.body.username ?? await generate_random_username();
+    req.body.email = req.body.email ?? req.body.username + '@gmail.com';
+    req.body.password = req.body.password ?? 'sadasdfasdfsadfsa';
+    
     // send_confirmation_code
     req.body.send_confirmation_code = req.body.send_confirmation_code ?? true;
 

--- a/src/backend/src/services/FeatureFlagService.js
+++ b/src/backend/src/services/FeatureFlagService.js
@@ -93,25 +93,24 @@ class FeatureFlagService extends BaseService {
             }
             return { options, value };
         })();
-
+        
         if ( ! this.known_flags.has(permission) ) {
             this.known_flags.set(permission, true);
         }
 
-        if ( this.known_flags[permission].$ === 'config-flag' ) {
-            return this.known_flags[permission].value;
+        if(this.known_flags.get(permission)?.$ === "config-flag") {
+            return this.known_flags.get(permission)?.value;
         }
 
         const actor = options.actor ?? Context.get('actor');
 
-        if ( this.known_flags[permission].$ === 'function-flag' ) {
-            return await this.known_flags[permission].fn({
+        if ( this.known_flags.get(permission)?.$ === 'function-flag' ) {
+            return await this.known_flags.get(permission)?.fn({
                 ...options,
                 actor
             });
         }
         
-
         const svc_permission = this.services.get('permission');
         const reading = await svc_permission.scan(actor, `feature:${permission}`);
         const l = PermissionUtil.reading_to_options(reading);

--- a/src/backend/src/services/ShareService.js
+++ b/src/backend/src/services/ShareService.js
@@ -45,7 +45,7 @@ class ShareService extends BaseService {
         svc_featureFlag.register('share', {
             $: 'function-flag',
             fn: async ({ actor }) => {
-                const user = actor.type.user;
+                const user = actor.type.user ?? null;
                 if ( ! user ) {
                     throw new Error('expected user');
                 }

--- a/src/backend/src/services/auth/AuthService.js
+++ b/src/backend/src/services/auth/AuthService.js
@@ -48,6 +48,17 @@ class AuthService extends BaseService {
         this.db = await this.services.get('database').get(DB_WRITE, 'auth');
         this.svc_session = await this.services.get('session');
         
+        const svc_feature_flag = await this.services.get("feature-flag");
+        svc_feature_flag.register("temp-users-disabled", {
+            $: "config-flag",
+            value: this.global_config.disable_temp_users ?? false
+        });
+
+        svc_feature_flag.register("user-signup-disabled", {
+            $: "config-flag",
+            value: this.global_config.disable_user_signup ?? false
+        })
+        
         // "FPE" stands for "Format Preserving Encryption"
         // The `uuid_fpe_key` is a key for creating encrypted alternatives
         // to UUIDs and decrypting them back to the original UUIDs
@@ -67,6 +78,7 @@ class AuthService extends BaseService {
         };
     }
 
+    
 
     /**
     * This method authenticates a user or app using a token.

--- a/src/gui/src/initgui.js
+++ b/src/gui/src/initgui.js
@@ -153,8 +153,10 @@ if(jQuery){
 }
 
 window.initgui = async function(options){
-    let url = new URL(window.location);
-    url = url.href;
+    const url = new URL(window.location).href;
+    window.url = url;
+    const url_paths = window.location.pathname.split('/').filter(element => element);
+    window.url_paths = url_paths
 
     let picked_a_user_for_sdk_login = false;
 
@@ -199,16 +201,14 @@ window.initgui = async function(options){
     // will hold the result of the whoami API call
     let whoami;
 
-    window.url_paths = window.location.pathname.split('/').filter(element => element);
-
     //--------------------------------------------------------------------------------------
     // Extract 'action' from URL
     //--------------------------------------------------------------------------------------
     let action;
-    if(url_paths[0]?.toLocaleLowerCase() === 'action' && url_paths[1]){
-        action = url_paths[1].toLowerCase();
+    if (window.url_paths[0]?.toLocaleLowerCase() === 'action' && window.url_paths[1]) {
+        action = window.url_paths[1].toLowerCase();
     }
-
+    
     //--------------------------------------------------------------------------------------
     // Determine if we are in full-page mode
     // i.e. https://puter.com/app/<app_name>/?puter.fullpage=true
@@ -789,6 +789,7 @@ window.initgui = async function(options){
             console.error('Error:', error);
         })
     }
+
     // -------------------------------------------------------------------------------------
     // Desktop Background
     // If we're in fullpage/emebedded/Auth Popup mode, we don't want to load the custom background


### PR DESCRIPTION
### Pull Request Description

#### Summary
This pull request introduces feature flags to control the behavior of temporary user accounts and user signups as requested in issue #696 . 
The new flags allow administrators to:
- Disable temporary user creation.
- Disable new user signups, restricting access to existing users only.


#### Changes and Features
1. **Feature Flags Added**:
   - `temp_users_disabled`: Disables the creation of temporary users.
   - `user_signup_disabled`: Disables user signup through the login interface.

2. **Backend Updates**:
   - Updated `AuthService` to register the new feature flags as config flags.
   - Updated `signup.js` to conditionally handle requests based on the feature flags.
   - Added helper functions to check the status of the feature flags.

4. **Bug Fixes**:
   - Corrected feature flag lookup in `FeatureFlagService` to use `Map.get()` instead of array key lookup.
   - Fixed missing `url_paths` initialization in `initgui.js`.
   - Added null checks in `ShareService` for better error handling.


#### Testing
- Verified backend responses for scenarios with `temp_users_disabled` and `user_signup_disabled` enabled/disabled.
- Tested GUI behavior when temporary users are disallowed.