### PR TITLE
Enhanced ai command to perfom other commands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "experiments/js-parse-and-output"
       ],
       "dependencies": {
+        "@heyputer/putility": "^1.0.2",
         "dedent": "^1.5.3",
         "javascript-time-ago": "^2.5.11",
         "json-colorizer": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     ]
   },
   "dependencies": {
+    "@heyputer/putility": "^1.0.2",
     "dedent": "^1.5.3",
     "javascript-time-ago": "^2.5.11",
     "json-colorizer": "^3.0.1",


### PR DESCRIPTION
This pull request enhances the ai command to recognize and execute system commands (e.g., mkdir, ls, etc.) directly from a prompt. Previously, the AI command could only respond with text, but now it can detect embedded commands and execute them seamlessly.

Changes Made
	•	Introduced logic to parse and extract system commands from the AI response using the pattern %%%command%%%.
	•	Added functionality to execute the extracted command within the shell environment.
	•	Moved the await ctx.externs.out.write(message + '\n'); statement into the else block to ensure regular messages are printed only when no command is detected. Now, ai command has enhanced capabilities where users can use it to interact with the terminal. This uses "ctx.shell.runPipeline" to run commands from inside a command.
