### PR TITLE
fix: made protocol dynamic in the publishURL displayed on 'Publish As Website' dialogbox

### DIFF
--- a/src/gui/src/UI/UIWindowPublishWebsite.js
+++ b/src/gui/src/UI/UIWindowPublishWebsite.js
@@ -37,7 +37,7 @@ async function UIWindowPublishWebsite(target_dir_uid, target_dir_name, target_di
             // subdomain
             h += `<div style="overflow: hidden;">`;
                 h += `<label style="margin-bottom: 10px;">${i18n('pick_name_for_website')}</label>`;
-                h += `<div style="font-family: monospace;">https://<input class="publish-website-subdomain" style="width:235px;" type="text" autocomplete="subdomain" spellcheck="false" autocorrect="off" autocapitalize="off" data-gramm_editor="false"/>.${html_encode(window.hosting_domain)}</div>`;
+                h += `<div style="font-family: monospace;">http://<input class="publish-website-subdomain" style="width:235px;" type="text" autocomplete="subdomain" spellcheck="false" autocorrect="off" autocapitalize="off" data-gramm_editor="false"/>.${html_encode(window.hosting_domain)}</div>`;
             h += `</div>`;
             // uid
             h += `<input class="publishWebsiteTargetDirUID" type="hidden" value="${html_encode(target_dir_uid)}"/>`;

--- a/src/gui/src/UI/UIWindowPublishWebsite.js
+++ b/src/gui/src/UI/UIWindowPublishWebsite.js
@@ -36,8 +36,9 @@ async function UIWindowPublishWebsite(target_dir_uid, target_dir_name, target_di
             h += `<div class="publish-website-error-msg"></div>`;
             // subdomain
             h += `<div style="overflow: hidden;">`;
-                h += `<label style="margin-bottom: 10px;">${i18n('pick_name_for_website')}</label>`;
-                h += `<div style="font-family: monospace;">http://<input class="publish-website-subdomain" style="width:235px;" type="text" autocomplete="subdomain" spellcheck="false" autocorrect="off" autocapitalize="off" data-gramm_editor="false"/>.${html_encode(window.hosting_domain)}</div>`;
+    h += `<label style="margin-bottom: 10px;">${i18n('pick_name_for_website')}</label>`;
+    
+                h += `<div style="font-family: monospace;">${html_encode(window.extractProtocol(window.url))}://<input class="publish-website-subdomain" style="width:235px;" type="text" autocomplete="subdomain" spellcheck="false" autocorrect="off" autocapitalize="off" data-gramm_editor="false"/>.${html_encode(window.hosting_domain)}</div>`;
             h += `</div>`;
             // uid
             h += `<input class="publishWebsiteTargetDirUID" type="hidden" value="${html_encode(target_dir_uid)}"/>`;

--- a/src/gui/src/helpers.js
+++ b/src/gui/src/helpers.js
@@ -2224,6 +2224,10 @@ window.extractSubdomain = function(url) {
     return subdomain;
 }
 
+window.extractProtocol = function (url) {
+    var protocol = url.split('://')[0];
+    return protocol;
+}
 window.sleep = function(ms){
     return new Promise(resolve => setTimeout(resolve, ms));
 }


### PR DESCRIPTION
This fix resolves #1157 

**Updates**
- Created a helper function `window.extractProtocol()` in `helper.js` to get the accurate protocol from the window URL, as this URL has the required data per configuration via  `static_hotsing_domain` and `protocol`
- The helper function is then called in-place of the hard-coded protocol **https** in the `protocol` part of the publish URL that is displayed on the 'Publish As Website' dialogbox.

The above approach hence resolves the issue, where-in when testing puter on localhost, the `protocol` is always displayed as `https://` in the publish URL, since it is hardcoded in the codebase.

After the new change:
![image](https://github.com/user-attachments/assets/7eddadee-0ac2-445b-a27e-301719785af6)
