### PR TITLE
tweak : moved clock to right between profile and search

### DIFF
--- a/src/gui/src/UI/UIDesktop.js
+++ b/src/gui/src/UI/UIDesktop.js
@@ -1103,12 +1103,9 @@ async function UIDesktop(options){
     let ht = '';
     ht += `<div class="toolbar" style="height:${window.toolbar_height}px; min-height:${window.toolbar_height}px; max-height:${window.toolbar_height}px;">`;
         // logo
-        ht += `<div id="toolbar-first" class="toolbar-btn toolbar-puter-logo" title="Puter" style="margin-left: 10px;"><img src="${window.icons['logo-white.svg']}" draggable="false" style="display:block; width:17px; height:17px"></div>`;
+        ht += `<div class="toolbar-btn toolbar-puter-logo" title="Puter" style="margin-left: 10px;"><img src="${window.icons['logo-white.svg']}" draggable="false" style="display:block; width:17px; height:17px"></div>`;
       
     
-        //clock 
-    ht += `<div id="clock" class="toolbar-clock" style="margin-left: 10px; margin-right: auto">12:00 AM Sun, Jan 01</div>`;
-
     // clock spacer
     ht += `<div class="toolbar-spacer"></div>`;
     
@@ -1140,6 +1137,10 @@ async function UIDesktop(options){
         
         // search button
         ht += `<div class="toolbar-btn search-btn" title="Search" style="background-image:url('${window.icons['search.svg']}')"></div>`;
+
+    
+        //clock 
+        ht += `<div id="clock" class="toolbar-clock" style="">12:00 AM Sun, Jan 01</div>`;
 
         // user options menu
         ht += `<div class="toolbar-btn user-options-menu-btn profile-pic" style="display:block;">`;

--- a/src/gui/src/css/style.css
+++ b/src/gui/src/css/style.css
@@ -2401,7 +2401,7 @@ label {
     color: white;
     font-size: 13px;
     background-color: #00000056;
-    
+    margin-left: 20px;
     /* prevent clock from moving other taskbar items */
     height: 22px;
     line-height: 22px;

--- a/src/gui/src/helpers.js
+++ b/src/gui/src/helpers.js
@@ -2551,8 +2551,8 @@ window.change_clock_visible = (clock_visible) => {
     
     newValue === 'auto' && window.is_fullscreen() ? $('#clock').show() : $('#clock').hide();
 
-    newValue === 'show' && $('#clock').show() && $('#toolbar-first').css('margin-right', '');
-    newValue === 'hide' && $('#clock').hide() &&  $('#toolbar-first').css('margin-right', 'auto');
+    newValue === 'show' && $('#clock').show();
+    newValue === 'hide' && $('#clock').hide();
 
     if(clock_visible) {
         // save clock_visible to user preferences


### PR DESCRIPTION
The tweaks under this commit resolve #1176 

**Changelog**
- Moved clock to the right side between the profile and search icons, ensuring its position is less likely to change due to other interactions on the toolbar
- Apps utilizing the mac style menubar will remain undisturbed.
- Cleaned up old positioning logic that was added for the initial clock enhancement


**Tested against each personalization settings**

1 : Hide - always hidden
![image](https://github.com/user-attachments/assets/e97e0002-c67c-4303-a613-1e91829e2b9c)

2 : Show - always visible
![image](https://github.com/user-attachments/assets/fbdb2bbe-6eab-4e59-84ed-f0a08c7e9722)

3 : Auto - Default, visible only in full-screen mode
![image](https://github.com/user-attachments/assets/4aaa9b36-c841-480c-b67b-3d8f0628155b)
