### PR TITLE
Fix yaml.docker-compose.security.no-new-privileges.no-new-privileges

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@
 version: "3.8"
 services:
   puter:
+    security_opt:
+      - no-new-privileges:true
     container_name: puter
     image: ghcr.io/heyputer/puter:latest
     pull_policy: always


### PR DESCRIPTION
This PR fixes yaml.docker-compose.security.no-new-privileges.no-new-privileges.