### PR TITLE
Make it easier to add file extensions to an app in bulk

### DIFF
--- a/src/dev-center/js/dev-center.js
+++ b/src/dev-center/js/dev-center.js
@@ -1073,7 +1073,11 @@ async function edit_app_section(cur_app_name, tab = 'deploy') {
     // Focus on the first input
     $('#edit-app-title').focus();
 
-    activate_tippy();
+    try {
+        activate_tippy();
+    } catch (e) {
+        console.log('no tippy:', e);
+    }
 
     // Add custom paste event handler for CSV processing
     if (tagify) {

--- a/src/dev-center/js/dev-center.js
+++ b/src/dev-center/js/dev-center.js
@@ -1081,6 +1081,10 @@ async function edit_app_section(cur_app_name, tab = 'deploy') {
 
     // Add custom paste event handler for CSV processing
     if (tagify) {
+        // Modify the Tagify settings to treat comma as a tag delimiter
+        tagify.settings.delimiters = ',';
+        
+        // Handle paste events to support bulk pasting of extensions
         tagify.DOM.input.addEventListener('paste', function(e) {
             // Get the pasted text
             const pastedText = e.clipboardData ? e.clipboardData.getData('text') : '';
@@ -1088,6 +1092,9 @@ async function edit_app_section(cur_app_name, tab = 'deploy') {
             // Check if the pasted text contains multiple items (using common delimiters)
             if (pastedText && /[,;\t\s]/.test(pastedText)) {
                 e.preventDefault(); // Prevent the default paste action
+                
+                // Remove any existing text in the input
+                tagify.DOM.input.textContent = '';
                 
                 // Split by common delimiters (comma, semicolon, tab, or space)
                 const extensions = pastedText.split(/[,;\t\s]+/)
@@ -1104,6 +1111,33 @@ async function edit_app_section(cur_app_name, tab = 'deploy') {
                     tagify.addTags(extensions);
                     
                     // Trigger change event to enable save button
+                    setTimeout(() => {
+                        toggleSaveButton();
+                        toggleResetButton();
+                    }, 10);
+                }
+            }
+        });
+        
+        // Also handle keydown events to support comma key presses
+        tagify.DOM.input.addEventListener('keydown', function(e) {
+            // If comma is pressed and there's text in the input
+            if (e.key === ',' && tagify.DOM.input.textContent.trim()) {
+                e.preventDefault();
+                
+                const text = tagify.DOM.input.textContent.trim();
+                
+                // Validate the text
+                if ((text.startsWith('.') || text.includes('/')) && 
+                    tagify.settings.pattern.test(text)) {
+                    
+                    // Add as tag
+                    tagify.addTags([text]);
+                    
+                    // Clear the input
+                    tagify.DOM.input.textContent = '';
+                    
+                    // Trigger change event
                     setTimeout(() => {
                         toggleSaveButton();
                         toggleResetButton();

--- a/src/dev-center/js/dev-center.js
+++ b/src/dev-center/js/dev-center.js
@@ -570,7 +570,7 @@ function generate_edit_app_section(app) {
                 <label for="edit-app-filetype-associations">File Associations</label>
                <p style="margin-top: 10px; font-size:13px;">A list of file type specifiers. For example if you include <code>.txt</code> your apps could be opened when a user clicks on a TXT file.</p>
                <p style="margin-top: 5px; font-size:13px;">You can paste multiple extensions at once (comma, space, or tab separated) or press comma to add each extension.</p>
-               <textarea id="edit-app-filetype-associations"  placeholder="Paste multiple extensions like: .txt, .doc, .pdf, application/json">${JSON.stringify(app.filetype_associations.map(item => ({ "value": item })), null, app.filetype_associations.length)}</textarea>
+               <textarea id="edit-app-filetype-associations"  placeholder="Paste multiple extensions like: .txt, .doc, .pdf, application/json">${JSON.stringify(app.filetype_associations.map(item => ({ "value": item })), null, app.filetype_associations.length).replace(/</g, '\\u003c')}</textarea>
 
                 <h3 style="font-size: 23px; border-bottom: 1px solid #EEE; margin-top: 50px; margin-bottom: 0px;">Window</h3>
                 <div>


### PR DESCRIPTION
### Please Note
I'm testing out an agentic AI code writing tool called [mycoder](https://github.com/drivecore/mycoder). Most of the comments (except for review comments) below are not written by me personally. Most of the code (except a small fix) is generated. Everything was manually tested by me and I reviewed all the code.

### Comment from `mycoder`
This PR addresses issue #1196 by adding support for pasting multiple file extensions at once in the Dev Center app.\n\n## Changes\n\n- Added support for pasting CSV-formatted file extensions (comma, semicolon, tab, or space separated)\n- Added a custom paste event handler to process and validate pasted extensions\n- Updated the placeholder text to inform users they can paste multiple extensions at once\n- Updated the UI text to make the feature more discoverable\n\nNow when users want to add many file extensions to their app, they can simply paste them all at once instead of having to press Enter after each one, which significantly improves the user experience when configuring apps.\n\nFixes #1196