### PR TITLE
fix: update check_usage_ to only consider past month usage

### DIFF
--- a/src/backend/src/modules/puterai/AIChatService.js
+++ b/src/backend/src/modules/puterai/AIChatService.js
@@ -662,11 +662,15 @@ class AIChatService extends BaseService {
         const reading = await svc_permission.scan(actor, `paid-services:ai-chat`);
         const options = PermissionUtil.reading_to_options(reading);
 
-        // Query current ai usage in terms of cost
+        // Query current ai usage in terms of cost (only from the past month)
+        const oneMonthAgo = new Date();
+        oneMonthAgo.setMonth(oneMonthAgo.getMonth() - 1);
+        const oneMonthAgoStr = oneMonthAgo.toISOString().slice(0, 19).replace('T', ' ');
+        
         const [row] = await this.db.read(
             'SELECT SUM(`cost`) AS sum FROM `ai_usage` ' +
-            'WHERE `user_id` = ?',
-            [actor.type.user.id]
+            'WHERE `user_id` = ? AND `created_at` >= ?',
+            [actor.type.user.id, oneMonthAgoStr]
         );
         
         const cost_used = row?.sum || 0;


### PR DESCRIPTION
## Description\nThis PR fixes the `check_usage_` function in `AIChatService.js` to only consider AI usage from the past month when checking against limits, rather than all historical usage.\n\n## Changes\n- Modified the SQL query to include a date filter for the past month\n- Added code to calculate the date one month ago\n\n## Related Issues\nFixes #1207\n\n## Testing\nManually verified that the SQL query now includes the date filter correctly.\n\n[ai]