### PR TITLE
fix: improve onLaunchedWithItems to prevent information loss

### DIFF
--- a/src/gui/src/helpers/launch_app.js
+++ b/src/gui/src/helpers/launch_app.js
@@ -208,21 +208,14 @@ const launch_app = async (options)=>{
         }
 
         if(file_signature){
+            // Only pass the file UUID to the app, and let onLaunchedWithItems
+            // fetch the complete file information via puter.js
             iframe_url.searchParams.append('puter.item.uid', file_signature.uid);
-            iframe_url.searchParams.append('puter.item.path', privacy_aware_path(options.file_path) || file_signature.path);
-            iframe_url.searchParams.append('puter.item.name', file_signature.fsentry_name);
-            iframe_url.searchParams.append('puter.item.read_url', file_signature.read_url);
-            iframe_url.searchParams.append('puter.item.write_url', file_signature.write_url);
-            iframe_url.searchParams.append('puter.item.metadata_url', file_signature.metadata_url);
-            iframe_url.searchParams.append('puter.item.size', file_signature.fsentry_size);
-            iframe_url.searchParams.append('puter.item.accessed', file_signature.fsentry_accessed);
-            iframe_url.searchParams.append('puter.item.modified', file_signature.fsentry_modified);
-            iframe_url.searchParams.append('puter.item.created', file_signature.fsentry_created);
         }
-        else if(options.readURL){
-            iframe_url.searchParams.append('puter.item.name', options.filename);
-            iframe_url.searchParams.append('puter.item.path', privacy_aware_path(options.file_path));
-            iframe_url.searchParams.append('puter.item.read_url', options.readURL);
+        else if(options.readURL && options.file_uid){
+            // Only pass the file UUID to the app, and let onLaunchedWithItems
+            // fetch the complete file information via puter.js
+            iframe_url.searchParams.append('puter.item.uid', options.file_uid);
         }
 
         // In godmode, we add the super token to the iframe URL

--- a/src/puter-js/src/modules/UI.js
+++ b/src/puter-js/src/modules/UI.js
@@ -605,24 +605,22 @@ class UI extends EventListener {
         // the URL parameters will be checked every time the callback is set which can cause problems if the callback is set multiple times.
         if(!this.#onLaunchedWithItems){
             let URLParams = new URLSearchParams(window.location.search);
-            if(URLParams.has('puter.item.name') && URLParams.has('puter.item.uid') && URLParams.has('puter.item.read_url')){
-                let fpath = URLParams.get('puter.item.path');
-
-                if(!fpath.startsWith('~/') && !fpath.startsWith('/'))
-                    fpath = '~/' + fpath;
-
-                callback([new FSItem({
-                    name: URLParams.get('puter.item.name'),
-                    path: fpath,
-                    uid: URLParams.get('puter.item.uid'),
-                    readURL: URLParams.get('puter.item.read_url'),
-                    writeURL: URLParams.get('puter.item.write_url'),
-                    metadataURL: URLParams.get('puter.item.metadata_url'),
-                    size: URLParams.get('puter.item.size'),
-                    accessed: URLParams.get('puter.item.accessed'),
-                    modified: URLParams.get('puter.item.modified'),
-                    created: URLParams.get('puter.item.created'),
-                })]);
+            if(URLParams.has('puter.item.uid')){
+                const fileUID = URLParams.get('puter.item.uid');
+                
+                // Fetch the complete file information using the UID
+                puter.fs.stat({ uid: fileUID })
+                    .then(fileInfo => {
+                        // Create an FSItem with the complete information
+                        callback([new FSItem(fileInfo)]);
+                    })
+                    .catch(error => {
+                        console.error('Error fetching file information:', error);
+                        // If there's an error, still call the callback with the minimal information
+                        callback([new FSItem({
+                            uid: fileUID
+                        })]);
+                    });
             }
         }
 


### PR DESCRIPTION
[ai]

## Fix for issue #1226: onLaunchedWithItems implementation to prevent information loss

This PR implements the solution suggested in issue #1226 to fix the problem with `onLaunchedWithItems` being prone to losing information about fsentries due to property duplication.

### Changes:

1. Modified `launch_app.js` to only pass the file UUID to apps after granting the app permission to access the file:
   - Instead of passing all file properties through the URL query parameters, we now only pass the file UUID
   - This eliminates the property duplication issue and keeps the URL shorter

2. Updated `UI.js` to have `onLaunchedWithItems` fetch the file information via puter.js:
   - When an app is launched with a file, it now uses `puter.fs.stat()` to get the complete file information using the UUID
   - This ensures that all file properties are consistently retrieved from a single source

### Benefits:

1. More robust approach that eliminates property duplication
2. Shorter URLs (avoids hitting URL length limits)
3. Apps get the most up-to-date file information
4. Consistent with how the rest of the system accesses file information

Fixes #1226