### PR TITLE
fix/bug#1233-iframe-overlap-issue

### DIFF
--- a/src/gui/src/css/style.css
+++ b/src/gui/src/css/style.css
@@ -904,13 +904,13 @@ span.header-sort-icon img {
     padding: 0;
     border: 1px solid #9a9a9a;
     box-shadow: 0px 0px 15px #00000066;
-    /* overflow: hidden; */
     border-radius: 4px;
     border: none;
     transition: opacity .2s;
     user-select: none !important;
     -moz-user-select: none !important;
     -webkit-user-select: none;
+    contain: paint;
 }
 
 .window[data-is_maximized="1"] {

--- a/src/gui/src/css/style.css
+++ b/src/gui/src/css/style.css
@@ -904,7 +904,7 @@ span.header-sort-icon img {
     padding: 0;
     border: 1px solid #9a9a9a;
     box-shadow: 0px 0px 15px #00000066;
-    overflow: hidden;
+    /* overflow: hidden; */
     border-radius: 4px;
     border: none;
     transition: opacity .2s;


### PR DESCRIPTION
This PR fixes the bug#1233- iframe overlap issue.

CSS property overflow: hidden at the parent container was interfering with the layout calculations and was forcefully clipping child elements. Making the resize div to float beside the iframe instead of overlapping.

Before:
<img width="1200" alt="image" src="https://github.com/user-attachments/assets/5510fbeb-2463-442e-906b-a5fbd72d630e" />

After fix:
<img width="1181" alt="image" src="https://github.com/user-attachments/assets/db7b9c83-9e70-4399-97ad-3366003ecf71" />
