### PR TITLE
Customized and draggable favorites view(#626)

### DIFF
--- a/src/gui/src/helpers.js
+++ b/src/gui/src/helpers.js
@@ -810,6 +810,13 @@ window.create_folder = async(basedir, appendto_element)=>{
 
     // create folder
     try{
+        //Modified the path so that it works correctly
+        //for Windows developpers as well
+        dirname = dirname.replace(/\\/g, '/')
+        if (dirname.charAt(0) !== '/') {
+            dirname = '/' + dirname;
+        }
+
         await puter.fs.mkdir({
             path: dirname + '/'+folder_name,
             rename: true,


### PR DESCRIPTION
So me and @EvaNtziou  implemented the features described in issue #626 for the favorites section.
So now you can:
1.Add or remove an item from favorites
2.Add more than one item to favorites at the same time if multiple items are selected
3.Be able to drag files and folders from the desktop to the favorites view

We did our best but we work on Windows so let us know if any issue occurs when you merge it. We are more than happy to help resolve it to ensure the best result!
Thank you very much
Below is a reference picture of how it looks like :
![favorites view](https://github.com/user-attachments/assets/922fdcbb-66be-46db-bec5-4c645436c949)
