### PR TITLE
fix: return proper error message when the model is not found

### DIFF
--- a/src/backend/src/modules/puterai/AIChatService.js
+++ b/src/backend/src/modules/puterai/AIChatService.js
@@ -437,6 +437,15 @@ class AIChatService extends BaseService {
                 const model_details = this.get_model_details(model_used, {
                     service_used,
                 });
+
+                if ( ! model_details ) {
+                    throw APIError.create('field_invalid', null, {
+                        key: 'model',
+                        expected: 'one of: ' +
+                            Object.keys(this.detail_model_map).join(', '),
+                        got: model_used,
+                    });
+                }
                 
                 const model_input_cost = model_details.cost.input;
                 const model_output_cost = model_details.cost.output;


### PR DESCRIPTION
fix #1326 

For this request:

```
await fetch(`${puter.APIOrigin}/drivers/call`, {
    "headers": {
        "Content-Type": "application/json",
        "Authorization": `Bearer ${puter.authToken}`,
    },
    "body": JSON.stringify({
        interface: 'puter-chat-completion',
        method: 'complete',
        args: {
            model: 'abc',
            messages: ['this is my prompt']
        }        
    }),
    "method": "POST",
})
```

We will got an error message like this before this pr:

```
{"success":false,"error":"Cannot read properties of undefined (reading 'cost')"}
```

And we will get a more clear response with this pr:
```
{
    "success": false,
    "error": {
        "key": "model",
        "expected": "one of: gpt-4o, gpt-4o-mini, o1, o1-mini, o1-pro, o3, o3-mini, o4-mini, gpt-4.1, gpt-4.1-mini, gpt-4.1-nano, gpt-4.5-preview, fake, costly, abuse",
        "got": "abc",
        "code": "field_invalid",
        "$": "heyputer:api/APIError",
        "message": "Field `model` is invalid. Expected one of: gpt-4o, gpt-4o-mini, o1, o1-mini, o1-pro, o3, o3-mini, o4-mini, gpt-4.1, gpt-4.1-mini, gpt-4.1-nano, gpt-4.5-preview, fake, costly, abuse. Got abc.",
        "status": 400
    }
}
```