### PR TITLE
backend/ai: Better AI model name coercion in backend

### DIFF
--- a/src/backend/doc/api/spec.md
+++ b/src/backend/doc/api/spec.md
@@ -1,0 +1,35 @@
+# API Specification
+
+## AI Model Naming
+
+### Scope
+
+This rule applies to `model` field in AI-related API endpoints. Such as:
+
+- `puter-chat-completion/complete`
+
+### Request Format
+
+- interface (type: string, required) (`"puter-chat-completion"`)
+- method (type: string, required) (`"complete"`)
+- driver (type: string, optional) (`"ai-chat"` / `"openrouter"`)
+- args
+  - model (type: string, required) (e.g., `"gpt-4o"`, `"openai/gpt-4o"`, `"azure:openai/gpt-4o"`)
+  - messages (type: array, required)
+    - (e.g., `["Hello! How are you?"]`)
+    - (e.g., `[{ content: "Hello! How are you?" }]`)
+
+### Rule
+
+- 3 formats are allowed:
+  - `<model-name>` (e.g., `gpt-4o`)
+  - `<vendor>/<model-name>` (e.g., `openai/gpt-4o`)
+  - `<supplier>:<vendor>/<model-name>` (e.g., `azure:openai/gpt-4o`)
+-
+- All models have a vender name. But not all models have a supplier name.
+- When the supplier name is specified, the validation of the model name is done by the supplier instead of puter backend.
+- We should only initialize an AI service if the corresponding config is given.
+
+- Backend will pick a model when multiple candidates match the request. For instance, if a request specifies `gpt-4o`, the system will pick the most affordable model that matches `gpt-4o` from all available models.
+- Backend will return an error on invalid model names and invalid formats.
+- Available models are defined in this [list](https://puter.com/puterai/chat/models).


### PR DESCRIPTION
fix #1327 

# TODO

- [x] create api specification for model name
- [x] provide temporary fix for chat api
- [x] make the fix more reasonable and structured
- [x] fix ci failure

# Usage

The following commands have been tested manually in Chrome console:

```js
// =================================================================
// no driver + <model>
// =================================================================

await fetch(`${puter.APIOrigin}/drivers/call`, {
    "headers": {
        "Content-Type": "application/json",
        "Authorization": `Bearer ${puter.authToken}`,
    },
    "body": JSON.stringify({
        interface: 'puter-chat-completion',
        method: 'complete',
        args: {
            model: 'gpt-4o-mini',
            messages: ['this is my prompt']
        }        
    }),
    "method": "POST",
})

// =================================================================
// no driver + <vendor>/<model>
// =================================================================

await fetch(`${puter.APIOrigin}/drivers/call`, {
    "headers": {
        "Content-Type": "application/json",
        "Authorization": `Bearer ${puter.authToken}`,
    },
    "body": JSON.stringify({
        interface: 'puter-chat-completion',
        method: 'complete',
        args: {
            model: 'openai/gpt-4o-mini',
            messages: ['this is my prompt']
        }        
    }),
    "method": "POST",
})

// =================================================================
// no driver + <supplier>:<vendor>/<model>
// =================================================================

await fetch(`${puter.APIOrigin}/drivers/call`, {
    "headers": {
        "Content-Type": "application/json",
        "Authorization": `Bearer ${puter.authToken}`,
    },
    "body": JSON.stringify({
        interface: 'puter-chat-completion',
        method: 'complete',
        args: {
            model: 'openai:openai/gpt-4o-mini',
            messages: ['this is my prompt']
        }        
    }),
    "method": "POST",
})

// =================================================================
// driver + <vendor>/<model>
// =================================================================

await fetch(`${puter.APIOrigin}/drivers/call`, {
    "headers": {
        "Content-Type": "application/json",
        "Authorization": `Bearer ${puter.authToken}`,
    },
    "body": JSON.stringify({
        interface: 'puter-chat-completion',
        method: 'complete',
        driver: 'ai-chat',
        args: {
            model: 'openai/gpt-4o-mini',
            messages: ['this is my prompt']
        }        
    }),
    "method": "POST",
})

await fetch(`${puter.APIOrigin}/drivers/call`, {
    "headers": {
        "Content-Type": "application/json",
        "Authorization": `Bearer ${puter.authToken}`,
    },
    "body": JSON.stringify({
        interface: 'puter-chat-completion',
        method: 'complete',
        driver: 'openai-completion',
        args: {
            model: 'openai/gpt-4o-mini',
            messages: ['this is my prompt']
        }        
    }),
    "method": "POST",
})

await fetch(`${puter.APIOrigin}/drivers/call`, {
    "headers": {
        "Content-Type": "application/json",
        "Authorization": `Bearer ${puter.authToken}`,
    },
    "body": JSON.stringify({
        interface: 'puter-chat-completion',
        method: 'complete',
        driver: 'openrouter',
        args: {
            model: 'openai/gpt-4o-mini',
            messages: ['this is my prompt']
        }        
    }),
    "method": "POST",
})

await fetch(`${puter.APIOrigin}/drivers/call`, {
    "headers": {
        "Content-Type": "application/json",
        "Authorization": `Bearer ${puter.authToken}`,
    },
    "body": JSON.stringify({
        interface: 'puter-chat-completion',
        method: 'complete',
        driver: 'wrong-driver',
        args: {
            model: 'openai/gpt-4o-mini',
            messages: ['this is my prompt']
        }        
    }),
    "method": "POST",
})
```