### PR TITLE
aws/polly: add new apis to puter-js, add new args to txt2speech

### DIFF
--- a/src/backend/src/api/APIError.js
+++ b/src/backend/src/api/APIError.js
@@ -500,6 +500,12 @@ module.exports = class APIError {
             status: 400,
             message: ({ message }) => message || 'Invalid captcha response',
         },
+
+        // TTS Errors
+        'invalid_engine': {
+            status: 400,
+            message: ({ engine, valid_engines }) => `Invalid engine: ${quot(engine)}. Valid engines are: ${valid_engines.map(quot).join(', ')}.`,
+        },
     };
 
     /**

--- a/src/backend/src/modules/puterai/AIInterfaceService.js
+++ b/src/backend/src/modules/puterai/AIInterfaceService.js
@@ -126,7 +126,14 @@ class AIInterfaceService extends BaseService {
             methods: {
                 list_voices: {
                     description: 'List available voices.',
+                    parameters: {
+                        engine: { type: 'string', optional: true },
+                    },
+                },
+                list_engines: {
+                    description: 'List available TTS engines with pricing information.',
                     parameters: {},
+                    result: { type: 'json' },
                 },
                 synthesize: {
                     description: 'Synthesize speech from text.',
@@ -135,6 +142,7 @@ class AIInterfaceService extends BaseService {
                         voice: { type: 'string' },
                         language: { type: 'string' },
                         ssml: { type: 'flag' },
+                        engine: { type: 'string', optional: true },
                     },
                     result_choices: [
                         {


### PR DESCRIPTION
in response to https://github.com/HeyPuter/puter/issues/1334

There’s no convenient way to add tests for the backend or frontend right now, so I’ll leave testing as a long-term task.

# TODO
- [x] update puter-js api
- [x] backend logic

# API Changes
The api for `puter.ai.txt2speech` has been updated from:

   ```js
        // * ai.txt2speech('Hello, world!')
        // * ai.txt2speech('Hello, world!', 'en-US')
        // * ai.txt2speech('Hello, world!', 'en-US', 'Brian')
   ```
  
to:

   ```js
        // 1. Shorthand API
        //      puter.ai.txt2speech("Hello world")
        // 2. Verbose API
        //      puter.ai.txt2speech("Hello world", {
        //           voice: "Joanna",
        //           engine: "neural",
        //           language: "en-US"
        //      })
        // 3. Positional arguments (Legacy)
        //      puter.ai.txt2speech(<text>, <language>, <voice>, <engine>)
        //      e.g:
        //      puter.ai.txt2speech("Hello world", "en-US")
        //      puter.ai.txt2speech("Hello world", "en-US", "Joanna")
        //      puter.ai.txt2speech("Hello world", "en-US", "Joanna", "neural")
        // 
        // Undefined parameters will be set to default values:
        // - voice: "Joanna"
        // - engine: "standard"
        // - language: "en-US"
   ```

# Behaviour Changes

Original language-predict logic has been removed, puter-js will assume the text is english if no "language" specified.

# Usage

The following commands have been tested manually in Chrome console:

```js
// Shorthand API

(await puter.ai.txt2speech("Hello world")).play();

// Verbose API

(await puter.ai.txt2speech("Hello world", {
    voice: "Kimberly"
})).play();

(await puter.ai.txt2speech("Hello world", {
    voice: "Olivia",
    engine: "generative"
})).play();

(await puter.ai.txt2speech("Hello world", {
    voice: "Daniel",
    engine: "neural",
    language: "en-US"
})).play();

// Positional arguments (Legacy)

(await puter.ai.txt2speech("Hello world", "en-US")).play();
(await puter.ai.txt2speech("Hello world", "en-US", "Kimberly")).play();
(await puter.ai.txt2speech("Hello world", "en-US", "Daniel", "neural")).play();

// Meta-info API

await puter.ai.txt2speech.listEngines();
await puter.ai.txt2speech.listVoices();
await puter.ai.txt2speech.listVoices("generative");

// Meta-info API with wrong argument

await puter.ai.txt2speech.listVoices("wrong-engine");
```