### PR TITLE
mkdir: return 403 error for mkdir action in the root dir

### DIFF
--- a/src/backend/src/filesystem/hl_operations/hl_mkdir.js
+++ b/src/backend/src/filesystem/hl_operations/hl_mkdir.js
@@ -282,6 +282,7 @@ class HLMkdir extends HLFilesystemOperation {
             : await this._get_existing_top_parent({ top_parent: parent_node })
             ;
 
+        // TODO: this can be removed upon completion of: https://github.com/HeyPuter/puter/issues/1352
         if ( top_parent.isRoot ) {
             // root directory is read-only
             throw APIError.create('forbidden', null, {

--- a/src/backend/src/filesystem/hl_operations/hl_mkdir.js
+++ b/src/backend/src/filesystem/hl_operations/hl_mkdir.js
@@ -275,10 +275,19 @@ class HLMkdir extends HLFilesystemOperation {
         console.log('USING PARENT', parent_node.selector.describe());
         let target_basename = _path.basename(values.path);
 
+        // "top_parent" is the immediate parent of the target directory
+        // (e.g: /home/foo/bar -> /home/foo)
         const top_parent = values.create_missing_parents
             ? await this._create_top_parent({ top_parent: parent_node })
             : await this._get_existing_top_parent({ top_parent: parent_node })
             ;
+
+        if ( top_parent.isRoot ) {
+            // root directory is read-only
+            throw APIError.create('forbidden', null, {
+                message: 'Cannot create directories in the root directory.'
+            });
+        }
 
         // `parent_node` becomes the parent of the last directory name
         // specified under `path`.


### PR DESCRIPTION
fix: #1348 

This PR adds check in the "mkdir" logic.
Backend now throws a "403 forbidden" instead of "500 internal server error" when creating dir in the root.

This PR has been tested manually for the following cases:

```js
// return "403 forbiddend" error
puter.fs.mkdir('/foo')

// create successfully
//
// "/bold_toy_921/Videos" is a dir created automatically when running puter locally
puter.fs.mkdir('/bold_toy_921/Videos/foo')

// "readdir" should be able to see "foo" dir now
await puter.fs.readdir('/bold_toy_921/Videos/')
```