### PR TITLE
fs: ll_mkdir/write -> provider.mkdir/write

### DIFF
--- a/src/backend/src/filesystem/ll_operations/ll_mkdir.js
+++ b/src/backend/src/filesystem/ll_operations/ll_mkdir.js
@@ -32,7 +32,7 @@ class LLMkdir extends LLFilesystemOperation {
 
     async _run () {
         const { parent, name, immutable } = this.values;
-        return parent.provider.mkdir({
+        return await parent.provider.mkdir({
             context: this.context,
             parent,
             name,

--- a/src/backend/src/modules/puterfs/lib/PuterFSProvider.js
+++ b/src/backend/src/modules/puterfs/lib/PuterFSProvider.js
@@ -32,11 +32,20 @@ const { ParallelTasks } = require('../../../util/otelutil');
 const { TYPE_DIRECTORY } = require('../../../filesystem/FSNodeContext');
 const APIError = require('../../../api/APIError');
 const { MODE_WRITE } = require('../../../services/fs/FSLockService');
+const { DB_WRITE } = require('../../../services/database/consts');
+const { stuck_detector_stream, hashing_stream } = require('../../../util/streamutil');
+
+const crypto = require('crypto');
+const { OperationFrame } = require('../../../services/OperationTraceService');
+
+const STUCK_STATUS_TIMEOUT = 10 * 1000;
+const STUCK_ALARM_TIMEOUT = 20 * 1000;
 
 class PuterFSProvider extends putility.AdvancedBase {
     static MODULES = {
         _path: require('path'),
         uuidv4: require('uuid').v4,
+        config: require('../../../config.js'),
     }
 
     get_capabilities () {
@@ -516,6 +525,325 @@ class PuterFSProvider extends putility.AdvancedBase {
         } finally {
             await lock_handle.unlock();
         }
+    }
+
+    /**
+     * Write a new file to the filesystem. Throws an error if the destination
+     * already exists.
+     * 
+     * @param {Object} param
+     * @param {Context} param.context
+     * @param {FSNode} param.parent: The parent directory of the file.
+     * @param {string} param.name: The name of the file.
+     * @param {File} param.file: The file to write.
+     * @returns {Promise<FSNode>}
+     */
+    async write_new({context, parent, name, file}) {
+        const { _path, uuidv4, config } = this.modules;
+
+        const {
+            tmp, fsentry_tmp, message, actor: actor_let, app_id,
+        } = context.values;
+        let actor = actor_let ?? Context.get('actor');
+
+        const svc = Context.get('services');
+        const sizeService = svc.get('sizeService');
+        const resourceService = svc.get('resourceService');
+        const svc_fsEntry = svc.get('fsEntryService');
+        const svc_event = svc.get('event');
+        const fs = svc.get('filesystem');
+
+        // TODO: fs:decouple-versions
+        //       add version hook externally so LLCWrite doesn't
+        //       need direct database access
+        const db = svc.get('database').get(DB_WRITE, 'filesystem');
+
+        const uid = uuidv4();
+
+        // determine bucket region
+        let bucket_region = config.s3_region ?? config.region;
+        let bucket = config.s3_bucket;
+
+        const svc_acl = context.get('services').get('acl');
+        if ( ! await svc_acl.check(actor, parent, 'write') ) {
+            throw await svc_acl.get_safe_acl_error(actor, parent, 'write');
+        }
+
+        const storage_resp = await this._storage_upload({
+            uuid: uid,
+            bucket, bucket_region, file,
+            tmp: {
+                ...tmp,
+                path: _path.join(await parent.get('path'), name),
+            }
+        });
+
+        fsentry_tmp.thumbnail = await fsentry_tmp.thumbnail_promise;
+        delete fsentry_tmp.thumbnail_promise;
+
+        const ts = Math.round(Date.now() / 1000);
+        const raw_fsentry = {
+            uuid: uid,
+            is_dir: 0,
+            user_id: actor.type.user.id,
+            created: ts,
+            accessed: ts,
+            modified: ts,
+            parent_uid: await parent.get('uid'),
+            name,
+            size: file.size,
+            path: _path.join(await parent.get('path'), name),
+            ...fsentry_tmp,
+
+            bucket_region,
+            bucket,
+
+            associated_app_id: app_id ?? null,
+        };
+
+        svc_event.emit('fs.pending.file', {
+            fsentry: FSNodeContext.sanitize_pending_entry_info(raw_fsentry),
+            context,
+        })
+
+        resourceService.register({
+            uid,
+            status: RESOURCE_STATUS_PENDING_CREATE,
+        });
+
+        const filesize = file.size;
+        sizeService.change_usage(actor.type.user.id, filesize);
+
+        const entryOp = await svc_fsEntry.insert(raw_fsentry);
+
+        (async () => {
+            await entryOp.awaitDone();
+            resourceService.free(uid);
+
+            const new_item_node = await fs.node(new NodeUIDSelector(uid));
+            const new_item = await new_item_node.get('entry');
+            const store_version_id = storage_resp.VersionId;
+            if( store_version_id ){
+                // insert version into db
+                db.write(
+                    "INSERT INTO `fsentry_versions` (`user_id`, `fsentry_id`, `fsentry_uuid`, `version_id`, `message`, `ts_epoch`) VALUES (?, ?, ?, ?, ?, ?)",
+                    [
+                        actor.type.user.id,
+                        new_item.id,
+                        new_item.uuid,
+                        store_version_id,
+                        message ?? null,
+                        ts,
+                    ]
+                );
+        }
+        })();
+
+        const node = await fs.node(new NodeUIDSelector(uid));
+
+        svc_event.emit('fs.create.file', {
+            node,
+            context,
+        });
+
+        return node;
+    }
+
+    /**
+     * Overwrite an existing file. Throws an error if the destination does not
+     * exist.
+     * 
+     * @param {Object} param
+     * @param {Context} param.context
+     * @param {FSNode} param.node: The node to write to.
+     * @param {File} param.file: The file to write.
+     * @returns {Promise<FSNode>}
+     */
+    async write_overwrite({ context, node, file }) {
+        const {
+            tmp, fsentry_tmp, message, actor: actor_let
+        } = context.values;
+        let actor = actor_let ?? Context.get('actor');
+
+        const svc = Context.get('services');
+        const sizeService = svc.get('sizeService');
+        const resourceService = svc.get('resourceService');
+        const svc_fsEntry = svc.get('fsEntryService');
+        const svc_event = svc.get('event');
+
+        // TODO: fs:decouple-versions
+        //       add version hook externally so LLCWrite doesn't
+        //       need direct database access
+        const db = svc.get('database').get(DB_WRITE, 'filesystem');
+
+        const svc_acl = context.get('services').get('acl');
+        if ( ! await svc_acl.check(actor, node, 'write') ) {
+            throw await svc_acl.get_safe_acl_error(actor, node, 'write');
+        }
+
+        const uid = await node.get('uid');
+
+        const bucket_region = node.entry.bucket_region;
+        const bucket = node.entry.bucket;
+
+        const state_upload = await this._storage_upload({
+            uuid: node.entry.uuid,
+            bucket, bucket_region, file,
+            tmp: {
+                ...tmp,
+                path: await node.get('path'),
+            }
+        });
+
+        if ( fsentry_tmp?.thumbnail_promise ) {
+            fsentry_tmp.thumbnail = await fsentry_tmp.thumbnail_promise;
+            delete fsentry_tmp.thumbnail_promise;
+        }
+
+        const ts = Math.round(Date.now() / 1000);
+        const raw_fsentry_delta = {
+            modified: ts,
+            accessed: ts,
+            size: file.size,
+            ...fsentry_tmp,
+        };
+
+        resourceService.register({
+            uid,
+            status: RESOURCE_STATUS_PENDING_CREATE,
+        });
+
+        const filesize = file.size;
+        sizeService.change_usage(actor.type.user.id, filesize);
+
+        const entryOp = await svc_fsEntry.update(uid, raw_fsentry_delta);
+
+        // depends on fsentry, does not depend on S3
+        (async () => {
+            await entryOp.awaitDone();
+            resourceService.free(uid);
+        })();
+
+        state_upload.post_insert({
+            db, user: actor.type.user, node, uid, message, ts,
+        });
+
+        const svc_fileCache = context.get('services').get('file-cache');
+        await svc_fileCache.invalidate(node);
+
+        svc_event.emit('fs.write.file', {
+            node,
+            context,
+        });
+
+        return node;
+    }
+
+
+    async _storage_upload ({
+        uuid,
+        bucket, bucket_region, file,
+        tmp,
+    }) {
+        const { config } = this.modules;
+
+        const svc = Context.get('services');
+        const log = svc.get('log-service').create('fs._storage_upload');
+        const errors = svc.get('error-service').create(log);
+        const svc_event = svc.get('event');
+
+        const svc_mountpoint = svc.get('mountpoint');
+        const storage = svc_mountpoint.get_storage();
+
+        bucket        ??= config.s3_bucket;
+        bucket_region ??= config.s3_region ?? config.region;
+
+        let upload_tracker = new UploadProgressTracker();
+
+        svc_event.emit('fs.storage.upload-progress', {
+            upload_tracker,
+            context: Context.get(),
+            meta: {
+                item_uid: uuid,
+                item_path: tmp.path,
+            }
+        })
+
+        if ( ! file.buffer ) {
+            let stream = file.stream;
+            let alarm_timeout = null;
+            stream = stuck_detector_stream(stream, {
+                timeout: STUCK_STATUS_TIMEOUT,
+                on_stuck: () => {
+                    this.frame.status = OperationFrame.FRAME_STATUS_STUCK;
+                    log.warn('Upload stream stuck might be stuck', {
+                        bucket_region,
+                        bucket,
+                        uuid,
+                    });
+                    alarm_timeout = setTimeout(() => {
+                        errors.report('fs.write.s3-upload', {
+                            message: 'Upload stream stuck for too long',
+                            alarm: true,
+                            extra: {
+                                bucket_region,
+                                bucket,
+                                uuid,
+                            },
+                        });
+                    }, STUCK_ALARM_TIMEOUT);
+                },
+                on_unstuck: () => {
+                    clearTimeout(alarm_timeout);
+                    this.frame.status = OperationFrame.FRAME_STATUS_WORKING;
+                }
+            });
+            file = { ...file, stream, };
+        }
+
+        let hashPromise;
+        if ( file.buffer ) {
+            const hash = crypto.createHash('sha256');
+            hash.update(file.buffer);
+            hashPromise = Promise.resolve(hash.digest('hex'));
+        } else {
+            const hs = hashing_stream(file.stream);
+            file.stream = hs.stream;
+            hashPromise = hs.hashPromise;
+        }
+
+        hashPromise.then(hash => {
+            const svc_event = Context.get('services').get('event');
+            console.log('\x1B[36;1m[fs.write]', uuid, hash);
+            svc_event.emit('outer.fs.write-hash', {
+                hash, uuid,
+            });
+        });
+
+        const state_upload = storage.create_upload();
+
+        try {
+            await state_upload.run({
+                uid: uuid,
+                file,
+                storage_meta: { bucket, bucket_region },
+                storage_api: { progress_tracker: upload_tracker },
+            });
+        } catch (e) {
+            errors.report('fs.write.storage-upload', {
+                source: e || new Error('unknown'),
+                trace: true,
+                alarm: true,
+                extra: {
+                    bucket_region,
+                    bucket,
+                    uuid,
+                },
+            });
+            throw APIError.create('upload_failed');
+        }
+
+        return state_upload;
     }
 }
 

--- a/src/backend/src/modules/web/lib/eggspress.js
+++ b/src/backend/src/modules/web/lib/eggspress.js
@@ -179,7 +179,18 @@ module.exports = function eggspress (route, settings, handler) {
         });
       } else await handler(req, res, next);
     } catch (e) {
-        api_error_handler(e, req, res, next);
+        if (e instanceof TypeError || e instanceof ReferenceError) {
+          // We add a dedicated branch for TypeError/ReferenceError since it usually
+          // indicates a bug in the backend. And it's pretty convenient to debug if we
+          // set a breakpoint here.
+          //
+          // Typical TypeError:
+          // - read properties of undefined
+          console.error(e);
+          api_error_handler(e, req, res, next);
+        } else {
+          api_error_handler(e, req, res, next);
+        }
     }
   };
 

--- a/tools/api-tester/lib/TestRegistry.js
+++ b/tools/api-tester/lib/TestRegistry.js
@@ -19,6 +19,11 @@ module.exports = class TestRegistry {
     }
 
     async run_all_tests(suiteName) {
+        // check if "suiteName" is valid
+        if (suiteName && !Object.keys(this.tests).includes(suiteName)) {
+            throw new Error(`Suite not found: ${suiteName}, valid suites are: ${Object.keys(this.tests).join(', ')}`);
+        }
+
         for ( const id in this.tests ) {
             if (suiteName && id !== suiteName) {
                 continue;

--- a/tools/api-tester/tests/fsentry.js
+++ b/tools/api-tester/tests/fsentry.js
@@ -74,7 +74,6 @@ const verify_fsentry = async (t, o) => {
         });
         await t.case('owner object has expected properties', () => {
             expect(o.owner).to.haveOwnProperty('username');
-            expect(o.owner).to.haveOwnProperty('email');
         });
     })
 }


### PR DESCRIPTION
this is a task related to #1354

I moved the mkdir/write logic from `ll_mkdir.js`/`ll_write.js` to `PuterFSProvider.js` with minimal changes.

# Test

This PR also passed all the apitest since it's based on #1376 