### PR TITLE
puter.js & gui changes required for cool app

### DIFF
--- a/src/gui/src/IPC.js
+++ b/src/gui/src/IPC.js
@@ -1315,6 +1315,13 @@ const ipc_listener = async (event, handled) => {
             $(el_filedialog_window).close();
             window.show_save_account_notice_if_needed();
         };
+
+        const tell_caller_its_cancelled = async () => {
+            target_iframe.contentWindow.postMessage({
+                msg: "fileSaveCancelled", 
+                original_msg_id: msg_id, 
+            }, '*');
+        };
         
         const write_file_tell_caller_and_update_views = async ({
             target_path, el_filedialog_window,
@@ -1468,6 +1475,7 @@ const ipc_listener = async (event, handled) => {
             iframe_msg_uid: msg_id,
             center: true,
             initiating_app_uuid: app_uuid,
+            onDialogCancel: () => tell_caller_its_cancelled(),
             onSaveFileDialogSave: async function(target_path, el_filedialog_window){
                 $(el_filedialog_window).find('.window-disable-mask, .busy-indicator').show();
                 let busy_init_ts = Date.now();

--- a/src/gui/src/IPC.js
+++ b/src/gui/src/IPC.js
@@ -437,6 +437,12 @@ const ipc_listener = async (event, handled) => {
             path: '/' + window.user.username + '/Desktop',
             // this is the uuid of the window to which this dialog will return
             parent_uuid: event.data.appInstanceID,
+            onDialogCancel: () => {
+                target_iframe.contentWindow.postMessage({
+                    msg: "fileOpenCancelled", 
+                    original_msg_id: msg_id, 
+                }, '*');
+            },
             show_maximize_button: false,
             show_minimize_button: false,
             title: 'Open',

--- a/src/gui/src/UI/UIWindow.js
+++ b/src/gui/src/UI/UIWindow.js
@@ -896,6 +896,7 @@ async function UIWindow(options) {
                 $(`.window[data-element_uuid="${options.parent_uuid}"]`).find('.window-disable-mask').hide();
                 $(el_window).close();
             })
+            if ( options.onDialogCancel ) options.onDialogCancel.call(el_window);
         })
     }
 

--- a/src/gui/src/helpers/launch_app.js
+++ b/src/gui/src/helpers/launch_app.js
@@ -201,6 +201,7 @@ const launch_app = async (options)=>{
 
         // add app_id to URL
         iframe_url.searchParams.append('puter.app.id', app_info.uuid);
+        iframe_url.searchParams.append('puter.app.name', app_info.name);
 
         // add parent_app_instance_id to URL
         if (options.parent_instance_id) {
@@ -209,7 +210,7 @@ const launch_app = async (options)=>{
 
         if(file_signature){
             iframe_url.searchParams.append('puter.item.uid', file_signature.uid);
-            iframe_url.searchParams.append('puter.item.path', privacy_aware_path(options.file_path) || file_signature.path);
+            iframe_url.searchParams.append('puter.item.path', options.file_path ? privacy_aware_path(options.file_path) : file_signature.path);
             iframe_url.searchParams.append('puter.item.name', file_signature.fsentry_name);
             iframe_url.searchParams.append('puter.item.read_url', file_signature.read_url);
             iframe_url.searchParams.append('puter.item.write_url', file_signature.write_url);

--- a/src/gui/src/services/ExecService.js
+++ b/src/gui/src/services/ExecService.js
@@ -48,7 +48,7 @@ export class ExecService extends Service {
     }
     
     // This method is exposed to apps via IPCService.
-    async launchApp ({ app_name, args, pseudonym, file_paths }, { ipc_context, msg_id } = {}) {
+    async launchApp ({ app_name, args, pseudonym, file_paths, items }, { ipc_context, msg_id } = {}) {
         const app = ipc_context?.caller?.app;
         const process = ipc_context?.caller?.process;
 
@@ -81,6 +81,13 @@ export class ExecService extends Service {
                 parent_pseudo_id: connection.backward.uuid,
             } : {}),
         };
+        
+        if ( items && items.length ) {
+            if ( items.length > 1 ) {
+                console.warn('launchApp does not support launch with multiple items (yet)');
+            }
+            launch_options.file_signature = items[0];
+        }
 
         // Check if file_paths are provided and caller has godmode permissions
         if (file_paths && Array.isArray(file_paths) && file_paths.length > 0 && process) {

--- a/src/puter-js/src/index.js
+++ b/src/puter-js/src/index.js
@@ -215,6 +215,11 @@ export default globalThis.puter = (function() {
             if(URLParams.has('puter.app.id')){
                 this.appID = decodeURIComponent(URLParams.get('puter.app.id'));
             }
+            
+            // Extract app name (added later)
+            if(URLParams.has('puter.app.name')){
+                this.appName = decodeURIComponent(URLParams.get('puter.app.name'));
+            }
 
             // Construct this App's AppData path based on the appID. AppData path is used to store files that are specific to this app.
             // The default AppData path is `~/AppData/<appID>`.

--- a/src/puter-js/src/modules/FileSystem/index.js
+++ b/src/puter-js/src/modules/FileSystem/index.js
@@ -15,6 +15,7 @@ import symlink from './operations/symlink.js';
 // a reserved keyword in javascript
 import deleteFSEntry from "./operations/deleteFSEntry.js";
 import { AdvancedBase } from '../../../../putility/index.js';
+import FSItem from '../FSItem.js';
 
 export class PuterJSFileSystemModule extends AdvancedBase {
 
@@ -31,6 +32,8 @@ export class PuterJSFileSystemModule extends AdvancedBase {
     write = write;
     sign = sign;
     symlink = symlink;
+    
+    FSItem = FSItem
 
     static NARI_METHODS = {
         stat: {

--- a/src/puter-js/src/modules/UI.js
+++ b/src/puter-js/src/modules/UI.js
@@ -735,13 +735,14 @@ class UI extends EventListener {
                 type = 'url';
             }
             const url = type === 'url' ? content.toString() : undefined;
-            const source_path = type === 'move' ? content : undefined;
-
+            const source_path = ['move','copy'].includes(type) ? content : undefined;
+            
             if(this.env === 'app'){
                 this.messageTarget?.postMessage({
                     msg: "showSaveFilePicker",
                     appInstanceID: this.appInstanceID,
                     content: url ? undefined : content,
+                    save_type: type,
                     url,
                     source_path,
                     suggestedName: suggestedName ?? '',

--- a/src/puter-js/src/modules/UI.js
+++ b/src/puter-js/src/modules/UI.js
@@ -1072,9 +1072,18 @@ class UI extends EventListener {
     }
 
     // Returns a Promise<AppConnection>
-    launchApp = async function launchApp(app_name, args, callback) {
+    /**
+     * launchApp opens the specified app in Puter with the specified argumets.
+     * @param {*} nameOrOptions - name of the app as a string, or an options object
+     * @param {*} args - named parameters that will be passed to the app as arguments
+     * @param {*} callback - in case you don't want to use `await` or `.then()`
+     * @returns 
+     */
+    launchApp = async function launchApp(nameOrOptions, args, callback) {
         let pseudonym = undefined;
         let file_paths = undefined;
+        let items = undefined;
+        let app_name = nameOrOptions; // becomes string after branch below
         
         // Handle case where app_name is an options object
         if (typeof app_name === 'object' && app_name !== null) {
@@ -1084,17 +1093,31 @@ class UI extends EventListener {
             args = args || options.args;
             callback = callback || options.callback;
             pseudonym = options.pseudonym;
+            items = options.items;
+        }
+        
+        if ( items ) {
+            if ( ! Array.isArray(items) ) items = [];
+            for ( let i=0 ; i < items.length ; i++ ) {
+                if ( items[i] instanceof FSItem ) {
+                    items[i] = items[i]._internalProperties.file_signature;
+                }
+            }
         }
         
         if ( app_name && app_name.includes('#(as)') ) {
             [app_name, pseudonym] = app_name.split('#(as)');
         }
+        
+        if ( ! app_name ) app_name = puter.appName;
+        
         const app_info = await this.#ipc_stub({
             method: 'launchApp',
             callback,
             parameters: {
                 app_name,
                 file_paths,
+                items,
                 pseudonym,
                 args,
             },

--- a/src/puter-js/src/modules/UI.js
+++ b/src/puter-js/src/modules/UI.js
@@ -4,6 +4,7 @@ import EventListener  from '../lib/EventListener.js';
 import putility from '@heyputer/putility';
 
 const FILE_SAVE_CANCELLED = Symbol('FILE_SAVE_CANCELLED');
+const FILE_OPEN_CANCELLED = Symbol('FILE_OPEN_CANCELLED');
 
 // AppConnection provides an API for interacting with another app.
 // It's returned by UI methods, and cannot be constructed directly by user code.
@@ -474,6 +475,10 @@ class UI extends EventListener {
                     // execute callback
                     this.#callbackFunctions[e.data.original_msg_id](FILE_SAVE_CANCELLED);
                 }
+                else if(e.data.msg === "fileOpenCancelled"){
+                    // execute callback
+                    this.#callbackFunctions[e.data.original_msg_id](FILE_OPEN_CANCELLED);
+                }
                 else{
                     // execute callback
                     this.#callbackFunctions[e.data.original_msg_id](e.data);
@@ -691,7 +696,8 @@ class UI extends EventListener {
     }
 
     showOpenFilePicker = function(options, callback){
-        return new Promise((resolve, reject) => {
+        const undefinedOnCancel = new putility.libs.promise.TeePromise();
+        const resolveOnlyPromise = new Promise((resolve, reject) => {
             if (!globalThis.open) {
                 return reject("This API is not compatible in Web Workers.");
             }
@@ -716,8 +722,18 @@ class UI extends EventListener {
                 'toolbar=no, location=no, directories=no, status=no, menubar=no, scrollbars=no, resizable=no, copyhistory=no, width='+w+', height='+h+', top='+top+', left='+left);
             }
             //register callback
-            this.#callbackFunctions[msg_id] = resolve;
+            this.#callbackFunctions[msg_id] = (maybe_result) => {
+                // Only resolve cancel events if this was called with `.undefinedOnCancel`
+                if ( maybe_result === FILE_OPEN_CANCELLED ) {
+                    undefinedOnCancel.resolve(undefined);
+                    return;
+                }
+                undefinedOnCancel.resolve(maybe_result);
+                resolve(maybe_result);
+            };
         })
+        resolveOnlyPromise.undefinedOnCancel = undefinedOnCancel;
+        return resolveOnlyPromise;
     }
 
     showFontPicker = function(options){


### PR DESCRIPTION
### add copy mode to `puter.ui.showSaveFilePicker()`

Adds a 'copy' mode to showSaveFilePicker. In this mode, a source file is copied to the target file. The file may not exist in another apps AppData directory. Unlike the 'move' mode, the file can be outside of the app's AppData directory (a "user" file); in this situation the user will be prompted to grant permission for the copy action. The app will have access to the newly-created copy.

### add `.undefinedOnCancel` to showSaveFilePicker

If you call `await puter.ui.showSaveFilePicker` and the user decides to cancel, the call just hangs (the Promise never settles). That really sucks, but fixing it would be a puter.js regression and that sucks even more. The special `.undefinedOnCancel` property attached to the returned promise allows a more sensible behavior where the promise resolves to `undefined` if the user clicks cancel:

```javascript
const result = await puter.ui.showSaveFilePicker().undefinedOnCancel;
// result might be `undefined` or a filesystem item.
```

### make it possible to pass signed files to `puter.ui.launchApp()`

It previously wasn't possible to implement behaviors such as "open a new instance of the app when a file is dragged on it". A commit in this PR adds the necessary changes to make this possible.