### PR TITLE
feat: add 'path' option to showOpenFileDialog

### DIFF
--- a/src/gui/src/IPC.js
+++ b/src/gui/src/IPC.js
@@ -432,9 +432,13 @@ const ipc_listener = async (event, handled) => {
             is_selectable_body = true;
 
         // Open dialog
+        let path = event.data.options?.path ??  '/' + window.user.username + '/Desktop';
+        if ( path.toLowerCase() === '%appdata%' ) {
+            path = '/' + window.user.username + '/AppData/' + app_uuid;
+        }
         UIWindow({
             allowed_file_types: allowed_file_types,
-            path: '/' + window.user.username + '/Desktop',
+            path,
             // this is the uuid of the window to which this dialog will return
             parent_uuid: event.data.appInstanceID,
             onDialogCancel: () => {

--- a/src/gui/src/IPC.js
+++ b/src/gui/src/IPC.js
@@ -433,8 +433,10 @@ const ipc_listener = async (event, handled) => {
 
         // Open dialog
         let path = event.data.options?.path ??  '/' + window.user.username + '/Desktop';
-        if ( path.toLowerCase() === '%appdata%' ) {
-            path = '/' + window.user.username + '/AppData/' + app_uuid;
+        if ( (''+path).toLowerCase().startsWith('%appdata%') ) {
+            path = path.slice('%appdata%'.length);
+            if ( path !== '' && ! path.startsWith('/') ) path = '/' + path;
+            path = '/' + window.user.username + '/AppData/' + app_uuid + path;
         }
         UIWindow({
             allowed_file_types: allowed_file_types,


### PR DESCRIPTION
This commit adds a 'path' option to showOpenFileDialog by supporting it in the relevant conditional block in IPC.js. A special path "%appdata%", which would otherwise produce an error in the file explorer (so no conflict is possible), will resolve to the appdata directory of the current app.

Example usage:
```javascript
await puter.ui.showOpenFilePicker({
  accept: ['.proj'],
  path: '%appdata%/projects',
});
```