### PR TITLE
fix wrong return value on file cache service

### DIFF
--- a/src/backend/src/services/file-cache/FileCacheService.js
+++ b/src/backend/src/services/file-cache/FileCacheService.js
@@ -196,7 +196,7 @@ class FileCacheService extends AdvancedBase {
         // If the file is still in pending it means we waited too long;
         // it's possible that reading the file failed is is delayed.
         if ( tracker.phase === FileTracker.PHASE_PENDING ) {
-            return this._get_path(await fsNode.get('uid'));
+            return null;
         }
 
         // Since we waited for the file to be ready, it's not impossible


### PR DESCRIPTION
fix #1397

It's tricky to write a dedicate unit test for the issue, but the bug is simple: `try_get_` return a **file path** in some cases when the **file content** is expected.

Wrong code:
https://github.com/HeyPuter/puter/blob/1e720a7aca36a358490cc158209c1f9abc89daac/src/backend/src/services/file-cache/FileCacheService.js#L196-L200

Expected return value:
https://github.com/HeyPuter/puter/blob/1e720a7aca36a358490cc158209c1f9abc89daac/src/backend/src/services/file-cache/FileCacheService.js#L166