### PR TITLE
captcha: add captcha widget to the signup window

### DIFF
--- a/doc/RFCS/20250826_captcha.md
+++ b/doc/RFCS/20250826_captcha.md
@@ -1,0 +1,57 @@
+- Feature Name: Cloudflare Turnstile CAPTCHA
+- Status: In Progress
+- Created: 2025-08-26
+
+## Summary
+
+We propose integrating **Cloudflare Turnstile** to protect our signup flow against automated bot activity, while maintaining a seamless experience for legitimate users.
+
+## Motivation
+
+Puter allocates resources to **free** user account — including storage, compute, and AI credits. To prevent these from being exploited by bots, we need a more robust verification mechanism. Although Puter currently includes a [custom CAPTCHA service](https://github.com/HeyPuter/puter/blob/4c3a68ee51a1b255edbe6b3c7e4c4e3b0394dae3/src/backend/src/modules/captcha/services/CaptchaService.js), it has several shortcomings:
+
+* The text-recognition CAPTCHA creates friction and disrupts the user experience.
+* Maintaining a token pool is resource-intensive and doesn’t scale well. The validation logic also requires ongoing maintenance within the codebase.
+
+## Choose of Service Provider
+
+We choose Cloudflare Turnstile since:
+
+* It's free for unlimited use.
+* It's easy to integrate.
+* It's relative secure.
+
+Here's a comparison of major CAPTCHA providers:
+
+| Provider                                                  | Security (typical)                                                             | User experience (typical)                                                               | Price (publicly listed)                                                                                                                                |
+| --------------------------------------------------------- | ------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Cloudflare Turnstile**                                  | **High** for most sites; adaptive challenges; works without image puzzles.     | **Excellent** (can be fully invisible or auto-verify; checkbox only for risky traffic). | **Free for everyone (unlimited use)**. ([The Cloudflare Blog][1], [cloudflare.com][2])                                                                 |
+| **Google reCAPTCHA (Essentials / Standard / Enterprise)** | **Medium–High** (v3 score + server rules; Enterprise adds features & support). | **Good–OK** (v3 is invisible; v2 can show puzzles).                                     | **Free up to 10k assessments/mo; \$8 for up to 100k/mo; then \$1 per 1k** (Enterprise tiers). ([Google Cloud][3])                                      |
+| **hCaptcha (Basic / Pro / Enterprise)**                   | **High** (ML signals; enterprise options).                                     | **Good** on Basic; **Very good** on Pro with “low-friction 99.9% passive mode.”         | **Basic: Free. Pro: \$99/mo annual (\$139 month-to-month) incl. 100k evals, then \$0.99/1k**; Enterprise custom. ([hcaptcha.com][4])                   |
+| **Friendly Captcha**                                      | **Medium–High** (proof-of-work + risk signals).                                | **Excellent** (invisible/automatic challenge; no image tasks).                          | **Starter €9/mo (1k req/mo); Growth €39/mo (5k/mo); Advanced €200/mo (50k/mo); Free non-commercial 1k/mo**; Enterprise custom. ([Friendly Captcha][5]) |
+| **Arkose Labs (FunCaptcha / MatchKey)**                   | **Very High** (step-up, anti-farm, enterprise focus).                          | **Good–OK** (challenge can be more involved when risk is high).                         | **Enterprise pricing (contact sales)**; publicly not listed. (Product overview only.) ([Arkose Labs][6])                                               |
+
+[1]: https://blog.cloudflare.com/turnstile-ga/?utm_source=chatgpt.com "Cloudflare is free of CAPTCHAs; Turnstile is free for everyone"
+[2]: https://www.cloudflare.com/application-services/products/turnstile/?utm_source=chatgpt.com "Cloudflare Turnstile | CAPTCHA Replacement Solution"
+[3]: https://cloud.google.com/recaptcha/docs/compare-tiers?utm_source=chatgpt.com "Compare features between reCAPTCHA tiers"
+[4]: https://www.hcaptcha.com/pricing?utm_source=chatgpt.com "Pricing"
+[5]: https://friendlycaptcha.com/ "Friendly Captcha - Privacy-First Bot Protection"
+[6]: https://www.arkoselabs.com/arkose-matchkey/?utm_source=chatgpt.com "Arkose MatchKey Advanced CAPTCHA Software"
+
+## Implementation
+
+### Signup Flow
+
+When a user submits the signup form, the client will include a **Turnstile token** alongside the other form data.
+On the backend, Puter will call the **Cloudflare Turnstile verification API** to validate this token before provisioning a new account.
+
+Only if the token is verified as valid will the signup request be processed. Invalid or missing tokens will result in a rejected signup attempt.
+
+### Desktop Rendering
+
+TODO
+
+## Configuration
+
+TODO
+

--- a/src/backend/src/services/PuterHomepageService.js
+++ b/src/backend/src/services/PuterHomepageService.js
@@ -166,6 +166,8 @@ class PuterHomepageService extends BaseService {
                 co_isolation_enabled: req.co_isolation_enabled,
                 // Add captcha requirements to GUI parameters
                 captchaRequired: captchaRequired,
+                // Add Turnstile site key to GUI parameters
+                turnstileSiteKey: config.services?.['cloudflare-turnstile']?.site_key,
             },
         }));
     }

--- a/src/gui/src/index.js
+++ b/src/gui/src/index.js
@@ -78,6 +78,9 @@ window.gui = async (options) => {
         await window.loadCSS('/dist/bundle.min.css');
     }
 
+    // Load Cloudflare Turnstile script
+    await window.loadScript('https://challenges.cloudflare.com/turnstile/v0/api.js', { defer: true });
+
     // 🚀 Launch the GUI 🚀
     window.initgui(options);
 }

--- a/tools/api-tester/tests/__entry__.js
+++ b/tools/api-tester/tests/__entry__.js
@@ -1,4 +1,12 @@
 module.exports = registry => {
+    // ======================================================================
+    // Auth
+    // ======================================================================
+    registry.add_test('auth', require('./auth'));
+
+    // ======================================================================
+    // File System
+    // ======================================================================
     registry.add_test('write_cart', require('./write_cart'));
     registry.add_test('move_cart', require('./move_cart'));
     registry.add_test('copy_cart', require('./copy_cart'));

--- a/tools/api-tester/tests/auth.js
+++ b/tools/api-tester/tests/auth.js
@@ -1,0 +1,28 @@
+const axios = require('axios');
+
+module.exports = {
+    name: 'auth',
+    do: async t => {
+        await t.case('signup', async () => {
+            const endpoint = 'signup';
+            const params = {
+                username: 'test',
+                password: 'test',
+            };
+            const res = await axios.request({
+                httpsAgent: this.httpsAgent,
+                method: 'post',
+                url: t.getURL(endpoint),
+                data: params,
+                headers: {
+                    ...t.headers_,
+                    'Content-Type': 'application/json',
+                    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36',
+                }
+            })
+            console.log('res.status:', res?.status);
+            console.log('res.statusText:', res?.statusText);
+            console.log('res.data:', res?.data);
+        });
+    },
+};


### PR DESCRIPTION
This PR introduce **Cloudflare Turnstile** on signup window to prevent the abuse of free account.

How to use:
1. Create a "widget" at Cloudflare's Turnstile panel.
2. Add following config to `volatile/config/config.json`:

```json
{
    "services": {
        ...
        "cloudflare-turnstile": {
            "enabled": true,
            "site_key": "<your site key>",
            "secret_key": "<your secret key"
        }
    },
    ...
}
```

Then the user will be validated by Cloudflare Turnstile during signup.

## TODO

- [ ] Test the signup without "cloudflare-turnstile" config.
- [ ] Test "invisible" verification mode.
- [ ] Write the instruction for Cloudflare Turnstile's best practice.