### PR TITLE
feat(UI): Differentiate tablet UI based on pointer capabilities

### DIFF
--- a/src/gui/src/initgui.js
+++ b/src/gui/src/initgui.js
@@ -374,12 +374,28 @@ window.initgui = async function(options){
     // Checks the type of device the user is on (phone, tablet, or desktop).
     // Depending on the device type, it sets a class attribute on the body tag
     // to style or script the page differently for each device type.
-    if(isMobile.phone)
+    
+    // if(isMobile.phone)
+    //     $('body').attr('class', 'device-phone');
+    // else if(isMobile.tablet)
+    //     $('body').attr('class', 'device-tablet');
+    // else
+    //     $('body').attr('class', 'device-desktop');
+
+    if (isMobile.phone) {
         $('body').attr('class', 'device-phone');
-    else if(isMobile.tablet)
-        $('body').attr('class', 'device-tablet');
-    else
+    } else if (isMobile.tablet) {
+        // This is our new, smarter check for tablets
+        if (window.matchMedia('(hover: hover)').matches) {
+            // The user has a mouse/trackpad, so give them the desktop UI
+            $('body').attr('class', 'device-desktop');
+        } else {
+            // The user is on a touch-only tablet, so give them the mobile UI
+            $('body').attr('class', 'device-tablet');
+        }
+    } else {
         $('body').attr('class', 'device-desktop');
+    }
 
     // Appends a meta tag to the head of the document specifying the character encoding to be UTF-8.
     // This ensures that special characters and symbols display correctly across various platforms and browsers.


### PR DESCRIPTION
Closes #1474

This PR fixes the issue where iPads were being served a mobile UI. The root cause is that all devices with the device-tablet class received the mobile layout, which is unsuitable for tablets used with a mouse/trackpad.

The solution is to differentiate tablets based on their input method using the (hover: hover) media query.
->Tablets that support hover (i.e., have a mouse) will now receive the device-desktop UI.
->Touch-only tablets will continue to receive the existing device-tablet (mobile) UI.

This ensures all users get the appropriate experience. The fix has been verified using browser developer tools to confirm the correct UI is served for iPads, iPhones, and desktops without regressions.