### PR TITLE
Reduce bottom bound on dragging UIItems

### DIFF
--- a/src/gui/src/UI/UIItem.js
+++ b/src/gui/src/UI/UIItem.js
@@ -288,7 +288,7 @@ function UIItem(options){
             const minLeft = -50;
             const maxLeft = window.desktop_width - 50;
             const minTop = window.toolbar_height;
-            const maxTop = window.desktop_height + window.toolbar_height - 50;
+            const maxTop = window.desktop_height + window.toolbar_height;
             
             // Apply constraints to ui.position
             ui.position.left = Math.max(minLeft, Math.min(maxLeft, ui.position.left));


### PR DESCRIPTION
Reduces the bottom bound for the behaviour introduced in a68f0ed to make it easier to drop items onto apps on the bottom taskbar.