### PR TITLE
fix(gui): prevent background apps from stealing focus

### DIFF
--- a/src/gui/src/UI/UIWindow.js
+++ b/src/gui/src/UI/UIWindow.js
@@ -96,6 +96,7 @@ async function UIWindow(options) {
     options.allowed_file_types = options.allowed_file_types ?? '';
     options.app = options.app ?? '';
     options.allow_context_menu = options.allow_context_menu ?? true;
+    options.background = options.background ?? false
     options.allow_native_ctxmenu = options.allow_native_ctxmenu ?? false;
     options.allow_user_select = options.allow_user_select ?? false;
     options.backdrop = options.backdrop ?? false;
@@ -601,7 +602,7 @@ async function UIWindow(options) {
     }
     // focus on this window and deactivate other windows
     if ( options.is_visible ) {
-        $(el_window).focusWindow();
+         if (!options.background) $(el_window).focusWindow()
     }
 
     if (window.animate_window_opening) {
@@ -1523,7 +1524,9 @@ async function UIWindow(options) {
                 el_window_app_iframe.contentWindow.postMessage({msg: "drop", x: (window.mouseX - rect.left), y: (window.mouseY - rect.top), items: items}, '*');
 
                 // bring focus to this window
-                $(el_window).focusWindow();
+                if (!options.background) {
+                 $(el_window).focusWindow()
+                }
             }
 
             // if this window is not a directory, cancel drop.
@@ -1666,8 +1669,9 @@ async function UIWindow(options) {
             clearTimeout(drag_enter_timeout);
             // If items are dragged over this window long enough, bring it to front
             drag_enter_timeout = setTimeout(function(){
-                // focus window
-                $(el_window).focusWindow();
+                if (!options.background) {
+                  $(el_window).focusWindow()
+                }
             }, 1400);
         },
         leave: function (dragsterEvent, event) {

--- a/src/gui/src/UI/UIWindow.js
+++ b/src/gui/src/UI/UIWindow.js
@@ -96,7 +96,6 @@ async function UIWindow(options) {
     options.allowed_file_types = options.allowed_file_types ?? '';
     options.app = options.app ?? '';
     options.allow_context_menu = options.allow_context_menu ?? true;
-    options.background = options.background ?? false
     options.allow_native_ctxmenu = options.allow_native_ctxmenu ?? false;
     options.allow_user_select = options.allow_user_select ?? false;
     options.backdrop = options.backdrop ?? false;
@@ -602,7 +601,7 @@ async function UIWindow(options) {
     }
     // focus on this window and deactivate other windows
     if ( options.is_visible ) {
-         if (!options.background) $(el_window).focusWindow()
+        $(el_window).focusWindow()
     }
 
     if (window.animate_window_opening) {
@@ -1524,8 +1523,8 @@ async function UIWindow(options) {
                 el_window_app_iframe.contentWindow.postMessage({msg: "drop", x: (window.mouseX - rect.left), y: (window.mouseY - rect.top), items: items}, '*');
 
                 // bring focus to this window
-                if (!options.background) {
-                 $(el_window).focusWindow()
+                if (options.is_visible) {
+                    $(el_window).focusWindow()
                 }
             }
 
@@ -1669,8 +1668,8 @@ async function UIWindow(options) {
             clearTimeout(drag_enter_timeout);
             // If items are dragged over this window long enough, bring it to front
             drag_enter_timeout = setTimeout(function(){
-                if (!options.background) {
-                  $(el_window).focusWindow()
+                if (options.is_visible) {
+                    $(el_window).focusWindow()
                 }
             }, 1400);
         },

--- a/src/gui/src/helpers/launch_app.js
+++ b/src/gui/src/helpers/launch_app.js
@@ -422,7 +422,7 @@ const launch_app = async (options)=>{
             // Send any saved broadcasts to the new app
             globalThis.services.get('broadcast').sendSavedBroadcastsTo(uuid);
 
-            // If `window-active` is set (meanign the window is focused), focus the window one more time
+            // If `window-active` is set (meaning the window is focused), focus the window one more time
             // this is to ensure that the iframe is `definitely` focused and can receive keyboard events (e.g. keydown)
             if($(process.references.el_win).hasClass('window-active')){
                 $(process.references.el_win).focusWindow();


### PR DESCRIPTION
# fix(gui): prevent background apps from stealing focus

## Summary
This pull request fixes an issue where launching a background application from the terminal would incorrectly steal keyboard focus. The change introduces a condition to the window creation logic, ensuring that only foreground applications receive focus upon launch, thereby preserving the user's context in the terminal.

## Root Cause
The `UIWindow` component was designed to unconditionally grant focus to any newly created window that was marked as visible. This behavior did not differentiate between interactive foreground applications and non-interactive background processes, causing the latter to incorrectly steal focus from the active window.

## Changes
- Added a new `options.background` property to the `UIWindow` component, which defaults to `false`.
- Modified the initial window creation logic in `UIWindow.js` to only call `focusWindow()` if the `options.background` property is `false`.
- Updated two additional event handlers (`drop` and `dragster:enter`) to also respect the `options.background` flag, ensuring focus is not stolen during drag-and-drop operations.

Closes #453 