### PR TITLE
test: add puterjs test to apiteste

### DIFF
--- a/tools/api-tester/README.md
+++ b/tools/api-tester/README.md
@@ -1,6 +1,6 @@
 # API Tester
 
-A test framework for testing the backend API of puter.
+A test framework for testing the puter HTTP API and puterjs API.
 
 ## Table of Contents
 
@@ -37,64 +37,70 @@ All commands below should be run from the root directory of puter.
     - token: The token of the user. (can be obtained by logging in on the webpage and typing `puter.authToken` in Developer Tools's console)
     - mountpoints: The mountpoints to test. (default config includes 2 mountpoints: `/` for "puter fs provider" and `/admin/tmp` for "memory fs provider")
 
-3. Run all tests (unit tests and benchmarks):
+3. Run tests against the HTTP API (unit tests and benchmarks):
 
     ```bash
-    node ./tools/api-tester/apitest.js --config=./tools/api-tester/config.yml
+    node ./tools/api-tester/apitest.js
+    ```
+
+4. (experimental) Run tests against the puter-js client:
+
+    ```bash
+    node ./tools/api-tester/apitest.js --puterjs
     ```
 
 ### Shorthands
 
-- Run all tests (unit tests and benchmarks):
+- Run tests against the HTTP API (unit tests and benchmarks):
 
     ```bash
-    node ./tools/api-tester/apitest.js --config=./tools/api-tester/config.yml
+    node ./tools/api-tester/apitest.js
     ```
 
-- Run all unit tests:
+- Run unit tests against the HTTP API:
 
     ```bash
-    node ./tools/api-tester/apitest.js --config=./tools/api-tester/config.yml --unit
+    node ./tools/api-tester/apitest.js --unit
     ```
 
-- Run all benchmarks:
+- Run benchmarks against the HTTP API:
 
     ```bash
-    node ./tools/api-tester/apitest.js --config=./tools/api-tester/config.yml --bench
+    node ./tools/api-tester/apitest.js --bench
     ```
 
 - Filter tests by suite name:
 
     ```bash
-    node ./tools/api-tester/apitest.js --config=./tools/api-tester/config.yml --unit --suite=mkdir
+    node ./tools/api-tester/apitest.js --unit --suite=mkdir
     ```
 
 - Filter benchmarks by name:
 
     ```bash
-    node ./tools/api-tester/apitest.js --config=./tools/api-tester/config.yml --bench --suite=stat_intensive_1
+    node ./tools/api-tester/apitest.js --bench --suite=stat_intensive_1
     ```
 
 - Stop on first failure:
 
     ```bash
-    node ./tools/api-tester/apitest.js --config=./tools/api-tester/config.yml --unit --stop-on-failure
+    node ./tools/api-tester/apitest.js --unit --stop-on-failure
     ```
 
 - (unimplemented) Filter tests by test name:
 
     ```bash
     # (wildcard matching) Run tests containing "memoryfs" in the name
-    node ./tools/api-tester/apitest.js --config=./tools/api-tester/config.yml --unit --test='*memoryfs*'
+    node ./tools/api-tester/apitest.js --unit --test='*memoryfs*'
 
     # (exact matching) Run the test "mkdir in memoryfs"
-    node ./tools/api-tester/apitest.js --config=./tools/api-tester/config.yml --unit --test='mkdir in memoryfs'
+    node ./tools/api-tester/apitest.js --unit --test='mkdir in memoryfs'
     ```
 
 - (unimplemented) Rerun failed tests in the last run:
 
     ```bash
-    node ./tools/api-tester/apitest.js --config=./tools/api-tester/config.yml --rerun-failed
+    node ./tools/api-tester/apitest.js --rerun-failed
     ```
 
 ## Basic Concepts

--- a/tools/api-tester/puter_js/__entry__.js
+++ b/tools/api-tester/puter_js/__entry__.js
@@ -1,0 +1,25 @@
+const load_puterjs = require('./load.cjs');
+
+async function run(conf) {
+  const puter = await load_puterjs();
+  if (conf.token) {
+    puter.setAuthToken(conf.token);
+  } else {
+    throw new Error('No token found in config file. Please add a "token" field to your config.yaml');
+  }
+  return;
+};
+
+module.exports = async registry => {
+  const puter = await load_puterjs();
+  if (registry.t?.conf?.token) {
+    puter.setAuthToken(registry.t.conf.token);
+  } else {
+    throw new Error('No token found in config file. Please add a "token" field to your config.yaml');
+  }
+
+  registry.t.puter = puter;
+
+  console.log('__entry__.js');
+  require('./auth/__entry__.js')(registry);
+};

--- a/tools/api-tester/puter_js/auth/__entry__.js
+++ b/tools/api-tester/puter_js/auth/__entry__.js
@@ -1,0 +1,3 @@
+module.exports = registry => {
+    registry.add_test('whoami', require('./whoami.js'));
+};

--- a/tools/api-tester/puter_js/auth/whoami.js
+++ b/tools/api-tester/puter_js/auth/whoami.js
@@ -1,0 +1,16 @@
+const chai = require('chai');
+chai.use(require('chai-as-promised'))
+const expect = chai.expect;
+
+module.exports = {
+    name: 'whoami',
+    description: 'a demo test for puterjs',
+    do: async t => {
+        const puter = t.puter;
+
+        await t.case('demo (whoami)', async () => {
+            const result = await puter.auth.whoami();
+            expect(result.username).to.equal('admin');
+        });
+    }
+}

--- a/tools/api-tester/puter_js/load.cjs
+++ b/tools/api-tester/puter_js/load.cjs
@@ -1,0 +1,13 @@
+const vm = require('vm');
+
+async function load_puterjs() {
+    const goodContext = {}
+    Object.getOwnPropertyNames(globalThis).forEach(name => { try { goodContext[name] = globalThis[name]; } catch { } })
+    goodContext.globalThis = goodContext
+    const code = await fetch("http://puter.localhost:4100/puter.js/v2").then(res => res.text());
+    const context = vm.createContext(goodContext);
+    const result = vm.runInNewContext(code, context);
+    return goodContext.puter;
+}
+
+module.exports = load_puterjs;


### PR DESCRIPTION
This PR introduce puterjs test to apitest, it also include a demo `whoami` test for demonstration.

All changes are confined to the `tools/api-tester` folder.