### PR TITLE
dev: remove suggested apps from readdir

### DIFF
--- a/src/backend/src/filesystem/hl_operations/hl_readdir.js
+++ b/src/backend/src/filesystem/hl_operations/hl_readdir.js
@@ -95,7 +95,7 @@ class HLReadDir extends HLFilesystemOperation {
 
             if ( ! no_assocs ) {
                 await Promise.all([
-                    child.fetchSuggestedApps(user),
+                   // child.fetchSuggestedApps(user),
                     child.fetchSubdomains(user),
                 ]);
             }


### PR DESCRIPTION
This PR removes the call to `fetchSuggestedApps` in `/readdir` to improve performance.

Issue: #1563

- `/readdir` now only fetches subdomains.
- Suggested apps are no longer loaded, reducing time cost (~25% of readdir).
- Functionality of directory listing remains unchanged.
