### PR TITLE
client-cache: update cache-invalidation policy to ts-based comparison

### DIFF
--- a/src/backend/src/routers/filesystem_api/cache.js
+++ b/src/backend/src/routers/filesystem_api/cache.js
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2024-present Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+"use strict"
+const eggspress = require('../../api/eggspress.js');
+const { Context } = require('../../util/context.js');
+
+module.exports = eggspress('/cache/last-change-timestamp', {
+    subdomain: 'api',
+    auth2: true,
+    verified: true,
+    fs: true,
+    json: true,
+    allowedMethods: ['GET'],
+}, async (req, res, next) => {
+    const svc_driver = Context.get('services').get('driver');
+    const driver_response = await svc_driver.call({
+        iface: 'puter-kvstore',
+        method: 'get',
+        args: { key: `last_change_timestamp:${req.user?.id}` },
+    });
+    const timestamp = driver_response.result;
+    res.json({ timestamp });
+});

--- a/src/backend/src/services/FilesystemAPIService.js
+++ b/src/backend/src/services/FilesystemAPIService.js
@@ -69,6 +69,8 @@ class FilesystemAPIService extends BaseService {
         // misc
         app.use(require('../routers/df'))
 
+        // cache
+        app.use(require('../routers/filesystem_api/cache'))
     }
 }
 

--- a/src/puter-js/src/modules/FileSystem/operations/copy.js
+++ b/src/puter-js/src/modules/FileSystem/operations/copy.js
@@ -56,8 +56,7 @@ const copy = function (...args) {
             dedupe_name: (options.dedupe_name || options.dedupeName),
         }));
 
-        // todo: EXTREMELY NAIVE CACHE PURGE
-        puter._cache.flushall();
+        this.updateCacheTimestamp();
     })
 }
 

--- a/src/puter-js/src/modules/FileSystem/operations/mkdir.js
+++ b/src/puter-js/src/modules/FileSystem/operations/mkdir.js
@@ -1,6 +1,6 @@
+import path from "../../../lib/path.js";
 import * as utils from '../../../lib/utils.js';
 import getAbsolutePathForApp from '../utils/getAbsolutePathForApp.js';
-import path from "../../../lib/path.js"
 
 const mkdir = function (...args) {
     let options = {};
@@ -54,8 +54,7 @@ const mkdir = function (...args) {
             create_missing_parents: (options.recursive || options.createMissingParents) ?? false,
         }));
 
-        // todo: EXTREMELY NAIVE CACHE PURGE
-        puter._cache.flushall();
+        this.updateCacheTimestamp();
     })
 }
 

--- a/src/puter-js/src/modules/FileSystem/operations/move.js
+++ b/src/puter-js/src/modules/FileSystem/operations/move.js
@@ -1,7 +1,7 @@
+import path from "../../../lib/path.js";
 import * as utils from '../../../lib/utils.js';
 import getAbsolutePathForApp from '../utils/getAbsolutePathForApp.js';
-import stat from "./stat.js"
-import path from "../../../lib/path.js"
+import stat from "./stat.js";
 
 const move = function (...args) {
     let options;
@@ -66,8 +66,7 @@ const move = function (...args) {
             original_client_socket_id: options.excludeSocketID,
         }));
 
-        // todo: EXTREMELY NAIVE CACHE PURGE
-        puter._cache.flushall();
+        this.updateCacheTimestamp();
 
     })
 }

--- a/src/puter-js/src/modules/FileSystem/operations/rename.js
+++ b/src/puter-js/src/modules/FileSystem/operations/rename.js
@@ -50,8 +50,8 @@ const rename = function (...args) {
         }
         
         xhr.send(JSON.stringify(dataToSend));
-        // todo: EXTREMELY NAIVE CACHE PURGE
-        puter._cache.flushall();
+
+        this.updateCacheTimestamp();
     })
 }
 

--- a/src/puter-js/src/modules/FileSystem/operations/upload.js
+++ b/src/puter-js/src/modules/FileSystem/operations/upload.js
@@ -1,6 +1,6 @@
+import path from "../../../lib/path.js";
 import * as utils from '../../../lib/utils.js';
 import getAbsolutePathForApp from '../utils/getAbsolutePathForApp.js';
-import path from "../../../lib/path.js"
 
 const upload = async function(items, dirPath, options = {}){
     return new Promise(async (resolve, reject) => {
@@ -429,11 +429,10 @@ const upload = async function(items, dirPath, options = {}){
             options.start();
         }
 
-        // todo: EXTREMELY NAIVE CACHE PURGE
-        puter._cache.flushall();
-
         // send request
         xhr.send(fd);
+
+        this.updateCacheTimestamp();
     })
 }
 

--- a/src/puter-js/src/modules/FileSystem/operations/write.js
+++ b/src/puter-js/src/modules/FileSystem/operations/write.js
@@ -1,4 +1,4 @@
-import path from "../../../lib/path.js"
+import path from "../../../lib/path.js";
 import getAbsolutePathForApp from '../utils/getAbsolutePathForApp.js';
 
 const write = async function (targetPath, data, options = {}) {
@@ -55,8 +55,7 @@ const write = async function (targetPath, data, options = {}) {
         throw new Error({ code: 'field_invalid', message: 'write() data parameter is an invalid type' });
     }
 
-    // todo: EXTREMELY NAIVE CACHE PURGE
-    puter._cache.flushall();
+    this.updateCacheTimestamp();
 
     // perform upload
     return this.upload(data, parent, options);


### PR DESCRIPTION
This PR replace the cache-invalidation policy from "invalidate on any update" to "invalidate when client-cache has an older timestamp".

It's ready for review/merge and there are some work to be done in the following PRs:
- persistent ts on server
- persistent cache on client