### PR TITLE
client-cache: remove pulling

### DIFF
--- a/src/puter-js/src/modules/FileSystem/index.js
+++ b/src/puter-js/src/modules/FileSystem/index.js
@@ -112,8 +112,8 @@ export class PuterJSFileSystemModule extends AdvancedBase {
     bindSocketEvents() {
         this.socket.on('cache.updated', (item) => {
             const local_ts = puter._cache.get(LAST_UPDATED_TS);
-            if (item.ts > local_ts || local_ts === undefined) {
-                console.log(`remote timestamp (${item.ts}) is newer than local timestamp (${local_ts}), flushing cache`);
+            if (item.timestamp > local_ts || local_ts === undefined) {
+                console.log(`remote timestamp (${item.timestamp}) is newer than local timestamp (${local_ts}), flushing cache`);
                 puter._cache.flushall();
             }
         });
@@ -208,7 +208,6 @@ export class PuterJSFileSystemModule extends AdvancedBase {
     updateCacheTimestamp() {
         // Add 1 second to mitigate clock skew and disable self-update.
         puter._cache.set(LAST_UPDATED_TS, Date.now() + 1000);
-        console.log(`set last updated ts to ${puter._cache.get(LAST_UPDATED_TS)}`);
     }
 
     /**
@@ -225,7 +224,7 @@ export class PuterJSFileSystemModule extends AdvancedBase {
             utils.setupXhrEventHandlers(xhr, undefined, undefined, async (result) => {
                 try {
                     const response = typeof result === 'string' ? JSON.parse(result) : result;
-                    resolve(response.timestamp || response.ts || Date.now());
+                    resolve(response.timestamp || Date.now());
                 } catch (e) {
                     reject(new Error('Failed to parse response'));
                 }

--- a/src/puter-js/src/modules/FileSystem/index.js
+++ b/src/puter-js/src/modules/FileSystem/index.js
@@ -107,9 +107,6 @@ export class PuterJSFileSystemModule extends AdvancedBase {
         });
 
         this.bindSocketEvents();
-
-        // Start cache monitoring
-        this.startCacheMonitoring();
     }
 
     bindSocketEvents() {
@@ -236,31 +233,5 @@ export class PuterJSFileSystemModule extends AdvancedBase {
 
             xhr.send();
         });
-    }
-
-    /**
-     * Starts the cache monitoring service that calls the cache API every 5 seconds.
-     *
-     * @memberof PuterJSFileSystemModule
-     * @returns {void}
-     */
-    startCacheMonitoring() {
-        if (this.cacheMonitoringInterval) {
-            clearInterval(this.cacheMonitoringInterval);
-        }
-
-        this.cacheMonitoringInterval = setInterval(async () => {
-            try {
-                const remoteTimestamp = await this.getCacheTimestamp();
-                const localTimestamp = puter._cache.get(LAST_UPDATED_TS);
-                
-                if (remoteTimestamp > localTimestamp || localTimestamp === undefined) {
-                    console.log(`remote timestamp (${remoteTimestamp}) is newer than local timestamp (${localTimestamp}), flushing cache`);
-                    puter._cache.flushall();
-                }
-            } catch (error) {
-                console.error('Failed to get cache timestamp:', error);
-            }
-        }, 5000);
     }
 }

--- a/src/puter-js/src/modules/FileSystem/operations/copy.js
+++ b/src/puter-js/src/modules/FileSystem/operations/copy.js
@@ -57,6 +57,9 @@ const copy = function (...args) {
         }));
 
         this.updateCacheTimestamp();
+
+        // TOOD (xiaochen): puter desktop will have stale cache without this, find out why
+        puter._cache.flushall();
     })
 }
 

--- a/src/puter-js/src/modules/FileSystem/operations/mkdir.js
+++ b/src/puter-js/src/modules/FileSystem/operations/mkdir.js
@@ -55,6 +55,9 @@ const mkdir = function (...args) {
         }));
 
         this.updateCacheTimestamp();
+
+        // TOOD (xiaochen): puter desktop will have stale cache without this, find out why
+        puter._cache.flushall();
     })
 }
 

--- a/src/puter-js/src/modules/FileSystem/operations/move.js
+++ b/src/puter-js/src/modules/FileSystem/operations/move.js
@@ -68,6 +68,8 @@ const move = function (...args) {
 
         this.updateCacheTimestamp();
 
+        // TOOD (xiaochen): puter desktop will have stale cache without this, find out why
+        puter._cache.flushall();
     })
 }
 

--- a/src/puter-js/src/modules/FileSystem/operations/rename.js
+++ b/src/puter-js/src/modules/FileSystem/operations/rename.js
@@ -52,6 +52,9 @@ const rename = function (...args) {
         xhr.send(JSON.stringify(dataToSend));
 
         this.updateCacheTimestamp();
+
+        // TOOD (xiaochen): puter desktop will have stale cache without this, find out why
+        puter._cache.flushall();
     })
 }
 

--- a/src/puter-js/src/modules/FileSystem/operations/upload.js
+++ b/src/puter-js/src/modules/FileSystem/operations/upload.js
@@ -433,6 +433,9 @@ const upload = async function(items, dirPath, options = {}){
         xhr.send(fd);
 
         this.updateCacheTimestamp();
+
+        // TOOD (xiaochen): puter desktop will have stale cache without this, find out why
+        puter._cache.flushall();
     })
 }
 

--- a/src/puter-js/src/modules/FileSystem/operations/write.js
+++ b/src/puter-js/src/modules/FileSystem/operations/write.js
@@ -57,6 +57,9 @@ const write = async function (targetPath, data, options = {}) {
 
     this.updateCacheTimestamp();
 
+    // TOOD (xiaochen): puter desktop will have stale cache without this, find out why
+    puter._cache.flushall();
+
     // perform upload
     return this.upload(data, parent, options);
 }


### PR DESCRIPTION
This is a hot-fix that remove the DDOS caused by http pulling. It's tested and ready for review/merge.

There are some issues remained that related to client-cache:

- [x] We set the cache no matter the pushing websocket is connected or not, this will cause stale cache when the ws connection is lost. (fixed: it's fine, "websocket lost and failed to reconnect" means the server is unreachable, cache validity isn’t a concern in this case.)
- [x] Seems puter.fs.socket failed to listen on 'cache.updated' event after reconnected. (How to reproduce: kill it via `puter.fs.socket.disconnect();`) (fixed: use `puter.fs.initializeSocket();` instead)
- [x] Remote ts is undefined. (client log: `remote timestamp (undefined) is newer than local timestamp (undefined), flushing cache`) (fixed in this PR)
- [x] `getCacheTimestamp` is unused. (fixed: this is fine, we need this api on session start to validate the local cache)