### PR TITLE
Fix bug with context menu positioning on page load

### DIFF
--- a/src/gui/src/UI/UIDesktop.js
+++ b/src/gui/src/UI/UIDesktop.js
@@ -860,10 +860,7 @@ async function UIDesktop(options) {
         if (event.target === el_desktop) {
             event.preventDefault();
             UIContextMenu({
-                position: {
-                    left: event.pageX,
-                    top: event.pageY
-                },
+                position: event.type === 'taphold' ? undefined : { left: event.pageX, top: event.pageY },
                 items: [
                     // -------------------------------------------
                     // Sort by

--- a/src/gui/src/UI/UIDesktop.js
+++ b/src/gui/src/UI/UIDesktop.js
@@ -860,6 +860,10 @@ async function UIDesktop(options) {
         if (event.target === el_desktop) {
             event.preventDefault();
             UIContextMenu({
+                position: {
+                    left: event.pageX,
+                    top: event.pageY
+                },
                 items: [
                     // -------------------------------------------
                     // Sort by


### PR DESCRIPTION
Fixes a bug where right clicking the desktop on page load without moving the mouse first would position the context menu at the top-left of the page.