### PR TITLE
fix: support async iterator for AI chat streaming mode in types

### DIFF
--- a/src/puter-js/index.d.ts
+++ b/src/puter-js/index.d.ts
@@ -32,11 +32,11 @@ declare class Puter {
 
 // AI Module
 interface AI {
-    chat(prompt: string, options?: ChatOptions): Promise<ChatResponse>;
-    chat(prompt: string, testMode?: boolean, options?: ChatOptions): Promise<ChatResponse>;
-    chat(prompt: string, imageURL?: string, testMode?: boolean, options?: ChatOptions): Promise<ChatResponse>;
-    chat(prompt: string, imageURLArray?: string[], testMode?: boolean, options?: ChatOptions): Promise<ChatResponse>;
-    chat(messages: ChatMessage[], testMode?: boolean, options?: ChatOptions): Promise<ChatResponse>;
+    chat(prompt: string, options?: ChatOptions): Promise<ChatResponse> | AsyncIterable<ChatResponseChunk>;
+    chat(prompt: string, testMode?: boolean, options?: ChatOptions): Promise<ChatResponse> | AsyncIterable<ChatResponseChunk>;
+    chat(prompt: string, imageURL?: string, testMode?: boolean, options?: ChatOptions): Promise<ChatResponse> | AsyncIterable<ChatResponseChunk>;
+    chat(prompt: string, imageURLArray?: string[], testMode?: boolean, options?: ChatOptions): Promise<ChatResponse> | AsyncIterable<ChatResponseChunk>;
+    chat(messages: ChatMessage[], testMode?: boolean, options?: ChatOptions): Promise<ChatResponse> | AsyncIterable<ChatResponseChunk>;
 
     img2txt(image: string | File | Blob, testMode?: boolean): Promise<string>;
 
@@ -107,6 +107,11 @@ interface Txt2SpeechOptions {
     language?: string;
     voice?: string;
     engine?: 'standard' | 'neural' | 'generative';
+}
+
+interface ChatResponseChunk {
+    text?: string;
+    [key: string]: any;
 }
 
 // Apps Module


### PR DESCRIPTION
PR Title
Support streaming in ChatResponse type

Description
Fixes #1645
Currently, the puter.ai.chat TypeScript definition only supports returning a Promise<ChatResponse>. When using streaming mode (stream: true), the function actually returns an AsyncIterable<ChatResponseChunk>, which causes type errors when consuming it with for await ... of.
This PR updates the type definition of AI.chat to correctly reflect both return types:
Promise<ChatResponse> when stream is false or omitted
AsyncIterable<ChatResponseChunk> when stream is true
This enables full TypeScript support for streaming AI chat responses.

Changes
Updated index.d.ts to allow AI.chat to return Promise<ChatResponse> | AsyncIterable<ChatResponseChunk>
