### PR TITLE
fix: preflight issue with protected endpoints

### DIFF
--- a/src/backend/src/middleware/configurable_auth.js
+++ b/src/backend/src/middleware/configurable_auth.js
@@ -40,6 +40,10 @@ const is_whoami = (req) => {
 // in endpoints that do not require authentication, but can
 // provide additional functionality if the user is authenticated.
 const configurable_auth = options => async (req, res, next) => {
+    if ( options.no_options_auth && req.method === 'OPTIONS' ) {
+        return next();
+    }
+
     const optional = options?.optional;
 
     // Request might already have been authed (PreAuthService)


### PR DESCRIPTION
When /user-protected/change-password (and presumably other endpoints under /user-protected) receive a preflight request they respond with HTTP status 401. This is because `.use()` calls on the router apply to all request methods erroneously.

This commit fixes the issue. Further investigation is required to determine when preflight requests started happening on this endpoint.