### PR TITLE
Add `dedupeName` to `CreateAppOptions`

### DIFF
--- a/src/puter-js/index.d.ts
+++ b/src/puter-js/index.d.ts
@@ -146,6 +146,7 @@ interface CreateAppOptions {
     icon?: string;
     maximizeOnStart?: boolean;
     filetypeAssociations?: string[];
+    dedupeName?: boolean;
 }
 
 interface GetAppOptions {


### PR DESCRIPTION
Fixes #1777 