### PR TITLE
fix: add shell option to npm spawn on Windows

### DIFF
--- a/src/backend/src/Kernel.js
+++ b/src/backend/src/Kernel.js
@@ -578,7 +578,7 @@ class Kernel extends AdvancedBase {
 
     async run_npm_install (path) {
         const npmCmd = process.platform === "win32" ? "npm.cmd" : "npm";
-        const proc = spawn(npmCmd, ["install"], { cwd: path, stdio: "pipe" });
+        const proc = spawn(npmCmd, ["install"], { cwd: path, stdio: "pipe", shell: true });
 
         let buffer = '';
 


### PR DESCRIPTION
## Description
Fixes Windows-specific EINVAL error when spawning npm install commands.

## Problem
On Windows, the [run_npm_install](cci:1://file:///d:/CSE_Projects2/roughfolder/puter/src/backend/src/Kernel.js:578:4-608:5) function in [Kernel.js](cci:7://file:///d:/CSE_Projects2/roughfolder/puter/src/backend/src/Kernel.js:0:0-0:0) was failing with `spawn EINVAL` error because it was missing the `shell: true` option when spawning `npm.cmd`.

## Solution
- Added `shell: true` to spawn options in [run_npm_install](cci:1://file:///d:/CSE_Projects2/roughfolder/puter/src/backend/src/Kernel.js:578:4-608:5) function
- Makes the spawn call consistent with other spawn calls in the codebase (`ProcessService.js` and [LocalTerminalService.js](cci:7://file:///d:/CSE_Projects2/roughfolder/puter/src/backend/src/modules/development/LocalTerminalService.js:0:0-0:0))
- Cross-platform compatible (works on Windows, Linux, macOS)

## Changes
- **File:** [src/backend/src/Kernel.js](cci:7://file:///d:/CSE_Projects2/roughfolder/puter/src/backend/src/Kernel.js:0:0-0:0)
- **Line:** 581
- **Change:** Added `shell: true` to spawn options

## Fixes
- Closes #1748 
- Closes #1797

Why Windows Needs shell: true:
- On Windows, npm.cmd is a batch file, not an executable
- Node.js spawn() cannot execute .cmd files directly without shell: true
- Without it, Windows throws EINVAL (Invalid argument) error

Proof from Codebase:
Other spawn calls in the same codebase already use shell: true:
- ProcessService.js line 76: spawn(command, args, { shell: true, ... })
- LocalTerminalService.js line 93: spawn(profile.shell[0], args, { shell: true, ... })

## Testing
- [x] Verified fix follows existing code patterns in the codebase
- [x] Minimal change with low risk
- [x] No functional changes to other parts of the system

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)