### PR TITLE
fix: access internal ID without assuming fetch

### DIFF
--- a/src/backend/src/filesystem/ll_operations/ll_read.js
+++ b/src/backend/src/filesystem/ll_operations/ll_read.js
@@ -83,7 +83,7 @@ class LLRead extends LLFilesystemOperation {
 
         // timestamp access
         await db.write('UPDATE `fsentries` SET `accessed` = ? WHERE `id` = ?',
-                        [Date.now() / 1000, fsNode.mysql_id]);
+                        [Date.now() / 1000, await fsNode.get('mysql-id')]);
 
         const ownerId = await fsNode.get('user_id');
         const chargedActor =  actor? actor: new Actor({


### PR DESCRIPTION
It might not be okay to assume an fsentry was already fetched when updating the accessed time in ll_read. I'd like to know what changed this to make this be the case, if it happens to be the case.