### PR TITLE
fix: also check this.entry.id when checking mysql_id

### DIFF
--- a/src/backend/src/filesystem/FSNodeContext.js
+++ b/src/backend/src/filesystem/FSNodeContext.js
@@ -627,7 +627,7 @@ module.exports = class FSNodeContext {
 
         if ( key === 'mysql-id' ) {
             await this.fetchEntry();
-            return this.mysql_id;
+            return this.mysql_id ?? this.entry.id;
         }
 
         if ( key === 'owner' ) {


### PR DESCRIPTION
There is a case where this.entry.id has a value in FSNodeContext while this.mysql_id does not. I was under the impression that this state was not possibole. The cause of this eludes me. This commit does not correct the root cause - it only adds a workaround to this issue by falling back to this.entry.id if this.mysql_id is `undefined`.