### PR TITLE
fix: error calling .startsWith on null mime_type

### DIFF
--- a/src/gui/src/UI/UIItem.js
+++ b/src/gui/src/UI/UIItem.js
@@ -1281,7 +1281,8 @@ function UIItem(options){
             // -------------------------------------------
             // Set as Wallpaper
             // -------------------------------------------
-            const mime_type = mime.getType($(el_item).attr('data-name'));
+            const mime_type = mime.getType($(el_item).attr('data-name')) ??
+                'application/octet-stream';
             if(!is_trashed && !is_trash && !options.is_dir && mime_type.startsWith('image/')) {
                 menu_items.push({
                     html: i18n('set_as_background'),


### PR DESCRIPTION
According to the package documentation: https://www.npmjs.com/package/mime
> null is returned in cases where an extension is not detected or recognized

This call to `.startsWith()` was causing an exception to be thrown upon right-clicking files without an extension, making it impossible to fix them.