### PR TITLE
Move operations (quick_check, mkdir, read) to extension

### DIFF
--- a/src/backend/src/filesystem/ll_operations/ll_mkdir.js
+++ b/src/backend/src/filesystem/ll_operations/ll_mkdir.js
@@ -16,19 +16,19 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-const APIError = require("../../api/APIError");
-const { MODE_WRITE } = require("../../services/fs/FSLockService");
-const { Context } = require("../../util/context");
-const { NodeUIDSelector, NodeChildSelector } = require("../node/selectors");
-const { RESOURCE_STATUS_PENDING_CREATE } = require("../../modules/puterfs/ResourceService");
-const { LLFilesystemOperation } = require("./definitions");
+const APIError = require('../../api/APIError');
+const { MODE_WRITE } = require('../../services/fs/FSLockService');
+const { Context } = require('../../util/context');
+const { NodeUIDSelector, NodeChildSelector } = require('../node/selectors');
+const { RESOURCE_STATUS_PENDING_CREATE } = require('../../modules/puterfs/ResourceService');
+const { LLFilesystemOperation } = require('./definitions');
 
 class LLMkdir extends LLFilesystemOperation {
     static CONCERN = 'filesystem';
     static MODULES = {
         _path: require('path'),
         uuidv4: require('uuid').v4,
-    }
+    };
 
     async _run () {
         const { parent, name, immutable } = this.values;

--- a/src/backend/src/modules/puterfs/PuterFSModule.js
+++ b/src/backend/src/modules/puterfs/PuterFSModule.js
@@ -1,33 +1,36 @@
 /*
  * Copyright (C) 2024-present Puter Technologies Inc.
- * 
+ *
  * This file is part of Puter.
- * 
+ *
  * Puter is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published
  * by the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-const { AdvancedBase } = require("@heyputer/putility");
-const FSNodeContext = require("../../filesystem/FSNodeContext");
-const capabilities = require("../../filesystem/definitions/capabilities");
-const selectors = require("../../filesystem/node/selectors");
-const { RuntimeModule } = require("../../extension/RuntimeModule");
-const { TmpProxyFSProvider } = require("./TmpProxyFSProvider");
+const { AdvancedBase } = require('@heyputer/putility');
+const FSNodeContext = require('../../filesystem/FSNodeContext');
+const capabilities = require('../../filesystem/definitions/capabilities');
+const selectors = require('../../filesystem/node/selectors');
+const { RuntimeModule } = require('../../extension/RuntimeModule');
+const { TmpProxyFSProvider } = require('./TmpProxyFSProvider');
+const { MODE_READ, MODE_WRITE } = require('../../services/fs/FSLockService');
 
 class PuterFSModule extends AdvancedBase {
     async install (context) {
         const services = context.get('services');
-        
+
+        const { RESOURCE_STATUS_PENDING_CREATE } = require('./ResourceService');
+
         // Expose filesystem declarations to extensions
         {
             const runtimeModule = new RuntimeModule({ name: 'fs' });
@@ -36,26 +39,33 @@ class PuterFSModule extends AdvancedBase {
                 selectors,
                 FSNodeContext,
                 TmpProxyFSProvider,
+                lock: {
+                    MODE_READ,
+                    MODE_WRITE,
+                },
+                resource: {
+                    RESOURCE_STATUS_PENDING_CREATE,
+                },
             };
             context.get('runtime-modules').register(runtimeModule);
         }
-        
-        const { ResourceService } = require("./ResourceService");
+
+        const { ResourceService } = require('./ResourceService');
         services.registerService('resourceService', ResourceService);
-        
-        const { DatabaseFSEntryService } = require("./DatabaseFSEntryService");
+
+        const { DatabaseFSEntryService } = require('./DatabaseFSEntryService');
         services.registerService('fsEntryService', DatabaseFSEntryService);
-        
+
         const { SizeService } = require('./SizeService');
         services.registerService('sizeService', SizeService);
-        
+
         const { MountpointService } = require('./MountpointService');
         services.registerService('mountpoint', MountpointService);
 
         // const { PuterFSService } = require('./PuterFSService');
         // services.registerService('puterfs', PuterFSService);
-        
-        const DatabaseFSEntryFetcher = require("./DatabaseFSEntryFetcher");
+
+        const DatabaseFSEntryFetcher = require('./DatabaseFSEntryFetcher');
         services.registerService('fsEntryFetcher', DatabaseFSEntryFetcher);
 
         const { MemoryFSService } = require('./customfs/MemoryFSService');

--- a/src/backend/src/modules/puterfs/lib/PuterFSProvider.js
+++ b/src/backend/src/modules/puterfs/lib/PuterFSProvider.js
@@ -89,36 +89,8 @@ class PuterFSProvider extends putility.AdvancedBase {
     async quick_check ({
         selector,
     }) {
-        // a wrapper that access underlying database directly
-        const fsEntryFetcher = this.#services.get('fsEntryFetcher');
-
-        // shortcut: has full path
-        if ( selector?.path ) {
-            const entry = await fsEntryFetcher.findByPath(selector.path);
-            return Boolean(entry);
-        }
-
-        // shortcut: has uid
-        if ( selector?.uid ) {
-            const entry = await fsEntryFetcher.findByUID(selector.uid);
-            return Boolean(entry);
-        }
-
-        // shortcut: parent uid + child name
-        if ( selector instanceof NodeChildSelector && selector.parent instanceof NodeUIDSelector ) {
-            return await fsEntryFetcher.nameExistsUnderParent(selector.parent.uid,
-                            selector.name);
-        }
-
-        // shortcut: parent id + child name
-        if ( selector instanceof NodeChildSelector && selector.parent instanceof NodeInternalIDSelector ) {
-            return await fsEntryFetcher.nameExistsUnderParentID(selector.parent.id,
-                            selector.name);
-        }
-
-        // TODO (xiaochen): we should fallback to stat but we cannot at this moment
-        // since stat requires a valid `FSNodeContext` argument.
-        return false;
+        console.error('This .quick_check should not be called!');
+        process.exit(1);
     }
 
     async stat ({

--- a/src/backend/src/modules/puterfs/lib/PuterFSProvider.js
+++ b/src/backend/src/modules/puterfs/lib/PuterFSProvider.js
@@ -90,7 +90,7 @@ class PuterFSProvider extends putility.AdvancedBase {
         selector,
     }) {
         console.error('This .quick_check should not be called!');
-        process.exit(1);
+        throw new Error('This .quick_check should not be called!');
     }
 
     async stat ({
@@ -383,12 +383,12 @@ class PuterFSProvider extends putility.AdvancedBase {
 
     async unlink ({ context, node, options = {} }) {
         console.error('This .unlink should not be called!');
-        process.exit(1);
+        throw new Error('This .unlink should not be called!');
     }
 
     async rmdir ({ context, node, options = {} }) {
         console.error('This .rmdir should not be called!');
-        process.exit(1);
+        throw new Error('This .rmdir should not be called!');
     }
 
     /**
@@ -858,7 +858,7 @@ class PuterFSProvider extends putility.AdvancedBase {
         range,
     }) {
         console.error('This .read should not be called!');
-        process.exit(1);
+        throw new Error('This .read should not be called!');
     }
 }
 

--- a/src/backend/src/modules/puterfs/lib/PuterFSProvider.js
+++ b/src/backend/src/modules/puterfs/lib/PuterFSProvider.js
@@ -402,74 +402,8 @@ class PuterFSProvider extends putility.AdvancedBase {
      * @returns {Promise<FSNode>}
      */
     async mkdir ({ context, parent, name, immutable }) {
-        const { actor, thumbnail } = context.values;
-
-        const svc_fslock = this.#services.get('fslock');
-        const lock_handle = await svc_fslock.lock_child(await parent.get('path'),
-                        name,
-                        MODE_WRITE);
-
-        try {
-            const ts = Math.round(Date.now() / 1000);
-            const uid = uuidv4();
-            const resourceService = this.#services.get('resourceService');
-            const svc_fsEntry = this.#services.get('fsEntryService');
-            const svc_event = this.#services.get('event');
-            const fs = this.#services.get('filesystem');
-
-            const existing = await fs.node(new NodeChildSelector(parent.selector, name));
-
-            if ( await existing.exists() ) {
-                throw APIError.create('item_with_same_name_exists', null, {
-                    entry_name: name,
-                });
-            }
-
-            const svc_acl = this.#services.get('acl');
-            if ( ! await parent.exists() ) {
-                throw APIError.create('subject_does_not_exist');
-            }
-            if ( ! await svc_acl.check(actor, parent, 'write') ) {
-                throw await svc_acl.get_safe_acl_error(actor, parent, 'write');
-            }
-
-            resourceService.register({
-                uid,
-                status: RESOURCE_STATUS_PENDING_CREATE,
-            });
-
-            const raw_fsentry = {
-                is_dir: 1,
-                uuid: uid,
-                parent_uid: await parent.get('uid'),
-                path: path.join(await parent.get('path'), name),
-                user_id: actor.type.user.id,
-                name,
-                created: ts,
-                accessed: ts,
-                modified: ts,
-                immutable: immutable ?? false,
-                ...(thumbnail ? {
-                    thumbnail: thumbnail,
-                } : {}),
-            };
-
-            const entryOp = await svc_fsEntry.insert(raw_fsentry);
-
-            await entryOp.awaitDone();
-            resourceService.free(uid);
-
-            const node = await fs.node(new NodeUIDSelector(uid));
-
-            svc_event.emit('fs.create.directory', {
-                node,
-                context: Context.get(),
-            });
-
-            return node;
-        } finally {
-            await lock_handle.unlock();
-        }
+        console.error('This .mkdir should not be called!');
+        throw new Error('This .mkdir should not be called!');
     }
 
     async update_thumbnail ({ context, node, thumbnail }) {

--- a/src/backend/src/modules/puterfs/lib/PuterFSProvider.js
+++ b/src/backend/src/modules/puterfs/lib/PuterFSProvider.js
@@ -885,21 +885,8 @@ class PuterFSProvider extends putility.AdvancedBase {
         version_id,
         range,
     }) {
-        // TODO: one PuterFS aggregates its own storage, don't get it
-        //       via mountpoint service.
-        const svc_mountpoint = context.get('services').get('mountpoint');
-        const storage = svc_mountpoint.get_storage(this.constructor.name);
-        const location = await node.get('s3:location') ?? {};
-        const stream = (await storage.create_read_stream(await node.get('uid'), {
-            // TODO: fs:decouple-s3
-            bucket: location.bucket,
-            bucket_region: location.bucket_region,
-            version_id,
-            key: location.key,
-            memory_file: node.entry,
-            ...(range ? { range } : {}),
-        }));
-        return stream;
+        console.error('This .read should not be called!');
+        process.exit(1);
     }
 }
 


### PR DESCRIPTION
Note that while this moves operations to the extension, underlying services like fsEntryService and fsEntryFetcher still need to be moved into the extension.

It was noticed while making these changes that right now PuterFSProvider's mkdir implementation contains the ACL logic and ll_mkdir does not. This needs to be fixed before custom filesystem implementations are prod-ready.