### PR TITLE
Fix: missing published/attached website icon for folder on different views (#1764)

### DIFF
--- a/src/gui/src/css/style.css
+++ b/src/gui/src/css/style.css
@@ -614,12 +614,27 @@ span.header-sort-icon img {
 }
 
 .item-container-list .item-badges {
-    display: none;
+    /* display: none; */
+    justify-content: flex-start !important;
+    left: 15px;
+    top: 12px;
+}
+.item-container-list .item-badges .item-badge {
+    height: 8px;
+    width: 8px;
 }
 
 .item-container-details .item-badges {
-    display: none;
+    /* display: none; */
+    justify-content: flex-start !important;
+    left: 15px;
+    top: 12px;
 }
+.item-container-details .item-badges .item-badge {
+    height: 8px;
+    width: 8px;
+}
+
 
 .item-badge {
     filter: drop-shadow(0px 0px 1px rgba(0, 0, 0, .4));


### PR DESCRIPTION
Fix : #1764 

<img width="1919" height="987" alt="Screenshot from 2025-11-08 12-51-29" src="https://github.com/user-attachments/assets/985eb2ca-87c9-492f-84a8-facb93615664" />

<img width="1919" height="987" alt="Screenshot from 2025-11-08 12-51-45" src="https://github.com/user-attachments/assets/681c88f8-0606-4336-82f8-d81dfa80cfed" />
