### PR TITLE
tweak(apitest): reduce benchmark size

### DIFF
--- a/tests/api-tester/benches/stat_intensive_1.js
+++ b/tests/api-tester/benches/stat_intensive_1.js
@@ -1,5 +1,5 @@
 const chai = require('chai');
-chai.use(require('chai-as-promised'))
+chai.use(require('chai-as-promised'));
 const expect = chai.expect;
 
 module.exports = {
@@ -9,23 +9,23 @@ module.exports = {
         console.log('stat intensive 1');
 
         const dir_count = 10;
-        const subdir_count = 100;
+        const subdir_count = 10;
 
         // key: uuid
         // value: path
         const dirs = {};
 
-        for (let i = 0; i < dir_count; i++) {
+        for ( let i = 0; i < dir_count; i++ ) {
             await t.mkdir(`dir_${i}`);
-            for (let j = 0; j < subdir_count; j++) {
+            for ( let j = 0; j < subdir_count; j++ ) {
                 const subdir = await t.mkdir(`dir_${i}/subdir_${j}`);
                 dirs[subdir.uid] = subdir.path;
             }
         }
 
         const start = Date.now();
-        for (let i = 0; i < 10; i++) {
-            for (const [uuid, path] of Object.entries(dirs)) {
+        for ( let i = 0; i < 10; i++ ) {
+            for ( const [uuid, path] of Object.entries(dirs) ) {
                 const stat = await t.stat_uuid(uuid);
                 expect(stat.is_dir).equal(true);
                 expect(stat.path).equal(path);
@@ -33,5 +33,5 @@ module.exports = {
         }
         const duration = Date.now() - start;
         return { duration };
-    }
+    },
 };

--- a/tests/api-tester/benches/write_intensive_1.js
+++ b/tests/api-tester/benches/write_intensive_1.js
@@ -1,5 +1,5 @@
 const chai = require('chai');
-chai.use(require('chai-as-promised'))
+chai.use(require('chai-as-promised'));
 const expect = chai.expect;
 
 module.exports = {
@@ -8,25 +8,25 @@ module.exports = {
     do: async t => {
         console.log('write intensive 1');
 
-        const dir_count = 100;
+        const dir_count = 10;
         const file_count = 10;
 
-        for ( let i=0 ; i < dir_count ; i++ ) {
+        for ( let i = 0 ; i < dir_count ; i++ ) {
             await t.mkdir(`dir_${i}`);
-            for ( let j=0 ; j < file_count ; j++ ) {
+            for ( let j = 0 ; j < file_count ; j++ ) {
                 const content = `example ${i} ${j}`;
                 await t.write(`dir_${i}/file_${j}.txt`, content, { overwrite: true });
             }
         }
 
-        for ( let i=0 ; i < dir_count ; i++ ) {
+        for ( let i = 0 ; i < dir_count ; i++ ) {
             const dir = await t.stat(`dir_${i}`);
             const files = await t.readdir(dir.path);
             expect(files.length).equal(file_count);
-            for ( let j=0 ; j < file_count ; j++ ) {
+            for ( let j = 0 ; j < file_count ; j++ ) {
                 const content = await t.read(`dir_${i}/file_${j}.txt`);
                 expect(content).equal(`example ${i} ${j}`);
             }
         }
-    }
+    },
 };


### PR DESCRIPTION
(also I let the linter do the linty thing, so additional whitespace changes)

We want this to be fast enough that this benchmark doesn't take a long time, but part of the effort of making it faster will be running the benchmark repeatedly, and if it takes a long time then it will take longer for us to make it faster.

This commit reduces the benchmark size for stat_intensive and write_intensive so that they don't take several minutes to complete.