### PR TITLE
Add missing together image model prefixes

### DIFF
--- a/src/puter-js/src/modules/AI.js
+++ b/src/puter-js/src/modules/AI.js
@@ -20,6 +20,13 @@ const TOGETHER_IMAGE_MODEL_PREFIXES = [
     'sg161222/',
     'wavymulder/',
     'prompthero/',
+    'bytedance-seed/',
+    'hidream-ai/',
+    'lykon/',
+    'qwen/',
+    'rundiffusion/',
+    'google/',
+    'ideogram/',
 ];
 
 const TOGETHER_IMAGE_MODEL_KEYWORDS = [


### PR DESCRIPTION
Fixes #1970 

- this should fix the proper selection for together ai model service
- only adding the missing ones here, instead of removing existing ones (even though their models are nonexistent)
  - the reason is, trying to be conservative, and don't want to break stuff
- the new model prefix is added from looking at the costmap btw, and seeing which are missing

maintainers feel free to edit this PR