### PR TITLE
fix: Add debounce to toolbar reveal when dragging windows to prevent accidental activation

### DIFF
--- a/src/gui/src/UI/UIDesktop.js
+++ b/src/gui/src/UI/UIDesktop.js
@@ -1548,21 +1548,21 @@ async function UIDesktop(options) {
     };
 
     // debounce timer to prevent toolbar showing immediately after drag ends
-    window.dragReleaseDebounceTimer = null;
+    window.drag_release_debounce_timer = null;
     const DRAG_RELEASE_DEBOUNCE_MS = 300; 
 
     // track when drag operations end to enable debounce
     $(document).on('dragend', function() {
-        window.dragReleaseDebounceTimer = setTimeout(() => {
-            window.dragReleaseDebounceTimer = null;
+        window.drag_release_debounce_timer = setTimeout(() => {
+            window.drag_release_debounce_timer = null;
         }, DRAG_RELEASE_DEBOUNCE_MS);
     });
 
     // also debounce when mouseup occurs while in drag state
     $(document).on('mouseup', function() {
         if (window.a_window_is_being_dragged || window.an_item_is_being_dragged) {
-            window.dragReleaseDebounceTimer = setTimeout(() => {
-                window.dragReleaseDebounceTimer = null;
+            window.drag_release_debounce_timer = setTimeout(() => {
+                window.drag_release_debounce_timer = null;
             }, DRAG_RELEASE_DEBOUNCE_MS);
         }
     });
@@ -1570,7 +1570,7 @@ async function UIDesktop(options) {
     // hovering over a hidden toolbar will show it
     $(document).on('mouseenter', '.toolbar-hidden', function () {
         // if a window is being dragged or currently in drag release debounce period, don't show the toolbar
-        if(window.a_window_is_being_dragged || window.dragReleaseDebounceTimer !== null)
+        if(window.a_window_is_being_dragged || window.drag_release_debounce_timer !== null)
             return;
 
         // if selectable is active , don't show the toolbar


### PR DESCRIPTION
Fix for issue: [#1862 ](https://github.com/HeyPuter/puter/issues/1862)

Fixed issue where toolbar would pop up briefly when a user drags a window to maximize over the toolbar

This PR introduces a small UX improvement to the desktop toolbar behavior. Previously, when a window was being dragged to the top of the screen to maximize it, the toolbar would pop up briefly causing an annoying unwanted behaviour.

Key Changes
- Added a debounce timer (dragReleaseDebounceTimer) that activates whenever a window drag operation ends.
- During the debounce period, the toolbar will not reveal itself, even if the mouse enters the toolbar area.
- Updated the toolbar mouseenter handler to respect the new debounce state.
- Ensures smoother drag interactions and prevents accidental toolbar activation during or immediately after window drag.
Result
Dragging windows feels more consistent, avoids unintended toolbar pop-ups.

https://github.com/user-attachments/assets/06f84a40-c9ee-4d18-94fe-2c491f0c835f