### PR TITLE
fix(puterfs): use node `crypto` instead of Web API

### DIFF
--- a/extensions/puterfs/PuterFSProvider.js
+++ b/extensions/puterfs/PuterFSProvider.js
@@ -20,6 +20,7 @@
 const STUCK_STATUS_TIMEOUT = 10 * 1000;
 const STUCK_ALARM_TIMEOUT = 20 * 1000;
 
+import crypto from 'node:crypto';
 import path_ from 'node:path';
 import { v4 as uuidv4 } from 'uuid';
 


### PR DESCRIPTION
By default node has a global `crypto` variable conforming to the standard for the Web Crypto API. However, this `crypto` object does not have the `createHash` function, so 'node:crypto' must be imported instead.