### PR TITLE
docs: onboarding — add issue & PR templates, clarify README local dev and .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,18 @@
-PORT=4000
+# Example .env for local dev — copy to `.env` in your host if needed.
+# Do NOT commit your real secrets.
+
+# Base URL (optional). Default will be http://localhost:4100
+# PUBLIC_URL=http://puter.localhost:4100
+
+# Database (if used): connection string placeholder
+# DATABASE_URL=postgres://user:pass@localhost:5432/puter
+
+# APP_SECRET is used to sign cookies / tokens in development.
+# Use a secure random value for production.
+# APP_SECRET=change-this-in-production
+
+# CLOUD_API_KEY example (if using third-party services)
+# CLOUD_API_KEY=
+
+# Turn off analytics / telemetry (boolean)
+# TELEMETRY=false

--- a/.github/ISSUE_TEMPLATE/good-first-issue.md
+++ b/.github/ISSUE_TEMPLATE/good-first-issue.md
@@ -1,0 +1,23 @@
+---
+name: Good first issue
+about: Use this template to propose a task that is suitable for new contributors.
+title: "good first issue: <short summary>"
+labels: ["good first issue","help wanted"]
+assignees: []
+---
+
+### Summary
+(Short, single-sentence description of the problem to solve)
+
+### Why this is helpful
+(One or two sentences explaining why this would help the project and who benefits.)
+
+### Acceptance criteria
+- [ ] What success looks like (e.g., "README wording improved", "typo fixed", "CI passes")
+
+### Steps / guidance
+1. Link to the file(s) to edit (e.g., `README.md`, `.env.example`, `src/...`).
+2. Recommended branch name: `fix/your-name-shortdesc`.
+3. Run locally: `npm install && npm start`. See `CONTRIBUTING.md` for setup.
+
+If you want help getting started, leave a comment and a maintainer or contributor will help.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Summary
+(One-sentence summary of the change.)
+
+## What it fixes / changes
+- Reference issue: Closes #<issue-number> (if applicable)
+- Short description of changes made
+
+## How I tested
+- Steps you ran locally: e.g., `npm install && npm start`
+- Tests run: `npm test` (if applicable). If doc-only change, mention that it's docs-only.
+
+## Checklist
+- [ ] My changes are small and focused
+- [ ] I followed the project's `CONTRIBUTING.md`
+- [ ] I ran `npm run lint` and fixed any warnings (if code changes)
+- [ ] This PR includes screenshots if UI changes were made
+
+## Notes for maintainers
+(Any additional context, optional)

--- a/README.md
+++ b/README.md
@@ -183,3 +183,29 @@ This repository, including all its contents, sub-projects, modules, and componen
 - [PuterAI Module](./src/backend/doc/modules/puterai/README.md)
 - [Metering Service](./src/backend/src/services/MeteringService/README.md)
 - [Extensions Development Guide](./extensions/README.md)
+
+### Local Development
+
+1. Clone & install
+\`\`\`bash
+git clone https://github.com/HeyPuter/puter
+cd puter
+npm install
+npm start
+\`\`\`
+
+2. Open in browser
+- App should be available at: \`http://puter.localhost:4100\` (or the next available port).
+
+3. Quick troubleshooting (First Run)
+- If \`puter.localhost\` does not resolve, try \`http://localhost:4100\` instead.
+- If port 4100 is already in use, \`npm start\` will pick the next free port — check the console output for the URL.
+- If the app fails to start:
+  - Ensure Node.js is a supported version (see \`package.json\` engines).
+  - Remove \`node_modules\` and reinstall: \`rm -rf node_modules package-lock.json && npm install\`.
+  - On Linux, if using Docker, ensure the directories are owned by uid 1000 as shown in the Docker instructions.
+- For Docker users, use the commands under **Docker / Docker Compose** later in this README.
+
+4. Need help?
+- Open an issue with the \`good first issue\` label or join the community Discord (link in the repo header).
+


### PR DESCRIPTION
This is a small documentation-only PR to improve contributor onboarding:

- Add `.github/ISSUE_TEMPLATE/good-first-issue.md` to help new contributors find tasks.
- Add `.github/PULL_REQUEST_TEMPLATE.md` to standardize PR info and ease reviews.
- Clarify README Local Development troubleshooting (tips for host/port, node_modules, Docker).
- Add explanatory comments to `.env.example`.

Why:
- These are low-risk, high-value changes that reduce friction for new contributors and make reviews faster.

How I tested:
- Document-only changes; no code changes. Verified files locally.

Notes:
- If any maintainers prefer the README change consolidated into an existing section rather than appended, I'm happy to update the PR per feedback.
