### PR TITLE
Add owner-wide and access-level permissions for apps/sites

### DIFF
--- a/src/backend/doc/lists-of-things/list-of-permissions.md
+++ b/src/backend/doc/lists-of-things/list-of-permissions.md
@@ -33,6 +33,8 @@
   will be specified here with `my-name`.
 - This permission is always rewritten as the permission
   described below (backend does this automatically).
+  
+- `<ACCESS-LEVEL>` may be `access`, `read`, or `write` (where `write` implies `read`, and `read` implies `access`).
 
 ### `site:uid#<UUID-OF-SITE>:access`
 - If the subdomain is **not** [protected](../features/protected-apps.md),
@@ -41,15 +43,34 @@
   allow access to the site via a Puter app iframe with
   a token for the entity to which permission was granted
 
-### `app:<NAME-OF-APP>:access`
+### `site:owner#<UUID-OF-USER>:<ACCESS-LEVEL>`
+- Grants access to **all protected sites owned by the specified user**.
+- When checking a specific site permission (`site:uid#...:<ACCESS-LEVEL>`), the system
+  treats this owner-wide permission as sufficient if the site's owner matches.
+- You can also specify the owner by username using
+  `site:owner@<USERNAME>:<ACCESS-LEVEL>`; it will be rewritten to the canonical
+  `owner#<UUID>` form automatically.
+  
+### `app:<NAME-OF-APP>:<ACCESS-LEVEL>`
 
 - `<NAME-OF-APP>` specifies the app that this
   permission is associated with.
 - This permission is always rewritten as the permission
   described below (backend does this automatically).
   
-### `app:uid#<UUID-OF-APP>:access`
+- `<ACCESS-LEVEL>` may be `access`, `read`, or `write` (where `write` implies `read`, and `read` implies `access`).
+  
+### `app:uid#<UUID-OF-APP>:<ACCESS-LEVEL>`
 - If the app is **not** [protected](../features/protected-apps.md),
   this permission is ignored by the system.
 - If the app **is** protected, this permission will
   allow reading the app's metadata and seeing that the app exists.
+
+### `app:owner#<UUID-OF-USER>:<ACCESS-LEVEL>`
+- Grants access to **all protected apps owned by the specified user**.
+- When checking a specific app permission (`app:uid#...:<ACCESS-LEVEL>`), the system
+  treats this owner-wide permission as sufficient if the app's owner matches.
+- You can also specify the owner by username using
+  `app:owner@<USERNAME>:<ACCESS-LEVEL>`; it will be rewritten to the canonical
+  `owner#<UUID>` form automatically.
+- Same access levels apply: `access`, `read`, `write` (`write` ⇒ `read` ⇒ `access`).

--- a/src/backend/src/modules/apps/ProtectedAppService.js
+++ b/src/backend/src/modules/apps/ProtectedAppService.js
@@ -17,9 +17,9 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-const { get_app } = require('../../helpers');
+const { get_app, get_user } = require('../../helpers');
 const { UserActorType } = require('../../services/auth/Actor');
-const { PermissionImplicator, PermissionUtil, PermissionRewriter } =
+const { PermissionExploder, PermissionImplicator, PermissionUtil, PermissionRewriter } =
     require('../../services/auth/permissionUtils.mjs');
 const BaseService = require('../../services/BaseService');
 
@@ -42,6 +42,21 @@ class ProtectedAppService extends BaseService {
     async _init () {
         const svc_permission = this.services.get('permission');
 
+        // Allow specifying owner by username and rewrite to the canonical UID form
+        svc_permission.register_rewriter(PermissionRewriter.create({
+            matcher: permission => {
+                if ( ! permission.startsWith('app:') ) return false;
+                const [_, specifier] = PermissionUtil.split(permission);
+                return specifier.startsWith('owner@');
+            },
+            rewriter: async permission => {
+                const [_1, owner_spec, ...rest] = PermissionUtil.split(permission);
+                const username = owner_spec.slice('owner@'.length);
+                const user = await get_user({ username });
+                return PermissionUtil.join(_1, `owner#${user.uuid ?? user.uid ?? user.id}`, ...rest);
+            },
+        }));
+
         svc_permission.register_rewriter(PermissionRewriter.create({
             matcher: permission => {
                 if ( ! permission.startsWith('app:') ) return false;
@@ -53,6 +68,51 @@ class ProtectedAppService extends BaseService {
                 const [_1, name, ...rest] = PermissionUtil.split(permission);
                 const app = await get_app({ name });
                 return PermissionUtil.join(_1, `uid#${app.uid}`, ...rest);
+            },
+        }));
+
+        // Access levels: write > read > access
+        svc_permission.register_exploder(PermissionExploder.create({
+            id: 'app-access-levels',
+            matcher: permission => permission.startsWith('app:'),
+            exploder: async ({ permission }) => {
+                const parts = PermissionUtil.split(permission);
+                if ( parts.length < 3 ) return [permission];
+
+                const [prefix, spec, lvl, ...rest] = parts;
+                const perms = [permission];
+                if ( lvl === 'access' ) {
+                    perms.push(PermissionUtil.join(prefix, spec, 'read', ...rest));
+                    perms.push(PermissionUtil.join(prefix, spec, 'write', ...rest));
+                } else if ( lvl === 'read' ) {
+                    perms.push(PermissionUtil.join(prefix, spec, 'write', ...rest));
+                }
+                return perms;
+            },
+        }));
+
+        // Explode a specific app access permission to the owner's wildcard permission
+        svc_permission.register_exploder(PermissionExploder.create({
+            id: 'app-owner-wildcard',
+            matcher: permission => {
+                if ( ! permission.startsWith('app:') ) return false;
+                const parts = PermissionUtil.split(permission);
+                return parts[1]?.startsWith('uid#') && parts[2];
+            },
+            exploder: async ({ permission }) => {
+                const [_1, app_spec, ...rest] = PermissionUtil.split(permission);
+                const app_uid = app_spec.slice('uid#'.length);
+                const app = await get_app({ uid: app_uid });
+                if ( ! app ) return [permission];
+
+                const owner = await get_user({ id: app.owner_user_id });
+                if ( ! owner ) return [permission];
+
+                const owner_id = owner.uuid ?? owner.uid ?? owner.id;
+                return [
+                    permission,
+                    PermissionUtil.join(_1, `owner#${owner_id}`, ...rest),
+                ];
             },
         }));
 


### PR DESCRIPTION
Expanded permission system to support owner-wide permissions (by UID or username) and hierarchical access levels (access, read, write) for both apps and sites. Updated permission documentation, backend services, and UI descriptions to reflect these changes, enabling more flexible and granular permission management.