### PR TITLE
fix: add missing 'it' import from vitest in MeteringService.test.ts

### DIFF
--- a/src/backend/src/services/MeteringService/MeteringService.test.ts
+++ b/src/backend/src/services/MeteringService/MeteringService.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { testKernel } from '../../../test.setup.mjs';
 
 describe('MeteringService', () => {


### PR DESCRIPTION
## Summary

This PR fixes a bug in `MeteringService.test.ts` where the `it` function from vitest was being used without being imported.

## Problem

The test file was using `it('should have some services', ...)` on line 6, but the import statement on line 1 only imported `{ describe, expect }` from vitest, causing a `ReferenceError: it is not defined` when running tests.

## Solution

Added `it` to the import statement:
```typescript
import { describe, expect, it } from 'vitest';
```

This is a simple one-line fix that resolves the test failure.