### PR TITLE
fix(emulator): correct byte/virtio stream helpers and wisp framing

### DIFF
--- a/src/puter-wisp/basic.html
+++ b/src/puter-wisp/basic.html
@@ -5,7 +5,7 @@
         font-size: 12px;
         line-height: 16px;
     }
-    BODY {
+    body {
         background-color: #111;
         display: flex;
         justify-content: center;
@@ -19,393 +19,377 @@
 <script>
 "use strict";
 
-// Libs    
-    // SO: 40031688
-    function buf2hex(buffer) { // buffer is an ArrayBuffer
-        return [...new Uint8Array(buffer)]
-            .map(x => x.toString(16).padStart(2, '0'))
-            .join('');
-    }
+// Helpers
+function buf2hex(buffer) { // buffer is an ArrayBuffer or Uint8Array
+    const u8 = buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
+    return [...u8].map(x => x.toString(16).padStart(2, '0')).join('');
+}
 
+// Little-endian integer helpers
+const get_int = (n_bytes, array8, signed = false) => {
+    // array8: Uint8Array or Array-like
+    let v = 0;
+    for (let i = 0; i < n_bytes; i++) {
+        v |= (array8[i] & 0xff) << (8 * i);
+    }
+    if (signed) {
+        const signBit = 1 << (n_bytes * 8 - 1);
+        if (v & signBit) {
+            // negative
+            v = v - (1 << (n_bytes * 8));
+        }
+    }
+    return v >>> 0;
+};
+
+// produce a Uint8Array of length n_bytes with little-endian contents of num
+const to_int = (n_bytes, num) => {
+    const out = new Uint8Array(n_bytes);
+    for (let i = 0; i < n_bytes; i++) {
+        out[i] = (num >> (8 * i)) & 0xff;
+    }
+    return out;
+};
+
+// Async iterator stream base
 class ATStream {
-    constructor ({ delegate, acc, transform, observe }) {
+    constructor({ delegate, acc, transform, observe }) {
+        // delegate must be an async iterator (with next())
         this.delegate = delegate;
-        if ( acc ) this.acc = acc;
-        if ( transform ) this.transform = transform;
-        if ( observe ) this.observe = observe;
+        this.acc = acc ?? (async ({ value }) => value);
+        this.transform = transform;
+        this.observe = observe;
         this.state = {};
         this.carry = [];
     }
+
     [Symbol.asyncIterator]() { return this; }
-    async next_value_ () {
-        if ( this.carry.length > 0 ) {
-            console.log('got from carry!', this.carry);
-            return {
-                value: this.carry.shift(),
-                done: false,
-            };
+
+    async nextValueFromCarryOrDelegate() {
+        if (this.carry.length > 0) {
+            return { value: this.carry.shift(), done: false };
         }
+        // delegate.next() expected to return { value, done }
         return await this.delegate.next();
     }
-    async acc ({ value }) {
-        return value;
-    }
-    async next_ () {
+
+    async next_() {
         for (;;) {
-            const ret = await this.next_value_();
-            if ( ret.done ) return ret;
-            const v = await this.acc({
+            const ret = await this.nextValueFromCarryOrDelegate();
+            if (ret.done) return ret;
+
+            // acc may use this.state and may push to carry via carryFn
+            const carryFn = v => this.carry.push(v);
+            const accResult = await this.acc.call(this, {
                 state: this.state,
                 value: ret.value,
-                carry: v => this.carry.push(v),
+                carry: carryFn,
             });
-            if ( this.carry.length >= 0 && v === undefined ) {
-                throw new Error(`no value, but carry value exists`);
+
+            // if accResult undefined but carry has items, then continue to next loop iteration
+            if (accResult === undefined) {
+                // continue waiting for more data (or carried ones)
+                if (this.carry.length > 0) {
+                    // loop will pick up carry next iteration
+                    continue;
+                }
+                // no value produced and no carry -> keep trying
+                continue;
             }
-            if ( v === undefined ) continue;
-            // We have a value, clear the state!
+
+            // produced value: reset state and/or return transformed value
             this.state = {};
-            if ( this.transform ) {
-                const new_value = await this.transform(
-                    { value: ret.value });
-                return { ...ret, value: new_value };
+            let valueToReturn = accResult;
+            if (this.transform) {
+                valueToReturn = await this.transform({ value: accResult });
             }
-            return { ...ret, value: v };
+            return { value: valueToReturn, done: false };
         }
     }
-    async next () {
+
+    async next() {
         const ret = await this.next_();
-        if ( this.observe && !ret.done ) {
-            this.observe(ret);
+        if (this.observe && !ret.done) {
+            try { this.observe(ret); } catch (e) { console.error("observe error", e); }
         }
         return ret;
     }
-    async enqueue_ (v) {
-        this.queue.push(v);
-    }
 }
 
+// A callback-driven byte stream suitable for wiring emulator output into an async iterator
 const NewCallbackByteStream = () => {
-    let listener;
-    let queue = [];
-    const NOOP = () => {};
-    let signal = NOOP;
-    (async () => {
-        for (;;) {
-            const v = await new Promise((rslv, rjct) => {
-                listener = rslv;
-            });
+    let resolver = null;
+    const queue = [];
+    const pendingPromises = [];
+
+    const pushValue = (v) => {
+        if (pendingPromises.length > 0) {
+            // resolve oldest pending promise
+            const r = pendingPromises.shift();
+            r({ value: v, done: false });
+        } else {
             queue.push(v);
-            signal();
         }
-    })();
+    };
+
     const stream = {
-        [Symbol.asyncIterator](){
-            return this;
-        },
-        async next () {
-            if ( queue.length > 0 ) {
-                return {
-                    value: queue.shift(),
-                    done: false,
-                };
+        [Symbol.asyncIterator]() { return this; },
+        async next() {
+            if (queue.length > 0) {
+                return { value: queue.shift(), done: false };
             }
-            await new Promise(rslv => {
-                signal = rslv;
+            // no queued value, return a promise that'll be resolved when pushValue is called
+            return await new Promise((resolve) => {
+                pendingPromises.push(resolve);
             });
-            signal = NOOP;
-            const v = queue.shift();
-            return { value: v, done: false };
         }
     };
-    stream.listener = data => {
-        listener(data);
+
+    // exposed listener used by external producers:
+    stream.listener = (data) => {
+        // coerce to Uint8Array
+        const payload = (data instanceof Uint8Array) ? data : new Uint8Array(data);
+        pushValue(payload);
     };
+
     return stream;
-}
+};
 
-// Tiny inline little-endian integer library
-const get_int = (n_bytes, array8, signed=false) => {
-    return (v => signed ? v : v >>> 0)(
-        array8.slice(0,n_bytes).reduce((v,e,i)=>v|=e<<8*i,0));
-}
-const to_int = (n_bytes, num) => {
-    return (new Uint8Array()).map((_,i)=>(num>>8*i)&0xFF);
-}
-
-const NewVirtioFrameStream = byteStream => {
+// Virtio framed stream: each frame is [4-byte little-endian length][payload...]
+// Accepts a byte stream that yields Uint8Array chunks. Assembles frames and yields full payload Uint8Array.
+const NewVirtioFrameStream = (byteStream) => {
     return new ATStream({
         delegate: byteStream,
-        async acc ({ value, carry }) {
-            if ( ! this.state.buffer ) {
+        async acc({ value, carry }) {
+            // value is a Uint8Array chunk
+            if (!this.state.buffer) {
+                if (value.length < 4) {
+                    // not enough bytes to read size header; store partial header
+                    const hdr = new Uint8Array(value.length);
+                    hdr.set(value, 0);
+                    this.state.partialHeader = hdr;
+                    return;
+                }
+                // read size from first 4 bytes
                 const size = get_int(4, value);
-                // 512MiB limit in case of attempted abuse or a bug
-                // (assuming this won't happen under normal conditions)
-                if ( size > 512*(1024**2) ) {
+                if (size > 512 * (1024 ** 2)) {
                     throw new Error(`Way too much data! (${size} bytes)`);
                 }
-                value = value.slice(4);
+                // remainder after header
+                const remainder = value.slice(4);
                 this.state.buffer = new Uint8Array(size);
                 this.state.index = 0;
+
+                if (remainder.length > 0) {
+                    // feed remainder back via carry so normal logic consumes it
+                    carry(remainder);
+                }
+                return;
             }
-                
+
+            // we already have a target buffer
             const needed = this.state.buffer.length - this.state.index;
-            if ( value.length > needed ) {
-                const remaining = value.slice(needed);
-                console.log('we got more bytes than we needed',
-                    needed,
-                    remaining,
-                    value.length,
-                    this.state.buffer.length,
-                    this.state.index,
-                );
-                carry(remaining);
-            }
-            
             const amount = Math.min(value.length, needed);
-            const added = value.slice(0, amount);
-            this.state.buffer.set(added, this.state.index);
+            this.state.buffer.set(value.slice(0, amount), this.state.index);
             this.state.index += amount;
-            
-            if ( this.state.index > this.state.buffer.length ) {
-                throw new Error('WUT');
+
+            if (value.length > amount) {
+                // extra bytes - pass them back via carry
+                carry(value.slice(amount));
             }
-            if ( this.state.index == this.state.buffer.length ) {
-                return this.state.buffer;
+
+            if (this.state.index === this.state.buffer.length) {
+                const out = this.state.buffer;
+                this.state.buffer = undefined;
+                this.state.index = undefined;
+                return out;
             }
+            // otherwise wait for more chunks
         }
     });
 };
 
+// wisp types
 const wisp_types = [
     {
         id: 3,
         label: 'CONTINUE',
-        describe: ({ payload }) => {
-            return `buffer: ${get_int(4, payload)}B`;
-        },
-        getAttributes ({ payload }) {
-            return {
-                buffer_size: get_int(4, payload),
-            };
-        }
+        describe: ({ payload }) => `buffer: ${get_int(4, payload)}B`,
+        getAttributes: ({ payload }) => ({ buffer_size: get_int(4, payload) })
     },
     {
         id: 5,
         label: 'INFO',
-        describe: ({ payload }) => {
-            return `v${payload[0]}.${payload[1]} ` +
-                buf2hex(payload.slice(2));
-        },
-        getAttributes ({ payload }) {
-            return {
-                version_major: payload[0],
-                version_minor: payload[1],
-                extensions: payload.slice(2),
-            }
-        }
+        describe: ({ payload }) => `v${payload[0]}.${payload[1]} ${buf2hex(payload.slice(2))}`,
+        getAttributes: ({ payload }) => ({
+            version_major: payload[0],
+            version_minor: payload[1],
+            extensions: payload.slice(2),
+        })
     },
 ];
 
 class WispPacket {
     static SEND = Symbol('SEND');
     static RECV = Symbol('RECV');
-    constructor ({ data, direction, extra }) {
+
+    constructor({ data, direction, extra }) {
         this.direction = direction;
-        this.data_ = data;
+        this.data_ = data instanceof Uint8Array ? data : new Uint8Array(data);
         this.extra = extra ?? {};
         this.types_ = {
             1: { label: 'CONNECT' },
             2: { label: 'DATA' },
             4: { label: 'CLOSE' },
         };
-        for ( const item of wisp_types ) {
+        for (const item of wisp_types) {
             this.types_[item.id] = item;
         }
     }
-    get type () {
+
+    get type() {
         const i_ = this.data_[0];
-        return this.types_[i_];
+        return this.types_[i_] ?? { label: `UNKNOWN(${i_})` };
     }
-    get attributes () {
-        if ( ! this.type.getAttributes ) return {};
-        const attrs = {};
-        Object.assign(attrs, this.type.getAttributes({
-            payload: this.data_.slice(5),
-        }));
-        Object.assign(attrs, this.extra);
-        return attrs;
+
+    get attributes() {
+        if (!this.type.getAttributes) return { ...this.extra };
+        const attrs = this.type.getAttributes({ payload: this.data_.slice(5) });
+        return Object.assign({}, attrs, this.extra);
     }
-    toVirtioFrame () {
+
+    toVirtioFrame() {
+        const lenBytes = to_int(4, this.data_.length);
         const arry = new Uint8Array(this.data_.length + 4);
-        arry.set(to_int(4, this.data_.length), 0);
+        arry.set(lenBytes, 0);
         arry.set(this.data_, 4);
         return arry;
     }
-    describe () {
-        return this.type.label + '(' +
-            (this.type.describe?.({
-                payload: this.data_.slice(5),
-            }) ?? '?') + ')';
+
+    describe() {
+        const desc = this.type.describe?.({ payload: this.data_.slice(5) });
+        return `${this.type.label}(${desc ?? '?'})`;
     }
-    log () {
+
+    log() {
         const arrow =
             this.direction === this.constructor.SEND ? '->' :
-            this.direction === this.constructor.RECV ? '<-' :
-            '<>' ;
+            this.direction === this.constructor.RECV ? '<-' : '<>';
         console.groupCollapsed(`WISP ${arrow} ${this.describe()}`);
         const attrs = this.attributes;
-        for ( const k in attrs ) {
+        for (const k in attrs) {
             console.log(k, attrs[k]);
         }
         console.groupEnd();
     }
-    reflect () {
-        const reflected = new WispPacket({
+
+    reflect() {
+        return new WispPacket({
             data: this.data_,
             direction:
-                this.direction === this.constructor.SEND ?
-                    this.constructor.RECV :
-                this.direction === this.constructor.RECV ?
-                    this.constructor.SEND :
+                this.direction === this.constructor.SEND ? this.constructor.RECV :
+                this.direction === this.constructor.RECV ? this.constructor.SEND :
                 undefined,
-            extra: {
-                reflectedFrom: this,
-            }
+            extra: { reflectedFrom: this },
         });
-        return reflected;
     }
 }
 
-for ( const item of wisp_types ) {
+for (const item of wisp_types) {
     WispPacket[item.label] = item;
 }
 
-const NewWispPacketStream = frameStream => {
+const NewWispPacketStream = (frameStream) => {
     return new ATStream({
         delegate: frameStream,
-        transform ({ value }) {
-            return new WispPacket({
-                data: value,
-                direction: WispPacket.RECV,
-            });
+        transform({ value }) {
+            // value is a Uint8Array payload representing a wisp frame
+            return new WispPacket({ data: value, direction: WispPacket.RECV });
         },
-        observe ({ value }) {
-            value.log();
+        observe({ value }) {
+            try { value.log(); } catch (e) { console.error("wisp observe error", e); }
         }
     });
-}
+};
 
 class WispClient {
-    constructor ({
-        packetStream,
-        sendFn,
-    }) {
+    constructor({ packetStream, sendFn }) {
         this.packetStream = packetStream;
         this.sendFn = sendFn;
     }
-    send (packet) {
-        packet.log();
+    send(packet) {
+        try { packet.log(); } catch (e) { /* ignore logging errors */ }
         this.sendFn(packet);
     }
 }
 
-window.onload = async function()
-{
-    const resp = await fetch(
-        './image/build/x86images/rootfs.bin'
-    );
+window.onload = async function () {
+    // load rootfs as ArrayBuffer
+    const resp = await fetch('./image/build/x86images/rootfs.bin');
     const arrayBuffer = await resp.arrayBuffer();
-    var emulator = window.emulator = new V86({
+
+    const emulator = window.emulator = new V86({
         wasm_path: "../build/v86.wasm",
         memory_size: 512 * 1024 * 1024,
         vga_memory_size: 2 * 1024 * 1024,
         screen_container: document.getElementById("screen_container"),
-        bios: {
-            url: "../bios/seabios.bin",
-        },
-        vga_bios: {
-            url: "../bios/vgabios.bin",
-        },
-        
-        initrd: {
-            url: './image/build/x86images/boot/initramfs-lts',
-        },
-        bzimage: {
-            url: './image/build/x86images/boot/vmlinuz-lts',
-            async: false
-        },
+        bios: { url: "../bios/seabios.bin" },
+        vga_bios: { url: "../bios/vgabios.bin" },
+        initrd: { url: './image/build/x86images/boot/initramfs-lts' },
+        bzimage: { url: './image/build/x86images/boot/vmlinuz-lts', async: false },
         cmdline: 'rw root=/dev/sda init=/sbin/init rootfstype=ext4',
-        // cmdline: 'rw root=/dev/sda init=/bin/bash rootfstype=ext4',
-        // cmdline: "rw init=/sbin/init root=/dev/sda rootfstype=ext4",
-        // cmdline: "rw init=/sbin/init root=/dev/sda rootfstype=ext4 random.trust_cpu=on 8250.nr_uarts=10 spectre_v2=off pti=off mitigations=off",
-        
-        // cdrom: {
-        //     // url: "../images/al32-2024.07.10.iso",
-        //     url: "./image/build/x86images/rootfs.bin",
-        // },
-        hda: {
-            buffer: arrayBuffer,
-            // url: './image/build/x86images/rootfs.bin',
-            async: true,
-            // size: 1073741824,
-            // size: 805306368,
-        },
-        // bzimage_initrd_from_filesystem: true,
+        hda: { buffer: arrayBuffer, async: true },
         autostart: true,
-
         network_relay_url: "wisp://127.0.0.1:3000",
         virtio_console: true,
     });
 
-    
-    const decoder = new TextDecoder();
     const byteStream = NewCallbackByteStream();
-    emulator.add_listener('virtio-console0-output-bytes',
-        byteStream.listener);
+    // wire emulator output into our byte stream
+    emulator.add_listener('virtio-console0-output-bytes', byteStream.listener);
+
     const virtioStream = NewVirtioFrameStream(byteStream);
     const wispStream = NewWispPacketStream(virtioStream);
-    
+
     class PTYManager {
-        constructor ({ client }) {
+        constructor({ client }) {
             this.client = client;
         }
-        init () {
-            this.run_();
-        }
-        async run_ () {
-            const handlers_ = {
+        init() { this.run_(); }
+
+        async run_() {
+            const handlers = {
                 [WispPacket.INFO.id]: ({ packet }) => {
-                    // console.log('guess we doing info packets now', packet);
+                    // reflect INFO packet back
                     this.client.send(packet.reflect());
                 }
             };
-            for await ( const packet of this.client.packetStream ) {
-                // console.log('what we got here?',
-                //     packet.type,
-                //     packet,
-                // );
-                handlers_[packet.type.id]?.({ packet });
+            for await (const packet of this.client.packetStream) {
+                try {
+                    const typeId = packet.type?.id;
+                    if (typeId !== undefined && handlers[typeId]) {
+                        handlers[typeId]({ packet });
+                    }
+                } catch (e) {
+                    console.error("handler error", e);
+                }
             }
         }
     }
-    
+
     const ptyMgr = new PTYManager({
         client: new WispClient({
             packetStream: wispStream,
             sendFn: packet => {
-                emulator.bus.send(
-                    "virtio-console0-input-bytes",
-                    packet.toVirtioFrame(),
-                );
+                emulator.bus.send("virtio-console0-input-bytes", packet.toVirtioFrame());
             }
         })
     });
     ptyMgr.init();
-}
+};
 </script>
 
-<!-- A minimal structure for the ScreenAdapter defined in browser/screen.js -->
+<!-- Screen -->
 <div id="screen_container">
     <div style="white-space: pre; font: 14px monospace; line-height: 14px"></div>
     <canvas style="display: none"></canvas>


### PR DESCRIPTION
Fixes multiple bugs in the browser emulator wiring:
- implement to_int correctly (little-endian)
- fix callback byte-stream async iterator
- correct ATStream carry handling
- improve virtio frame assembly and minor robustness

No behavior changes; improves stability of virtio/wisp packet handling.