### PR TITLE
dev: add __import_identity__ to config for debug use

### DIFF
--- a/src/backend/src/config.js
+++ b/src/backend/src/config.js
@@ -21,6 +21,7 @@ const deep_proto_merge = require('./config/deep_proto_merge');
 // const reserved_words = require('./config/reserved_words');
 
 let config = {};
+config.__import_identity__ = require('uuid').v4();
 
 // Static defaults
 config.servers = [];
@@ -149,8 +150,6 @@ config.os.refined = config.os.archbtw;
 if ( config.os.refined ) {
     config.no_browser_launch = true;
 }
-
-module.exports = config;
 
 // NEW_CONFIG_LOADING
 const maybe_port = config =>


### PR DESCRIPTION
The vitest test suite can import different states of the same module, so this value was very helpful in determining that this was happening and eventually the cause.