### PR TITLE
Add methods for apps to request access to standard directories

### DIFF
--- a/src/gui/src/UI/UIWindowRequestPermission.js
+++ b/src/gui/src/UI/UIWindowRequestPermission.js
@@ -170,19 +170,26 @@ async function get_permission_description (permission) {
                     } else {
                         fsentry = await puter.fs.stat({ uid: resource_id, consistency: 'eventual' });
                     }
-                    fs_description_html = `use ${html_encode(fsentry.name)} located at ${html_encode(fsentry.dirpath)} with ${html_encode(action)} access.`;
+                    fs_description_html = i18n('perm_fs_file_access', {
+                        name: fsentry.name,
+                        path: fsentry.dirpath,
+                        access: action,
+                    });
                 } catch (e) {
                     // Can't stat, use resource_id directly
-                    fs_description_html = `access ${html_encode(resource_id)} with ${html_encode(action)} access.`;
+                    fs_description_html = i18n('perm_fs_resource_access', {
+                        resource_id: resource_id,
+                        access: action,
+                    });
                 }
             }
         }
 
         const permission_mappings = {
             'fs': fs_description_html,
-            'thread': action === 'post' ? `post to thread ${html_encode(resource_id)}.` : null,
-            'service': action === 'ii' ? `use ${html_encode(resource_id)} to invoke ${html_encode(interface_name)}.` : null,
-            'driver': `use ${html_encode(resource_id)} to ${html_encode(action)}.`,
+            'thread': action === 'post' ? i18n('perm_thread_post', { thread: resource_id }) : null,
+            'service': action === 'ii' ? i18n('perm_service_invoke', { service: resource_id, interface: interface_name }) : null,
+            'driver': i18n('perm_driver_use', { driver: resource_id, action: action }),
         };
 
         return permission_mappings[resource_type];
@@ -194,7 +201,7 @@ async function get_permission_description (permission) {
         if ( whoami.uuid !== parts[1] ) return null;
 
         if ( parts[2] === 'email' && parts[3] === 'read' ) {
-            return 'see your email address';
+            return i18n('perm_email_read');
         }
     }
 
@@ -212,12 +219,12 @@ async function get_standard_folder_description (resource_id, action) {
     const whoami = await puter.auth.whoami();
     const directories = whoami.directories || {};
 
-    // Standard folder names we recognize
-    const folder_descriptions = {
-        'Desktop': 'your Desktop folder',
-        'Documents': 'your Documents folder',
-        'Pictures': 'your Pictures folder',
-        'Videos': 'your Videos folder',
+    // Standard folder names we recognize - maps to i18n keys
+    const folder_i18n_keys = {
+        'Desktop': 'perm_folder_desktop',
+        'Documents': 'perm_folder_documents',
+        'Pictures': 'perm_folder_pictures',
+        'Videos': 'perm_folder_videos',
     };
 
     // Check if resource_id matches any of the user's standard directories
@@ -231,10 +238,14 @@ async function get_standard_folder_description (resource_id, action) {
         if ( path_parts.length !== 2 ) continue;
 
         const folder_name = path_parts[1];
-        const folder_desc = folder_descriptions[folder_name];
-        if ( ! folder_desc ) continue;
+        const folder_i18n_key = folder_i18n_keys[folder_name];
+        if ( ! folder_i18n_key ) continue;
 
-        return `<strong>${html_encode(action)}</strong> ${folder_desc}.`;
+        const folder_desc = i18n(folder_i18n_key);
+        return i18n('perm_folder_access', {
+            access: `<strong>${html_encode(action)}</strong>`,
+            folder: folder_desc,
+        }, false);
     }
 
     return null;

--- a/src/gui/src/i18n/translations/en.js
+++ b/src/gui/src/i18n/translations/en.js
@@ -514,6 +514,19 @@ const en = {
 
         'set_as_background': 'Set as Desktop Background',
 
+        // Permission Descriptions
+        'perm_fs_file_access': 'use {{name}} located at {{path}} with {{access}} access.',
+        'perm_fs_resource_access': 'access {{resource_id}} with {{access}} access.',
+        'perm_folder_access': '{{access}} {{folder}}.',
+        'perm_thread_post': 'post to thread {{thread}}.',
+        'perm_service_invoke': 'use {{service}} to invoke {{interface}}.',
+        'perm_driver_use': 'use {{driver}} to {{action}}.',
+        'perm_email_read': 'see your email address',
+        'perm_folder_desktop': 'your Desktop folder',
+        'perm_folder_documents': 'your Documents folder',
+        'perm_folder_pictures': 'your Pictures folder',
+        'perm_folder_videos': 'your Videos folder',
+
         'error_user_or_path_not_found': 'User or path not found.',
         'error_invalid_username': 'Invalid username.',
     },

--- a/src/puter-js/src/modules/Perms.js
+++ b/src/puter-js/src/modules/Perms.js
@@ -125,7 +125,7 @@ export default class Perms {
      */
     async requestEmail () {
         let whoami;
-        whoami = await puter.auth.whoami();
+        whoami = await this.puter.auth.whoami();
         if ( whoami.email !== undefined ) return whoami.email;
         const granted = await this.puter.ui.requestPermission({
             permission: `user:${whoami.uuid}:email:read`,
@@ -134,6 +134,136 @@ export default class Perms {
             whoami = await this.puter.auth.whoami();
         }
         return whoami.email;
+    }
+
+    /**
+     * Request read access to the user's Desktop folder. If the user has already
+     * granted this permission the user will not be prompted and the path will
+     * be returned. If the user grants permission the path will be returned.
+     * If the user does not allow access `undefined` will be returned.
+     *
+     * @return {string|undefined} The Desktop path or undefined
+     */
+    async requestReadDesktop () {
+        return this.requestFolder_('Desktop', 'read');
+    }
+
+    /**
+     * Request write access to the user's Desktop folder. If the user has already
+     * granted this permission the user will not be prompted and the path will
+     * be returned. If the user grants permission the path will be returned.
+     * If the user does not allow access `undefined` will be returned.
+     *
+     * @return {string|undefined} The Desktop path or undefined
+     */
+    async requestWriteDesktop () {
+        return this.requestFolder_('Desktop', 'write');
+    }
+
+    /**
+     * Request read access to the user's Documents folder. If the user has already
+     * granted this permission the user will not be prompted and the path will
+     * be returned. If the user grants permission the path will be returned.
+     * If the user does not allow access `undefined` will be returned.
+     *
+     * @return {string|undefined} The Documents path or undefined
+     */
+    async requestReadDocuments () {
+        return this.requestFolder_('Documents', 'read');
+    }
+
+    /**
+     * Request write access to the user's Documents folder. If the user has already
+     * granted this permission the user will not be prompted and the path will
+     * be returned. If the user grants permission the path will be returned.
+     * If the user does not allow access `undefined` will be returned.
+     *
+     * @return {string|undefined} The Documents path or undefined
+     */
+    async requestWriteDocuments () {
+        return this.requestFolder_('Documents', 'write');
+    }
+
+    /**
+     * Request read access to the user's Pictures folder. If the user has already
+     * granted this permission the user will not be prompted and the path will
+     * be returned. If the user grants permission the path will be returned.
+     * If the user does not allow access `undefined` will be returned.
+     *
+     * @return {string|undefined} The Pictures path or undefined
+     */
+    async requestReadPictures () {
+        return this.requestFolder_('Pictures', 'read');
+    }
+
+    /**
+     * Request write access to the user's Pictures folder. If the user has already
+     * granted this permission the user will not be prompted and the path will
+     * be returned. If the user grants permission the path will be returned.
+     * If the user does not allow access `undefined` will be returned.
+     *
+     * @return {string|undefined} The Pictures path or undefined
+     */
+    async requestWritePictures () {
+        return this.requestFolder_('Pictures', 'write');
+    }
+
+    /**
+     * Request read access to the user's Videos folder. If the user has already
+     * granted this permission the user will not be prompted and the path will
+     * be returned. If the user grants permission the path will be returned.
+     * If the user does not allow access `undefined` will be returned.
+     *
+     * @return {string|undefined} The Videos path or undefined
+     */
+    async requestReadVideos () {
+        return this.requestFolder_('Videos', 'read');
+    }
+
+    /**
+     * Request write access to the user's Videos folder. If the user has already
+     * granted this permission the user will not be prompted and the path will
+     * be returned. If the user grants permission the path will be returned.
+     * If the user does not allow access `undefined` will be returned.
+     *
+     * @return {string|undefined} The Videos path or undefined
+     */
+    async requestWriteVideos () {
+        return this.requestFolder_('Videos', 'write');
+    }
+
+    /**
+     * Internal helper to request access to a user's special folder.
+     * @private
+     * @param {string} folderName - The name of the folder (Desktop, Documents, Pictures, Videos)
+     * @param {string} accessLevel - The access level (read, write)
+     * @return {string|undefined} The folder path or undefined
+     */
+    async requestFolder_ (folderName, accessLevel) {
+        const whoami = await this.puter.auth.whoami();
+        const folderPath = `/${whoami.username}/${folderName}`;
+
+        // Check if we already have access by trying to stat the folder
+        try {
+            await this.puter.fs.stat({ path: folderPath });
+            
+            // If we can stat the folder, we have at least read access
+            if ( accessLevel !== 'write' ) {
+                return folderPath;
+            }
+        } catch (e) {
+            // No access yet, need to request permission
+        }
+
+        const granted = await this.puter.ui.requestPermission({
+            permission: `fs:${folderPath}:${accessLevel}`,
+        });
+
+        if ( granted ) {
+            return folderPath;
+        }
+
+        return undefined;
     }
     // #endregion
 }


### PR DESCRIPTION
I accidentally re-used by `requestEmail` branch, so that's why the name is a bit confusing. This PR includes the addition of methods such as `puter.perms.requestReadDesktop()`, more user-friendly permission request messages, and i18n (without translations)