### PR TITLE
Fix AI types

### DIFF
--- a/src/puter-js/types/modules/ai.d.ts
+++ b/src/puter-js/types/modules/ai.d.ts
@@ -188,7 +188,9 @@ export class AI {
 
     txt2speech (text: string, testMode?: boolean): Promise<HTMLAudioElement>;
     txt2speech (text: string, options: Txt2SpeechOptions, testMode?: boolean): Promise<HTMLAudioElement>;
-    txt2speech (text: string, language: string, voice?: string, engine?: string): Promise<HTMLAudioElement>;
+    txt2speech (text: string, language: string, testMode?: boolean): Promise<HTMLAudioElement>;
+    txt2speech (text: string, language: string, voice: string, testMode?: boolean): Promise<HTMLAudioElement>;
+    txt2speech (text: string, language: string, voice: string, engine: string, testMode?: boolean): Promise<HTMLAudioElement>;
 }
 
 // NOTE: AI responses contain provider-specific payloads that are not fully typed here because


### PR DESCRIPTION
- remove constructor
- remove global methods, setAuthToken, setAPIOrigin
- use stricter type (removing `[key: string]: unknown;`)
- fix streaming intellisense
- add missing imageURLArray handling
- fix all positional testmode and options
- simplify txt2speech
- add missing options everywhere
- add missing return type for chat
- fix return type speech2speech

and probably some more that i didn't write here