### PR TITLE
added keyboard shortcut guide to the UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1019,7 +1019,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1394,7 +1393,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1438,7 +1436,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3269,7 +3266,6 @@
       "resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.22.12.tgz",
       "integrity": "sha512-xcmww1O/JFP2MrlGUMd3Q78S3Qu6W3mYTXYuIqFq33EorgYHV/HqymHfXy9GjiCJ7OI+7lWx6nYFOzU7M4rd1Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jimp/core": "^0.22.12"
       }
@@ -3306,7 +3302,6 @@
       "resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.22.12.tgz",
       "integrity": "sha512-xslz2ZoFZOPLY8EZ4dC29m168BtDx95D6K80TzgUi8gqT7LY6CsajWO0FAxDwHz6h0eomHMfyGX0stspBrTKnQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jimp/utils": "^0.22.12"
       },
@@ -3319,7 +3314,6 @@
       "resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.22.12.tgz",
       "integrity": "sha512-S0vJADTuh1Q9F+cXAwFPlrKWzDj2F9t/9JAbUvaaDuivpyWuImEKXVz5PUZw2NbpuSHjwssbTpOZ8F13iJX4uw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jimp/utils": "^0.22.12"
       },
@@ -3344,7 +3338,6 @@
       "resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.22.12.tgz",
       "integrity": "sha512-xImhTE5BpS8xa+mAN6j4sMRWaUgUDLoaGHhJhpC+r7SKKErYDR0WQV4yCE4gP+N0gozD0F3Ka1LUSaMXrn7ZIA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jimp/utils": "^0.22.12",
         "tinycolor2": "^1.6.0"
@@ -3388,7 +3381,6 @@
       "resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.22.12.tgz",
       "integrity": "sha512-FNuUN0OVzRCozx8XSgP9MyLGMxNHHJMFt+LJuFjn1mu3k0VQxrzqbN06yIl46TVejhyAhcq5gLzqmSCHvlcBVw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jimp/utils": "^0.22.12"
       },
@@ -3512,7 +3504,6 @@
       "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.22.12.tgz",
       "integrity": "sha512-3NyTPlPbTnGKDIbaBgQ3HbE6wXbAlFfxHVERmrbqAi8R3r6fQPxpCauA8UVDnieg5eo04D0T8nnnNIX//i/sXg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jimp/utils": "^0.22.12"
       },
@@ -3525,7 +3516,6 @@
       "resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.22.12.tgz",
       "integrity": "sha512-9YNEt7BPAFfTls2FGfKBVgwwLUuKqy+E8bDGGEsOqHtbuhbshVGxN2WMZaD4gh5IDWvR+emmmPPWGgaYNYt1gA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jimp/utils": "^0.22.12"
       },
@@ -3541,7 +3531,6 @@
       "resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.22.12.tgz",
       "integrity": "sha512-dghs92qM6MhHj0HrV2qAwKPMklQtjNpoYgAB94ysYpsXslhRTiPisueSIELRwZGEr0J0VUxpUY7HgJwlSIgGZw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jimp/utils": "^0.22.12"
       },
@@ -3824,7 +3813,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -7952,7 +7940,6 @@
       "integrity": "sha512-jCzKdm/QK0Kg4V4IK/oMlRZlY+QOcdjv89U2NgKHZk1CYTj82/RVSx1mV/0gqCVMJ/DA+Zf/S4NBWNF8GQ+eqQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.0",
         "@typescript-eslint/types": "8.48.0",
@@ -8576,8 +8563,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
       "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
@@ -8636,7 +8622,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -9371,7 +9356,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -9616,7 +9600,6 @@
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
       "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.3",
@@ -11203,7 +11186,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.1.tgz",
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -17963,7 +17945,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -19741,7 +19722,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -19966,7 +19946,6 @@
       "integrity": "sha512-tI2l/nFHC5rLh7+5+o7QjKjSR04ivXDF4jcgV0f/bTQ+OJiITy5S6gaynVsEM+7RqzufMnVbIon6Sr5x1SDYaQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -20060,7 +20039,6 @@
       "integrity": "sha512-d9B2J9Cm9dN9+6nxMnnNJKJCtcyKfnHj15N6YNJfaFHRLua/d3sRKU9RuKmO9mB0XdFtUizlxfz/VPbd3OxGhw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.14",
         "@vitest/mocker": "4.0.14",
@@ -20192,7 +20170,6 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.103.0.tgz",
       "integrity": "sha512-HU1JOuV1OavsZ+mfigY0j8d1TgQgbZ6M+J75zDkpEAwYeXjWSqrGJtgnPblJjd/mAyTNQ7ygw0MiKOn6etz8yw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -20242,7 +20219,6 @@
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",
@@ -20473,7 +20449,6 @@
       "resolved": "https://registry.npmjs.org/winston/-/winston-3.18.3.tgz",
       "integrity": "sha512-NoBZauFNNWENgsnC9YpgyYwOVrl2m58PpQ8lNHjV3kosGs7KJ7Npk9pCUE+WJlawVSe8mykWDKWFSVfs3QO9ww==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@colors/colors": "^1.6.0",
         "@dabh/diagnostics": "^2.0.8",
@@ -20613,7 +20588,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -20845,7 +20819,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -21392,7 +21365,7 @@
     },
     "src/puter-js": {
       "name": "@heyputer/puter.js",
-      "version": "2.1.9",
+      "version": "2.1.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@heyputer/kv.js": "^0.2.1",

--- a/src/gui/src/UI/UIDesktop.js
+++ b/src/gui/src/UI/UIDesktop.js
@@ -43,6 +43,7 @@ import UIWindowWelcome from './UIWindowWelcome.js';
 import launch_app from '../helpers/launch_app.js';
 import item_icon from '../helpers/item_icon.js';
 import UIWindowSearch from './UIWindowSearch.js';
+import UIWindowKeyboardShortcuts from './UIWindowKeyboardShortcuts.js';
 
 async function UIDesktop (options) {
     // start a transaction if we're not in embedded or fullpage mode
@@ -2262,6 +2263,16 @@ $(document).on('click', '.user-options-menu-btn', async function (e) {
                 id: 'contact_us',
                 onClick: async function () {
                     UIWindowFeedback();
+                },
+            },
+            //--------------------------------------------------
+            // Keyboard Shortcuts
+            //--------------------------------------------------
+            {
+                html: i18n('keyboard_shortcuts'),
+                id: 'keyboard_shortcuts',
+                onClick: async function () {
+                    UIWindowKeyboardShortcuts();
                 },
             },
             // -------------------------------------------

--- a/src/gui/src/UI/UIWindowKeyboardShortcuts.js
+++ b/src/gui/src/UI/UIWindowKeyboardShortcuts.js
@@ -1,0 +1,142 @@
+/**
+ * Copyright (C) 2024-present Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import UIWindow from './UIWindow.js';
+
+async function UIWindowKeyboardShortcuts (options) {
+    const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+    const modKey = isMac ? '⌘' : 'Ctrl';
+    const altKey = isMac ? '⌥' : 'Alt';
+    const deleteKey = isMac ? '⌫' : 'Delete';
+
+    // Define all keyboard shortcuts organized by category
+    const shortcutCategories = [
+        {
+            title_i18n: 'shortcuts_general',
+            shortcuts: [
+                { keys: [`${modKey}`, 'F'], description_i18n: 'shortcut_search' },
+                { keys: [`${modKey}`, '?'], description_i18n: 'shortcut_show_shortcuts' },
+                { keys: ['F1'], description_i18n: 'shortcut_show_shortcuts' },
+                { keys: ['Esc'], description_i18n: 'shortcut_close_dialog' },
+            ],
+        },
+        {
+            title_i18n: 'shortcuts_file_management',
+            shortcuts: [
+                { keys: [`${modKey}`, 'A'], description_i18n: 'shortcut_select_all' },
+                { keys: [`${modKey}`, 'C'], description_i18n: 'shortcut_copy' },
+                { keys: [`${modKey}`, 'X'], description_i18n: 'shortcut_cut' },
+                { keys: [`${modKey}`, 'V'], description_i18n: 'shortcut_paste' },
+                { keys: [`${modKey}`, 'Z'], description_i18n: 'shortcut_undo' },
+                { keys: [deleteKey], description_i18n: 'shortcut_move_to_trash' },
+                { keys: isMac ? [`${altKey}`, `${modKey}`, `${deleteKey}`] : ['Shift', 'Delete'], description_i18n: 'shortcut_delete_permanently' },
+            ],
+        },
+        {
+            title_i18n: 'shortcuts_navigation',
+            shortcuts: [
+                { keys: ['↑', '↓', '←', '→'], description_i18n: 'shortcut_navigate_items' },
+                { keys: ['Enter'], description_i18n: 'shortcut_open_selected' },
+                { keys: ['Shift', '↑↓←→'], description_i18n: 'shortcut_extend_selection' },
+            ],
+        },
+        {
+            title_i18n: 'shortcuts_windows',
+            shortcuts: [
+                { keys: ['Ctrl', 'W'], description_i18n: 'shortcut_close_window' },
+            ],
+        },
+    ];
+
+    let h = '';
+    h += '<div class="keyboard-shortcuts-window">';
+    h += `<h2 class="keyboard-shortcuts-title">${i18n('keyboard_shortcuts')}</h2>`;
+    h += `<p class="keyboard-shortcuts-subtitle">${i18n('keyboard_shortcuts_subtitle')}</p>`;
+
+    shortcutCategories.forEach(category => {
+        h += '<div class="keyboard-shortcuts-category">';
+        h += `<h3 class="keyboard-shortcuts-category-title">${i18n(category.title_i18n)}</h3>`;
+        h += '<div class="keyboard-shortcuts-list">';
+
+        category.shortcuts.forEach(shortcut => {
+            h += '<div class="keyboard-shortcut-item">';
+            h += '<div class="keyboard-shortcut-keys">';
+            shortcut.keys.forEach((key, index) => {
+                h += `<kbd class="keyboard-shortcut-key">${html_encode(key)}</kbd>`;
+                if ( index < shortcut.keys.length - 1 ) {
+                    h += '<span class="keyboard-shortcut-plus">+</span>';
+                }
+            });
+            h += '</div>';
+            h += `<span class="keyboard-shortcut-description">${i18n(shortcut.description_i18n)}</span>`;
+            h += '</div>';
+        });
+
+        h += '</div>';
+        h += '</div>';
+    });
+
+    h += '<div class="keyboard-shortcuts-footer">';
+    h += `<p class="keyboard-shortcuts-tip">${i18n('keyboard_shortcuts_tip')}</p>`;
+    h += '</div>';
+    h += '</div>';
+
+    const el_window = await UIWindow({
+        title: i18n('keyboard_shortcuts'),
+        icon: null,
+        uid: null,
+        is_dir: false,
+        body_content: h,
+        has_head: true,
+        selectable_body: false,
+        allow_context_menu: false,
+        is_resizable: false,
+        is_droppable: false,
+        init_center: true,
+        allow_native_ctxmenu: false,
+        allow_user_select: false,
+        window_class: 'window-keyboard-shortcuts',
+        width: 550,
+        height: 'auto',
+        dominant: true,
+        show_in_taskbar: false,
+        draggable_body: false,
+        single_instance: true,
+        app: 'keyboard-shortcuts',
+        onAppend: function (this_window) {
+        },
+        window_css: {
+            height: 'initial',
+        },
+        body_css: {
+            width: 'initial',
+            height: 'initial',
+            'background-color': 'rgb(245, 247, 249)',
+            'backdrop-filter': 'blur(3px)',
+            padding: '0',
+            overflow: 'auto',
+            'max-height': 'calc(100vh - 150px)',
+        },
+    });
+
+    return el_window;
+}
+
+export default UIWindowKeyboardShortcuts;
+

--- a/src/gui/src/css/style.css
+++ b/src/gui/src/css/style.css
@@ -5437,3 +5437,141 @@ fieldset[name=number-code] {
     width: 20px;
     height: 20px;
 }
+/* =====================================================
+   Keyboard Shortcuts Window
+   ===================================================== */
+
+.keyboard-shortcuts-window {
+    padding: 24px 28px;
+    max-width: 550px;
+}
+
+.keyboard-shortcuts-title {
+    margin: 0 0 6px 0;
+    font-size: 22px;
+    font-weight: 600;
+    color: #1a1a2e;
+    letter-spacing: -0.3px;
+}
+
+.keyboard-shortcuts-subtitle {
+    margin: 0 0 24px 0;
+    font-size: 13px;
+    color: #6b7280;
+}
+
+.keyboard-shortcuts-category {
+    margin-bottom: 20px;
+}
+
+.keyboard-shortcuts-category:last-of-type {
+    margin-bottom: 16px;
+}
+
+.keyboard-shortcuts-category-title {
+    margin: 0 0 10px 0;
+    font-size: 13px;
+    font-weight: 600;
+    color: #374151;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    padding-bottom: 6px;
+    border-bottom: 1px solid #e5e7eb;
+}
+
+.keyboard-shortcuts-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.keyboard-shortcut-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 12px;
+    background: #fff;
+    border-radius: 8px;
+    border: 1px solid #e5e7eb;
+    transition: all 0.15s ease;
+}
+
+.keyboard-shortcut-item:hover {
+    background: #f9fafb;
+    border-color: #d1d5db;
+}
+
+.keyboard-shortcut-keys {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    flex-shrink: 0;
+}
+
+.keyboard-shortcut-key {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 28px;
+    height: 26px;
+    padding: 0 8px;
+    font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Segoe UI', system-ui, sans-serif;
+    font-size: 12px;
+    font-weight: 500;
+    color: #374151;
+    background: linear-gradient(180deg, #fafafa 0%, #f0f0f0 100%);
+    border: 1px solid #d1d5db;
+    border-radius: 6px;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05), inset 0 1px 0 rgba(255, 255, 255, 0.8);
+}
+
+.keyboard-shortcut-plus {
+    color: #9ca3af;
+    font-size: 11px;
+    font-weight: 500;
+    margin: 0 2px;
+}
+
+.keyboard-shortcut-description {
+    font-size: 13px;
+    color: #4b5563;
+    text-align: right;
+    flex: 1;
+    margin-left: 16px;
+}
+
+.keyboard-shortcuts-footer {
+    margin-top: 16px;
+    padding-top: 16px;
+    border-top: 1px solid #e5e7eb;
+}
+
+.keyboard-shortcuts-tip {
+    margin: 0;
+    font-size: 12px;
+    color: #9ca3af;
+    text-align: center;
+    font-style: italic;
+}
+
+.window-keyboard-shortcuts .window-body {
+    background: linear-gradient(180deg, #f8fafc 0%, #f1f5f9 100%);
+}
+
+/* Responsive adjustments */
+@media (max-width: 600px) {
+    .keyboard-shortcuts-window {
+        padding: 16px 20px;
+    }
+
+    .keyboard-shortcut-item {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 8px;
+    }
+
+    .keyboard-shortcut-description {
+        text-align: left;
+        margin-left: 0;
+    }
+}

--- a/src/gui/src/i18n/translations/en.js
+++ b/src/gui/src/i18n/translations/en.js
@@ -533,6 +533,29 @@ const en = {
 
         'error_user_or_path_not_found': 'User or path not found.',
         'error_invalid_username': 'Invalid username.',
+
+        // Keyboard Shortcuts
+        'keyboard_shortcuts': 'Keyboard Shortcuts',
+        'keyboard_shortcuts_subtitle': 'Quick reference for navigating Puter like a pro',
+        'shortcuts_general': 'General',
+        'shortcuts_file_management': 'File Management',
+        'shortcuts_navigation': 'Navigation',
+        'shortcuts_windows': 'Windows',
+        'shortcut_search': 'Open Search',
+        'shortcut_show_shortcuts': 'Show Keyboard Shortcuts',
+        'shortcut_close_dialog': 'Close dialog or menu',
+        'shortcut_select_all': 'Select all items',
+        'shortcut_copy': 'Copy selected items',
+        'shortcut_cut': 'Cut selected items',
+        'shortcut_paste': 'Paste items',
+        'shortcut_undo': 'Undo last action',
+        'shortcut_move_to_trash': 'Move to Trash',
+        'shortcut_delete_permanently': 'Delete permanently',
+        'shortcut_navigate_items': 'Navigate between items',
+        'shortcut_open_selected': 'Open selected item',
+        'shortcut_extend_selection': 'Extend selection',
+        'shortcut_close_window': 'Close active window',
+        'keyboard_shortcuts_tip': 'Tip: Press Ctrl+? or F1 anytime to see this guide',
     },
 };
 

--- a/src/gui/src/icons/keyboard.svg
+++ b/src/gui/src/icons/keyboard.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="2" y="4" width="20" height="16" rx="2" ry="2"/>
+  <line x1="6" y1="8" x2="6" y2="8"/>
+  <line x1="10" y1="8" x2="10" y2="8"/>
+  <line x1="14" y1="8" x2="14" y2="8"/>
+  <line x1="18" y1="8" x2="18" y2="8"/>
+  <line x1="6" y1="12" x2="6" y2="12"/>
+  <line x1="10" y1="12" x2="10" y2="12"/>
+  <line x1="14" y1="12" x2="14" y2="12"/>
+  <line x1="18" y1="12" x2="18" y2="12"/>
+  <line x1="7" y1="16" x2="17" y2="16"/>
+</svg>
+

--- a/src/gui/src/keyboard.js
+++ b/src/gui/src/keyboard.js
@@ -19,6 +19,7 @@
 
 import UIAlert from './UI/UIAlert.js';
 import UIWindowSearch from './UI/UIWindowSearch.js';
+import UIWindowKeyboardShortcuts from './UI/UIWindowKeyboardShortcuts.js';
 import launch_app from './helpers/launch_app.js';
 import open_item from './helpers/open_item.js';
 import determine_active_container_parent from './helpers/determine_active_container_parent.js';
@@ -33,6 +34,20 @@ $(document).bind('keydown', async function (e) {
         e.preventDefault();
         e.stopPropagation();
         UIWindowSearch();
+        return false;
+    }
+
+    //-----------------------------------------------------------------------------
+    // Keyboard Shortcuts Guide
+    // ctrl/command + ? (shift + /) or F1, will open UIWindowKeyboardShortcuts
+    //-----------------------------------------------------------------------------
+    if (
+        (((e.ctrlKey || e.metaKey) && e.shiftKey && e.which === 191) || e.which === 112) &&
+        !$(focused_el).is('input') && !$(focused_el).is('textarea')
+    ) {
+        e.preventDefault();
+        e.stopPropagation();
+        UIWindowKeyboardShortcuts();
         return false;
     }
 


### PR DESCRIPTION
## Description
Closes #2037

This PR adds a keyboard shortcuts guide to the Puter UI, allowing users to discover and learn available shortcuts.

## Features Added
- New "Keyboard Shortcuts" modal window showing all available shortcuts
- Accessible via:
  - `Ctrl+?` (or `Cmd+?` on Mac) / `F1` keyboard shortcut
  - User options menu → "Keyboard Shortcuts"
- Shortcuts are organized by category (General, File Management, Navigation, Windows)
- Platform-aware: Shows correct modifier keys for Mac (⌘, ⌥) vs Windows/Linux (Ctrl, Alt)
- Responsive design for mobile devices
- Full i18n support for translations

## Files Changed
- `src/gui/src/UI/UIWindowKeyboardShortcuts.js` - New modal component
- `src/gui/src/keyboard.js` - Added Ctrl+?/F1 shortcut handler
- `src/gui/src/UI/UIDesktop.js` - Added menu item to user options
- `src/gui/src/i18n/translations/en.js` - Added translation keys
- `src/gui/src/css/style.css` - Added styling for the modal
- `src/gui/src/icons/keyboard.svg` - New keyboard icon