### PR TITLE
Add auth types

### DIFF
--- a/src/puter-js/types/modules/auth.d.ts
+++ b/src/puter-js/types/modules/auth.d.ts
@@ -1,8 +1,18 @@
-export interface AuthUser {
+export interface User {
     uuid: string;
     username: string;
-    email_confirmed?: boolean;
-    [key: string]: unknown;
+    email_confirmed?: boolean | number;
+    actual_free_storage?: number;
+    app_name?: string;
+    feature_flags?: Record<string, unknown>;
+    hasDevAccountAccess?: boolean;
+    is_temp?: boolean;
+    last_activity_ts?: number;
+    otp?: boolean;
+    paid_storage?: number;
+    referral_code?: string;
+    requires_email_confirmation?: boolean | number;
+    subscribed?: boolean;
 }
 
 export interface AllowanceInfo {
@@ -32,17 +42,21 @@ export interface DetailedAppUsage {
     [key: string]: APIUsage;
 }
 
+export interface SignInResult {
+    success: boolean;
+    token: string;
+    app_uid: string;
+    username: string;
+    error?: string;
+    msg?: string;
+}
+
 export class Auth {
-    constructor (context: { authToken?: string; APIOrigin: string; appID?: string });
-
-    setAuthToken (authToken: string): void;
-    setAPIOrigin (APIOrigin: string): void;
-
-    signIn (options?: { attempt_temp_user_creation?: boolean }): Promise<AuthUser | { token?: string }>;
+    signIn (options?: { attempt_temp_user_creation?: boolean }): Promise<SignInResult>;
     signOut (): void;
     isSignedIn (): boolean;
-    getUser (): Promise<AuthUser>;
-    whoami (): Promise<AuthUser>;
+    getUser (): Promise<User>;
+    whoami (): Promise<User>;
     getMonthlyUsage (): Promise<MonthlyUsage>;
     getDetailedAppUsage (appId: string): Promise<DetailedAppUsage>;
 }


### PR DESCRIPTION
- removed constructor and global method
- rename AuthUser -> User
- add SignInResult type
- add more param to User

---

hi team, so this PR should cover like the absolute stuff that we return, but here comes the question, should we even expose these types? like in User, there's like feature flags etc

2 approaches here
- hide non essential one -> easier for user to see relevant properties, but then we are hiding stuff
- show absolutely everything -> up to user to use it or no, but it will be cluttering

i'm leaning towards option 2, because i think it should be up to the user to decide, like if we were to hide stuff, how to decide like which is hidden or which is shown

thoughts?