### PR TITLE
Fix FS types

### DIFF
--- a/src/puter-js/index.d.ts
+++ b/src/puter-js/index.d.ts
@@ -4,7 +4,7 @@ import type { Apps, AppListOptions, AppRecord, CreateAppOptions, UpdateAppAttrib
 import type { Auth, APIUsage, AllowanceInfo, AppUsage, AuthUser, DetailedAppUsage, MonthlyUsage } from './types/modules/auth.d.ts';
 import type { Debug } from './types/modules/debug.d.ts';
 import type { Driver, DriverDescriptor, Drivers } from './types/modules/drivers.d.ts';
-import type { PuterJSFileSystemModule, CopyOptions, DeleteOptions, MkdirOptions, MoveOptions, ReadOptions, ReaddirOptions, SignResult, SpaceInfo, UploadOptions, WriteOptions } from './types/modules/filesystem.d.ts';
+import type { FS, CopyOptions, DeleteOptions, MkdirOptions, MoveOptions, ReadOptions, ReaddirOptions, SignResult, SpaceInfo, UploadOptions, WriteOptions } from './types/modules/filesystem.d.ts';
 import type { FSItem, FileSignatureInfo, InternalFSProperties } from './types/modules/fs-item.d.ts';
 import type { Hosting, Subdomain } from './types/modules/hosting.d.ts';
 import type { KV, KVIncrementPath, KVPair } from './types/modules/kv.d.ts';
@@ -83,7 +83,7 @@ export type {
     PTLSSocket,
     Puter,
     PuterEnvironment,
-    PuterJSFileSystemModule,
+    FS,
     ReadOptions,
     ReaddirOptions,
     RequestCallbacks,

--- a/src/puter-js/types/puter.d.ts
+++ b/src/puter-js/types/puter.d.ts
@@ -3,7 +3,7 @@ import type { Apps } from './modules/apps.d.ts';
 import type { Auth } from './modules/auth.d.ts';
 import type { Debug } from './modules/debug.d.ts';
 import type { Drivers } from './modules/drivers.d.ts';
-import type { PuterJSFileSystemModule, SpaceInfo } from './modules/filesystem.d.ts';
+import type { FS } from './modules/filesystem.d.ts';
 import type { FSItem } from './modules/fs-item.d.ts';
 import type { Hosting } from './modules/hosting.d.ts';
 import type { KV } from './modules/kv.d.ts';
@@ -51,7 +51,7 @@ export class Puter {
     apps: Apps;
     auth: Auth;
     os: OS;
-    fs: PuterJSFileSystemModule;
+    fs: FS;
     ui: UI;
     hosting: Hosting;
     kv: KV;


### PR DESCRIPTION
- rename `PuterJSFileSystemModule` to `FS`
- add missing overloads for all methods
  - this is mostly the callback ones
  - although this one also depends if we want to expose them, since we don't document it anywhere in docs
  - personally i think it's fine
- add missing options for all methods

