### PR TITLE
Add gpt 5.2 variants

### DIFF
--- a/src/backend/src/services/ai/chat/providers/OpenAiProvider/models.ts
+++ b/src/backend/src/services/ai/chat/providers/OpenAiProvider/models.ts
@@ -18,6 +18,33 @@ export const OPEN_AI_MODELS: IChatModel[] = [
         max_tokens: 128000,
     },
     {
+        id: 'gpt-5.2-chat-latest',
+        aliases: ['gpt-5.2-chat'],
+        costs_currency: 'usd-cents',
+        input_cost_key: 'prompt_tokens',
+        output_cost_key: 'completion_tokens',
+        costs: {
+            tokens: 1_000_000,
+            prompt_tokens: 175,
+            cached_tokens: 17.5,
+            completion_tokens: 1400,
+        },
+        max_tokens: 128000,
+    },
+    {
+        id: 'gpt-5.2-pro-2025-12-11',
+        aliases: ['gpt-5.2-pro'],
+        costs_currency: 'usd-cents',
+        input_cost_key: 'prompt_tokens',
+        output_cost_key: 'completion_tokens',
+        costs: {
+            tokens: 1_000_000,
+            prompt_tokens: 2100,
+            completion_tokens: 16800,
+        },
+        max_tokens: 128000,
+    },
+    {
         id: 'gpt-5.1',
         costs_currency: 'usd-cents',
         input_cost_key: 'prompt_tokens',


### PR DESCRIPTION
reference:
- https://platform.openai.com/docs/models/gpt-5.2
- https://platform.openai.com/docs/models/gpt-5.2-chat-latest
- https://platform.openai.com/docs/models/gpt-5.2-pro

info
- gpt-5.2-chat has the same price as normal gpt-5.2
- gpt-5.2-pro don't have caching