### PR TITLE
Add alias for gpt-5.2-chat

### DIFF
--- a/src/backend/src/services/ai/chat/providers/OpenAiProvider/models.ts
+++ b/src/backend/src/services/ai/chat/providers/OpenAiProvider/models.ts
@@ -5,6 +5,7 @@ import { IChatModel } from '../types';
 export const OPEN_AI_MODELS: IChatModel[] = [
     {
         id: 'gpt-5.2-chat-latest',
+        aliases: ['gpt-5.2-chat'],
         costs_currency: 'usd-cents',
         input_cost_key: 'prompt_tokens',
         output_cost_key: 'completion_tokens',


### PR DESCRIPTION
this is so the model is accessible via just `gpt-5.2-chat`