### PR TITLE
Fix speech2txt options type

### DIFF
--- a/src/puter-js/types/modules/ai.d.ts
+++ b/src/puter-js/types/modules/ai.d.ts
@@ -105,11 +105,16 @@ export interface Txt2SpeechOptions {
     voice_settings?: Record<string, unknown>;
 }
 
-export interface Speech2TxtOptions {
+export interface Speech2TxtResult {
+    text: string;
+    language: string;
+    segments?: Record<string, unknown>[];
+}
+
+interface BaseSpeech2TxtOptions {
     file?: string | File | Blob;
     audio?: string | File | Blob;
     model?: string;
-    response_format?: string;
     language?: string;
     prompt?: string;
     stream?: boolean;
@@ -121,6 +126,14 @@ export interface Speech2TxtOptions {
     known_speaker_names?: string[];
     known_speaker_references?: string[];
     extra_body?: Record<string, unknown>;
+}
+
+export interface TextFormatSpeech2TxtOptions extends BaseSpeech2TxtOptions {
+    response_format: "text";
+}
+
+export interface Speech2TxtOptions extends BaseSpeech2TxtOptions {
+    response_format?: Exclude<string, "text">;
 }
 
 export interface Speech2SpeechOptions {
@@ -178,9 +191,11 @@ export class AI {
     txt2vid (prompt: string, options: Txt2VidOptions): Promise<HTMLVideoElement>;
     txt2vid (options: Txt2VidOptions, testMode?: boolean): Promise<HTMLVideoElement>;
 
-    speech2txt (source: string | File | Blob, testMode?: boolean): Promise<string | Record<string, unknown>>;
-    speech2txt (source: string | File | Blob, options: Speech2TxtOptions, testMode?: boolean): Promise<string | Record<string, unknown>>;
-    speech2txt (options: Speech2TxtOptions, testMode?: boolean): Promise<string | Record<string, unknown>>;
+    speech2txt (source: string | File | Blob, testMode?: boolean): Promise<string>;
+    speech2txt (source: string | File | Blob, options: TextFormatSpeech2TxtOptions, testMode?: boolean): Promise<string>;
+    speech2txt (source: string | File | Blob, options: Speech2TxtOptions, testMode?: boolean): Promise<Speech2TxtResult>;
+    speech2txt (options: TextFormatSpeech2TxtOptions, testMode?: boolean): Promise<string>;
+    speech2txt (options: Speech2TxtOptions, testMode?: boolean): Promise<Speech2TxtResult>;
 
     speech2speech (source: string | File | Blob, testMode?: boolean): Promise<HTMLAudioElement>;
     speech2speech (source: string | File | Blob, options: Speech2SpeechOptions, testMode?: boolean): Promise<HTMLAudioElement>;


### PR DESCRIPTION
- make a `response_format` text specific option
- add Speech2TxtResult
- add overload for text format