### PR TITLE
Add optional requestCallbacks options to getUser

### DIFF
--- a/src/puter-js/types/modules/auth.d.ts
+++ b/src/puter-js/types/modules/auth.d.ts
@@ -1,3 +1,5 @@
+import { RequestCallbacks } from "../shared";
+
 export interface User {
     uuid: string;
     username: string;
@@ -55,7 +57,7 @@ export class Auth {
     signIn (options?: { attempt_temp_user_creation?: boolean }): Promise<SignInResult>;
     signOut (): void;
     isSignedIn (): boolean;
-    getUser (): Promise<User>;
+    getUser (options:? RequestCallbacks<User>): Promise<User>;
     whoami (): Promise<User>;
     getMonthlyUsage (): Promise<MonthlyUsage>;
     getDetailedAppUsage (appId: string): Promise<DetailedAppUsage>;


### PR DESCRIPTION
- the getUser method has the legacy callback (success, error), adding it here for completeness

note:
- i'm not gonna document the callback in docs, because i think it will just confuse users
- same with all the fs stuff that has callbacks