### PR TITLE
Add flux.2 max for together provider

### DIFF
--- a/src/backend/src/services/MeteringService/costMaps/togetherCostMap.ts
+++ b/src/backend/src/services/MeteringService/costMaps/togetherCostMap.ts
@@ -30,6 +30,7 @@ export const TOGETHER_COST_MAP = {
     'together-image:black-forest-labs/FLUX.2-pro': 0.03 * 100_000_000,
     'together-image:black-forest-labs/FLUX.2-flex': 0.03 * 100_000_000,
     'together-image:black-forest-labs/FLUX.2-dev': 0.0154 * 100_000_000,
+    'together-image:black-forest-labs/FLUX.2-max': 0.07 * 100_000_000,
     'together-image:google/flash-image-2.5': 0.039 * 100_000_000,
     'together-image:google/gemini-3-pro-image': 0.134 * 100_000_000,
     'together-image:google/imagen-4.0-fast': 0.02 * 100_000_000,

--- a/src/backend/src/services/ai/image/providers/TogetherImageGenerationProvider/models.ts
+++ b/src/backend/src/services/ai/image/providers/TogetherImageGenerationProvider/models.ts
@@ -316,4 +316,13 @@ export const TOGETHER_IMAGE_GENERATION_MODELS: IImageModel[] = [
         allowedQualityLevels: [''],
         costs: { '1MP': 0 },
     },
+    {
+        id: 'togetherai:black-forest-labs/FLUX.2-max',
+        aliases: ['black-forest-labs/FLUX.2-max', 'FLUX.2-max'],
+        costs_currency: 'usd-cents',
+        index_cost_key: '1MP',
+        name: 'black-forest-labs/FLUX.2-max',
+        allowedQualityLevels: [''],
+        costs: { '1MP': 7 },
+    },
 ];


### PR DESCRIPTION
- add flux.2 max to provider model.ts and costMap
- i'm not sure if we are still using the costMap (?)
- although i believe we used to allow all models from together directly, but has changed to explicitly add it before its enabled

info:
- together hasn't published pricing for this actually
- i got this number $0.07 per MP from black forest labs
- looking at previous flux.1 and flux.2 models it's the same between bfl and together, so i predict it will be the same
- if someone can review and cross check this, i would appreciate that a lot