### PR TITLE
Fix workers types

### DIFF
--- a/src/puter-js/types/modules/workers.d.ts
+++ b/src/puter-js/types/modules/workers.d.ts
@@ -1,22 +1,25 @@
 export interface WorkerInfo {
     name: string;
     url: string;
-    file_path?: string;
-    file_uid?: string;
-    created_at?: string;
+    file_path: string;
+    file_uid: string;
+    created_at: string;
 }
 
 export interface WorkerDeployment {
     success: boolean;
     url: string;
-    errors?: unknown[];
+    errors?: string[];
 }
 
 export class WorkersHandler {
     create (workerName: string, filePath: string, appName?: string): Promise<WorkerDeployment>;
     delete (workerName: string): Promise<boolean>;
     exec (request: RequestInfo | URL, init?: RequestInit): Promise<Response>;
-    get (workerName: string): Promise<WorkerInfo>;
+    get (workerName: string): Promise<WorkerInfo | undefined>;
     list (): Promise<WorkerInfo[]>;
-    getLoggingHandle (workerName: string): Promise<EventTarget & { close: () => void }>;
+    getLoggingHandle (workerName: string): Promise<EventTarget & {
+        close: () => void;
+        onLog: (event: MessageEvent) => void;
+    }>;
 }


### PR DESCRIPTION
- adjust WorkerInfo and WorkerDeployment property
- adjust get return type
- adjust getLoggingHandle return type

note:
- i don't document getLoggingHandle, i assume this is internal
- onLog doesn't seem to do anything in the implementation, although still adding it for now
- lmk if onLog is not needed