### PR TITLE
Update gemini models config

### DIFF
--- a/src/backend/src/services/ai/chat/providers/GeminiProvider/models.ts
+++ b/src/backend/src/services/ai/chat/providers/GeminiProvider/models.ts
@@ -4,7 +4,7 @@ export const GEMINI_MODELS: IChatModel[] = [
     {
         id: 'gemini-2.0-flash',
         name: 'Gemini 2.0 Flash',
-        context: 131072,
+        context: 1_048_576,
         costs_currency: 'usd-cents',
         input_cost_key: 'prompt_tokens',
         output_cost_key: 'completion_tokens',
@@ -74,7 +74,7 @@ export const GEMINI_MODELS: IChatModel[] = [
             completion_tokens: 1000,
             cached_tokens: 13,
         },
-        max_tokens: 200_000,
+        max_tokens: 65536,
     },
     {
         id: 'gemini-3-pro-preview',
@@ -89,7 +89,7 @@ export const GEMINI_MODELS: IChatModel[] = [
             completion_tokens: 1200,
             cached_tokens: 20,
         },
-        max_tokens: 200_000,
+        max_tokens: 65536,
     },
     {
         id: 'gemini-3-flash-preview',


### PR DESCRIPTION
for some reason the numbers we have are inaccurate, compared to google own docs
i found these while adding the gemini 3 flash

- gemini 3 pro preview should have 65,536 max tokens (source: https://ai.google.dev/gemini-api/docs/models#gemini-3-pro)
- gemini 2.5 pro should also have 65,536 max tokens (https://ai.google.dev/gemini-api/docs/pricing#gemini-2.5-pro)
- gemini 2 flash should have 1M context (https://ai.google.dev/gemini-api/docs/models#gemini-2.0-flash)

please help cross check and review this

although nothing is wrong/broken yet with these models? 
they still work, but idk what the implication is having these incorrect information