### PR TITLE
Data access simplifications (part 1: apps driver)

### DIFF
--- a/src/backend/src/data/hardcoded-permissions.js
+++ b/src/backend/src/data/hardcoded-permissions.js
@@ -115,6 +115,7 @@ const hardcoded_user_group_permissions = {
             'service:apps:ii:crud-q': policy_perm('temp.es'),
             'service:es\\Cnotification:ii:crud-q': policy_perm('user.es'),
             'service:es\\Capp:ii:crud-q': policy_perm('user.es'),
+            'service:app:ii:crud-q': policy_perm('user.es'),
             'service:es\\Csubdomain:ii:crud-q': policy_perm('user.es'),
         },
         '78b1b1dd-c959-44d2-b02c-8735671f9997': {
@@ -123,6 +124,7 @@ const hardcoded_user_group_permissions = {
             'driver:puter-kvstore': policy_perm('user.kv'),
             'service:es\\Cnotification:ii:crud-q': policy_perm('user.es'),
             'service:es\\Capp:ii:crud-q': policy_perm('user.es'),
+            'service:app:ii:crud-q': policy_perm('user.es'),
             'service:es\\Csubdomain:ii:crud-q': policy_perm('user.es'),
             'service:apps:ii:crud-q': policy_perm('user.es'),
         },

--- a/src/backend/src/modules/data-access/AppService.comp.test.js
+++ b/src/backend/src/modules/data-access/AppService.comp.test.js
@@ -20,137 +20,6 @@ import AppService from './AppService';
 
 import { describe, expect, it } from 'vitest';
 
-/*
-// CRITICAL: Mock BOTH Context modules (CommonJS and ESM) BEFORE any other imports
-// CommonJS modules use '../../util/context', ESM modules use '../../util/esmcontext.js'
-vi.mock('../../util/context', async () => {
-    const actual = await vi.importActual('../../util/context');
-    const { Context: OriginalContext } = actual;
-
-    // Store original get method BEFORE patching
-    const originalGet = OriginalContext.get;
-
-    // Store test values
-    let testContext = null;
-    let testActor = null;
-    let testUser = null;
-
-    // Patch Context.get to use test values
-    OriginalContext.get = function(key, options) {
-        // Check test values FIRST
-        if (key === 'actor' && testActor) {
-            return testActor;
-        }
-        if (key === 'user' && testUser) {
-            return testUser;
-        }
-
-        // Call original get method
-        return originalGet.call(this, key, options);
-    };
-
-    // Export patched Context with setters for test values
-    return {
-        ...actual,
-        Context: OriginalContext,
-        __setTestValues: (ctx, actor, user) => {
-            testContext = ctx;
-            testActor = actor;
-            testUser = user;
-        },
-        __clearTestValues: () => {
-            testContext = null;
-            testActor = null;
-            testUser = null;
-        },
-    };
-});
-
-vi.mock('../../util/esmcontext.js', async () => {
-    const actual = await vi.importActual('../../util/esmcontext.js');
-    const { Context: OriginalContext } = actual;
-
-    // Store original get method BEFORE patching
-    const originalGet = OriginalContext.get;
-
-    // Store test values
-    let testContext = null;
-    let testActor = null;
-    let testUser = null;
-
-    // Patch Context.get to use test values
-    OriginalContext.get = function(key, options) {
-        // Check test values FIRST
-        if (key === 'actor' && testActor) {
-            return testActor;
-        }
-        if (key === 'user' && testUser) {
-            return testUser;
-        }
-
-        // Call original get method
-        return originalGet.call(this, key, options);
-    };
-
-    // Export patched Context with setters for test values
-    return {
-        ...actual,
-        Context: OriginalContext,
-        __setTestValues: (ctx, actor, user) => {
-            testContext = ctx;
-            testActor = actor;
-            testUser = user;
-        },
-        __clearTestValues: () => {
-            testContext = null;
-            testActor = null;
-            testUser = null;
-        },
-    };
-});
-
-// Store test values globally - this is the most reliable approach
-let globalTestActor = null;
-let globalTestUser = null;
-
-// Patch Context.get directly (after imports) - this MUST work
-// We patch it on the actual Context class that's imported
-const originalContextGet = Context.get;
-Context.get = function(key, options) {
-    // ALWAYS check global test values FIRST - this is the most reliable
-    if (key === 'actor' && globalTestActor) {
-        return globalTestActor;
-    }
-    if (key === 'user' && globalTestUser) {
-        return globalTestUser;
-    }
-    // Call original
-    return originalContextGet.call(this, key, options);
-};
-
-// Also patch the Context class that CommonJS modules might have cached
-// Intercept require() calls to context.js and ensure they get our patched version
-const Module = require('module');
-const originalRequire = Module.prototype.require;
-Module.prototype.require = function(id) {
-    const result = originalRequire.call(this, id);
-    // If this is context.js, patch its Context.get
-    if (id.includes('util/context') && result && result.Context) {
-        const originalGet = result.Context.get;
-        result.Context.get = function(key, options) {
-            if (key === 'actor' && globalTestActor) {
-                return globalTestActor;
-            }
-            if (key === 'user' && globalTestUser) {
-                return globalTestUser;
-            }
-            return originalGet.call(this, key, options);
-        };
-    }
-    return result;
-};
-*/
-
 const ES_APP_ARGS = {
     entity: 'app',
     upstream: ESBuilder.create([
@@ -182,16 +51,15 @@ const ES_APP_ARGS = {
     ]),
 };
 
+// Fix: Manually initialize AsyncLocalStorage store for Vitest
+// Under Vitest, AsyncLocalStorage may not have a store initialized, causing Context.get() to fail.
+// This manually creates a store and sets the root context, ensuring Context operations work.
+// This may be a side-effect of OpenTelemetry's own use of AsyncLocalStorage.
 const fixContextInitialization = async (callback) => {
-    process.stdout.write(`contextAsyncLocalStorage:${ Context.contextAsyncLocalStorage }\n`);
-    try {
-        return Context.contextAsyncLocalStorage.run(Context.root, () => {
-            Context.contextAsyncLocalStorage.getStore().set('context', Context.root);
-            callback();
-        });
-    } catch (e) {
-        process.stdout.write(e.stack);
-    }
+    return await Context.contextAsyncLocalStorage.run(Context.root, async () => {
+        Context.contextAsyncLocalStorage.getStore().set('context', Context.root);
+        return await callback();
+    });
 };
 
 const testWithEachService = async (fnToRunOnBoth) => {
@@ -244,8 +112,6 @@ describe('AppService Regression Prevention Tests', () => {
     it('should create the app', async () => {
         await fixContextInitialization(async () => {
             await testWithEachService(async ({ kernel, key }) => {
-                // Context initialization fix
-
                 // Create a test user and context
                 const db = kernel.services.get('database').get('write', 'test');
                 const userId = 1;
@@ -284,38 +150,15 @@ describe('AppService Regression Prevention Tests', () => {
 
                 await userContext.arun(async () => {
                     Context.set('actor', actor);
-                    // Set test values in BOTH mocked Context modules AND globally
-                    // globalTestActor = actor;
-                    // globalTestUser = user;
-
-                    const contextCJS = require('../../util/context');
-                    const contextESM = await import('../../util/esmcontext.js');
-                    if ( contextCJS.__setTestValues ) contextCJS.__setTestValues(userContext, actor, user);
-                    if ( contextESM.__setTestValues ) contextESM.__setTestValues(userContext, actor, user);
-
-                    process.stdout.write(`actor: ${actor}\n`);
-                    process.stdout.write(`context root from test: ${Context.get('rootContextUUID')}\n`);
-
-                    try {
-                        const service = kernel.services.get(key);
-                        const crudQ = service.constructor.IMPLEMENTS['crud-q'];
-                        await crudQ.create.call(service, {
-                            object: {
-                                name: 'test-app',
-                                title: 'Test App',
-                                index_url: 'https://example.com',
-                            },
-                        });
-                    } finally {
-                        // Clear after test
-                        // globalTestActor = null;
-                        // globalTestUser = null;
-
-                        const contextCJS = require('../../util/context');
-                        const contextESM = await import('../../util/esmcontext.js');
-                        if ( contextCJS.__clearTestValues ) contextCJS.__clearTestValues();
-                        if ( contextESM.__clearTestValues ) contextESM.__clearTestValues();
-                    }
+                    const service = kernel.services.get(key);
+                    const crudQ = service.constructor.IMPLEMENTS['crud-q'];
+                    await crudQ.create.call(service, {
+                        object: {
+                            name: 'test-app',
+                            title: 'Test App',
+                            index_url: 'https://example.com',
+                        },
+                    });
                 });
             });
         });

--- a/src/backend/src/modules/data-access/AppService.comp.test.js
+++ b/src/backend/src/modules/data-access/AppService.comp.test.js
@@ -1,0 +1,323 @@
+import { createTestKernel } from '../../../tools/test.mjs';
+import { tmp_provide_services } from '../../helpers.js';
+import AppES from '../../om/entitystorage/AppES';
+import { AppLimitedES } from '../../om/entitystorage/AppLimitedES';
+import { ESBuilder } from '../../om/entitystorage/ESBuilder';
+import { MaxLimitES } from '../../om/entitystorage/MaxLimitES';
+import { ProtectedAppES } from '../../om/entitystorage/ProtectedAppES';
+import { SetOwnerES } from '../../om/entitystorage/SetOwnerES';
+import SQLES from '../../om/entitystorage/SQLES';
+import ValidationES from '../../om/entitystorage/ValidationES';
+import WriteByOwnerOnlyES from '../../om/entitystorage/WriteByOwnerOnlyES';
+import { Eq, Or } from '../../om/query/query';
+import { Actor, UserActorType } from '../../services/auth/Actor';
+import { EntityStoreService } from '../../services/EntityStoreService';
+import { Context } from '../../util/esmcontext.js';
+import { AppIconService } from '../apps/AppIconService';
+import { AppInformationService } from '../apps/AppInformationService';
+import { OldAppNameService } from '../apps/OldAppNameService';
+import AppService from './AppService';
+
+import { describe, expect, it } from 'vitest';
+
+/*
+// CRITICAL: Mock BOTH Context modules (CommonJS and ESM) BEFORE any other imports
+// CommonJS modules use '../../util/context', ESM modules use '../../util/esmcontext.js'
+vi.mock('../../util/context', async () => {
+    const actual = await vi.importActual('../../util/context');
+    const { Context: OriginalContext } = actual;
+
+    // Store original get method BEFORE patching
+    const originalGet = OriginalContext.get;
+
+    // Store test values
+    let testContext = null;
+    let testActor = null;
+    let testUser = null;
+
+    // Patch Context.get to use test values
+    OriginalContext.get = function(key, options) {
+        // Check test values FIRST
+        if (key === 'actor' && testActor) {
+            return testActor;
+        }
+        if (key === 'user' && testUser) {
+            return testUser;
+        }
+
+        // Call original get method
+        return originalGet.call(this, key, options);
+    };
+
+    // Export patched Context with setters for test values
+    return {
+        ...actual,
+        Context: OriginalContext,
+        __setTestValues: (ctx, actor, user) => {
+            testContext = ctx;
+            testActor = actor;
+            testUser = user;
+        },
+        __clearTestValues: () => {
+            testContext = null;
+            testActor = null;
+            testUser = null;
+        },
+    };
+});
+
+vi.mock('../../util/esmcontext.js', async () => {
+    const actual = await vi.importActual('../../util/esmcontext.js');
+    const { Context: OriginalContext } = actual;
+
+    // Store original get method BEFORE patching
+    const originalGet = OriginalContext.get;
+
+    // Store test values
+    let testContext = null;
+    let testActor = null;
+    let testUser = null;
+
+    // Patch Context.get to use test values
+    OriginalContext.get = function(key, options) {
+        // Check test values FIRST
+        if (key === 'actor' && testActor) {
+            return testActor;
+        }
+        if (key === 'user' && testUser) {
+            return testUser;
+        }
+
+        // Call original get method
+        return originalGet.call(this, key, options);
+    };
+
+    // Export patched Context with setters for test values
+    return {
+        ...actual,
+        Context: OriginalContext,
+        __setTestValues: (ctx, actor, user) => {
+            testContext = ctx;
+            testActor = actor;
+            testUser = user;
+        },
+        __clearTestValues: () => {
+            testContext = null;
+            testActor = null;
+            testUser = null;
+        },
+    };
+});
+
+// Store test values globally - this is the most reliable approach
+let globalTestActor = null;
+let globalTestUser = null;
+
+// Patch Context.get directly (after imports) - this MUST work
+// We patch it on the actual Context class that's imported
+const originalContextGet = Context.get;
+Context.get = function(key, options) {
+    // ALWAYS check global test values FIRST - this is the most reliable
+    if (key === 'actor' && globalTestActor) {
+        return globalTestActor;
+    }
+    if (key === 'user' && globalTestUser) {
+        return globalTestUser;
+    }
+    // Call original
+    return originalContextGet.call(this, key, options);
+};
+
+// Also patch the Context class that CommonJS modules might have cached
+// Intercept require() calls to context.js and ensure they get our patched version
+const Module = require('module');
+const originalRequire = Module.prototype.require;
+Module.prototype.require = function(id) {
+    const result = originalRequire.call(this, id);
+    // If this is context.js, patch its Context.get
+    if (id.includes('util/context') && result && result.Context) {
+        const originalGet = result.Context.get;
+        result.Context.get = function(key, options) {
+            if (key === 'actor' && globalTestActor) {
+                return globalTestActor;
+            }
+            if (key === 'user' && globalTestUser) {
+                return globalTestUser;
+            }
+            return originalGet.call(this, key, options);
+        };
+    }
+    return result;
+};
+*/
+
+const ES_APP_ARGS = {
+    entity: 'app',
+    upstream: ESBuilder.create([
+        SQLES, { table: 'app', debug: true },
+        AppES,
+        AppLimitedES, {
+            permission_prefix: 'apps-of-user',
+            exception: async () => {
+                const actor = Context.get('actor');
+                return new Or({
+                    children: [
+                        new Eq({
+                            key: 'approved_for_listing',
+                            value: 1,
+                        }),
+                        new Eq({
+                            key: 'uid',
+                            value: actor.type.app.uid,
+                        }),
+                    ],
+                });
+            },
+        },
+        WriteByOwnerOnlyES,
+        ValidationES,
+        SetOwnerES,
+        ProtectedAppES,
+        MaxLimitES, { max: 5000 },
+    ]),
+};
+
+const fixContextInitialization = async (callback) => {
+    process.stdout.write(`contextAsyncLocalStorage:${ Context.contextAsyncLocalStorage }\n`);
+    try {
+        return Context.contextAsyncLocalStorage.run(Context.root, () => {
+            Context.contextAsyncLocalStorage.getStore().set('context', Context.root);
+            callback();
+        });
+    } catch (e) {
+        process.stdout.write(e.stack);
+    }
+};
+
+const testWithEachService = async (fnToRunOnBoth) => {
+    const esAppTestKernel = await createTestKernel({
+        testCore: true,
+        initLevelString: 'init',
+        serviceMap: {
+            'app-information': AppInformationService,
+            'app-icon': AppIconService,
+            'old-app-name': OldAppNameService,
+            'es:app': EntityStoreService,
+        },
+        serviceMapArgs: {
+            'es:app': ES_APP_ARGS,
+        },
+    });
+    await tmp_provide_services(esAppTestKernel.services);
+
+    const appTestKernel = await createTestKernel({
+        testCore: true,
+        initLevelString: 'init',
+        serviceMap: {
+            'app-information': AppInformationService,
+            'app-icon': AppIconService,
+            'old-app-name': OldAppNameService,
+            'app': AppService,
+        },
+    });
+    await tmp_provide_services(appTestKernel.services);
+
+    await fnToRunOnBoth({ kernel: esAppTestKernel, key: 'es:app' });
+    await fnToRunOnBoth({ kernel: appTestKernel, key: 'app' });
+
+    // Expect these tables to have the same values:
+    const relevant_tables = ['apps', 'app_filetype_association'];
+    const db_esApp = esAppTestKernel.services.get('database').get('write', 'test');
+    const db_app = appTestKernel.services.get('database').get('write', 'test');
+    for ( const table_name of relevant_tables ) {
+        const rows_esApp = db_esApp.read(`SELECT * FROM ${table_name}`);
+        const rows_app = db_app.read(`SELECT * FROM ${table_name}`);
+        expect(rows_app).toEqual(rows_esApp);
+    }
+};
+
+describe('AppService Regression Prevention Tests', () => {
+    it('should be testable with two test kernels', async () => {
+        await testWithEachService(() => {
+        });
+    });
+    it('should create the app', async () => {
+        await fixContextInitialization(async () => {
+            await testWithEachService(async ({ kernel, key }) => {
+                // Context initialization fix
+
+                // Create a test user and context
+                const db = kernel.services.get('database').get('write', 'test');
+                const userId = 1;
+                const username = 'testuser';
+                const uuid = `user-uuid-${userId}`;
+
+                // Insert the user into the database if not exists
+                const existingUser = await kernel.services.get('database')
+                    .get('read', 'test')
+                    .read('SELECT * FROM user WHERE uuid = ?', [uuid]);
+
+                if ( existingUser.length === 0 ) {
+                    await db.write('INSERT INTO user (uuid, username, free_storage) VALUES (?, ?, ?)',
+                                    [uuid, username, 1024 * 1024 * 1024]);
+                }
+
+                // Read the user back to get the actual id
+                const users = await kernel.services.get('database')
+                    .get('read', 'test')
+                    .read('SELECT * FROM user WHERE uuid = ?', [uuid]);
+
+                const user = users[0];
+                if ( ! user ) {
+                    throw new Error('Failed to create or retrieve test user');
+                }
+
+                const actor = await Actor.create(UserActorType, { user });
+                if ( !actor || !actor.type ) {
+                    throw new Error('Failed to create actor');
+                }
+
+                const userContext = kernel.root_context.sub({
+                    user,
+                    actor,
+                });
+
+                await userContext.arun(async () => {
+                    Context.set('actor', actor);
+                    // Set test values in BOTH mocked Context modules AND globally
+                    // globalTestActor = actor;
+                    // globalTestUser = user;
+
+                    const contextCJS = require('../../util/context');
+                    const contextESM = await import('../../util/esmcontext.js');
+                    if ( contextCJS.__setTestValues ) contextCJS.__setTestValues(userContext, actor, user);
+                    if ( contextESM.__setTestValues ) contextESM.__setTestValues(userContext, actor, user);
+
+                    process.stdout.write(`actor: ${actor}\n`);
+                    process.stdout.write(`context root from test: ${Context.get('rootContextUUID')}\n`);
+
+                    try {
+                        const service = kernel.services.get(key);
+                        const crudQ = service.constructor.IMPLEMENTS['crud-q'];
+                        await crudQ.create.call(service, {
+                            object: {
+                                name: 'test-app',
+                                title: 'Test App',
+                                index_url: 'https://example.com',
+                            },
+                        });
+                    } finally {
+                        // Clear after test
+                        // globalTestActor = null;
+                        // globalTestUser = null;
+
+                        const contextCJS = require('../../util/context');
+                        const contextESM = await import('../../util/esmcontext.js');
+                        if ( contextCJS.__clearTestValues ) contextCJS.__clearTestValues();
+                        if ( contextESM.__clearTestValues ) contextESM.__clearTestValues();
+                    }
+                });
+            });
+        });
+    });
+});

--- a/src/backend/src/modules/data-access/AppService.comp.test.js
+++ b/src/backend/src/modules/data-access/AppService.comp.test.js
@@ -316,14 +316,7 @@ describe('AppService Regression Prevention Tests', () => {
                     },
                 });
 
-                // Update it
-                const updated = await crudQ.update.call(service, {
-                    object: { uid: created.uid },
-                    id: { name: 'update-test-app' },
-                    options: {},
-                });
-
-                // Verify update worked - the object fields should be merged
+                // Update title and description
                 await crudQ.update.call(service, {
                     object: {
                         uid: created.uid,
@@ -381,16 +374,18 @@ describe('AppService Regression Prevention Tests', () => {
                     },
                 });
 
-                // Update with filetype associations
+                // Update with filetype associations (include title to avoid empty SET clause)
                 await crudQ.update.call(service, {
                     object: {
                         uid: created.uid,
+                        title: 'Filetype App Updated',
                         filetype_associations: ['txt', 'md', 'json'],
                     },
                     id: { name: 'filetype-app' },
                 });
 
                 const read = await crudQ.read.call(service, { uid: created.uid });
+                expect(read.title).toBe('Filetype App Updated');
                 expect(read.filetype_associations).toEqual(
                                 expect.arrayContaining(['txt', 'md', 'json']));
             });

--- a/src/backend/src/modules/data-access/AppService.js
+++ b/src/backend/src/modules/data-access/AppService.js
@@ -45,12 +45,14 @@ export default class AppService extends BaseService {
 
         const userCanEditOnly = Array.prototype.includes.call(predicate, 'user-can-edit');
 
-        const stmt = 'SELECT *, ' +
+        const stmt = 'SELECT apps.*, ' +
             'owner_user.username AS owner_user_username, ' +
-            'owner_user.uuid AS owner_user_uuid ' +
+            'owner_user.uuid AS owner_user_uuid, ' +
+            'app_owner.uid AS app_owner_uid ' +
             'FROM apps ' +
-            'LEFT JOIN user owner_user ON owner_user_id = owner_user.id ' +
-            `${userCanEditOnly ? 'WHERE owner_user_id=?' : ''} ` +
+            'LEFT JOIN user owner_user ON apps.owner_user_id = owner_user.id ' +
+            'LEFT JOIN apps app_owner ON apps.app_owner = app_owner.id ' +
+            `${userCanEditOnly ? 'WHERE apps.owner_user_id=?' : ''} ` +
             'LIMIT 5000';
         const values = userCanEditOnly ? [Context.get('user').id] : [];
         const rows = await db.read(stmt, values);
@@ -82,6 +84,10 @@ export default class AppService extends BaseService {
             // app.app_owner;
             // app.filetype_associations = row.filetype_associations;
             // app.owner = row.owner;
+
+            app.app_owner = {
+                uid: row.app_owner_uid,
+            };
 
             {
                 const owner_user = extract_from_prefix(row, 'owner_user_');

--- a/src/backend/src/modules/data-access/AppService.js
+++ b/src/backend/src/modules/data-access/AppService.js
@@ -47,7 +47,23 @@ export default class AppService extends BaseService {
                 return await this.#update({ object, id, options });
             },
             async upsert ({ object, id, options }) {
-                // TODO
+                // Try to find an existing entity
+                let existing = null;
+
+                if ( object.uid !== undefined || id !== undefined ) {
+                    existing = await this.#read({
+                        uid: object.uid,
+                        id,
+                    });
+                }
+
+                if ( existing ) {
+                    // Entity exists, call update
+                    return await this.#update({ object, id, options });
+                } else {
+                    // Entity doesn't exist, call create
+                    return await this.#create({ object, options });
+                }
             },
             async read ({ uid, id, params = {} }) {
                 return this.#read({ uid, id, params });

--- a/src/backend/src/modules/data-access/AppService.js
+++ b/src/backend/src/modules/data-access/AppService.js
@@ -2,6 +2,7 @@ import BaseService from '../../services/BaseService.js';
 import { DB_READ } from '../../services/database/consts.js';
 import { Context } from '../../util/context.js';
 import AppRepository from './AppRepository.js';
+import { as_bool } from './lib/coercion.js';
 
 /**
  * AppService contains an instance using the repository pattern
@@ -51,20 +52,20 @@ export default class AppService extends BaseService {
             const app = {};
 
             // FROM ROW
-            app.approved_for_incentive_program = row.approved_for_incentive_program;
-            app.approved_for_listing = row.approved_for_listing;
-            app.approved_for_opening_items = row.approved_for_opening_items;
-            app.background = row.background;
+            app.approved_for_incentive_program = as_bool(row.approved_for_incentive_program);
+            app.approved_for_listing = as_bool(row.approved_for_listing);
+            app.approved_for_opening_items = as_bool(row.approved_for_opening_items);
+            app.background = as_bool(row.background);
             app.created_at = row.created_at;
             app.created_from_origin = row.created_from_origin;
             app.description = row.description;
-            app.godmode = row.godmode;
+            app.godmode = as_bool(row.godmode);
             app.icon = row.icon;
             app.index_url = row.index_url;
-            app.maximize_on_start = row.maximize_on_start;
+            app.maximize_on_start = as_bool(row.maximize_on_start);
             app.metadata = row.metadata;
             app.name = row.name;
-            app.protected = row.protected;
+            app.protected = as_bool(row.protected);
             app.stats = row.stats;
             app.title = row.title;
             app.uid = row.uid;

--- a/src/backend/src/modules/data-access/AppService.js
+++ b/src/backend/src/modules/data-access/AppService.js
@@ -105,14 +105,14 @@ export default class AppService extends BaseService {
 
             {
                 const owner_user = extract_from_prefix(row, 'owner_user_');
-                app.owner_user = user_to_client(owner_user);
+                app.owner = user_to_client(owner_user);
             }
 
             if ( typeof row.filetypes === 'string' ) {
                 try {
-                    const filetypesAsJSON = JSON.parse(row.filetypes);
+                    let filetypesAsJSON = JSON.parse(row.filetypes);
+                    filetypesAsJSON = filetypesAsJSON.filter(ft => ft !== null);
                     for ( let i = 0 ; i < filetypesAsJSON.length ; i++ ) {
-                        if ( filetypesAsJSON[i] === null ) continue;
                         if ( typeof filetypesAsJSON[i] !== 'string' ) {
                             throw new Error(`expected filetypesAsJSON[${i}] to be a string, got: ${filetypesAsJSON[i]}`);
                         }
@@ -226,14 +226,14 @@ export default class AppService extends BaseService {
 
         {
             const owner_user = extract_from_prefix(row, 'owner_user_');
-            app.owner_user = user_to_client(owner_user);
+            app.owner = user_to_client(owner_user);
         }
 
         if ( typeof row.filetypes === 'string' ) {
             try {
-                const filetypesAsJSON = JSON.parse(row.filetypes);
+                let filetypesAsJSON = JSON.parse(row.filetypes);
+                filetypesAsJSON = filetypesAsJSON.filter(ft => ft !== null);
                 for ( let i = 0 ; i < filetypesAsJSON.length ; i++ ) {
-                    if ( filetypesAsJSON[i] === null ) continue;
                     if ( typeof filetypesAsJSON[i] !== 'string' ) {
                         throw new Error(`expected filetypesAsJSON[${i}] to be a string, got: ${filetypesAsJSON[i]}`);
                     }

--- a/src/backend/src/modules/data-access/AppService.test.js
+++ b/src/backend/src/modules/data-access/AppService.test.js
@@ -1,0 +1,527 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import AppService from './AppService.js';
+
+// Mock the Context module
+vi.mock('../../util/context.js', () => ({
+    Context: {
+        get: vi.fn(),
+    },
+}));
+
+import { Context } from '../../util/context.js';
+
+describe('AppService', () => {
+    let appService;
+    let mockDb;
+    let mockServices;
+
+    // Helper to create a mock database row
+    const createMockAppRow = (overrides = {}) => ({
+        id: 1,
+        uid: 'app-uid-123',
+        name: 'test-app',
+        title: 'Test App',
+        description: 'A test application',
+        icon: 'icon.png',
+        index_url: 'https://example.com/app',
+        created_at: '2024-01-01T00:00:00Z',
+        created_from_origin: 'localhost',
+        metadata: '{}',
+        stats: '{}',
+        approved_for_incentive_program: 0,
+        approved_for_listing: 1,
+        approved_for_opening_items: 1,
+        background: 0,
+        godmode: 0,
+        maximize_on_start: 0,
+        protected: 0,
+        owner_user_id: 1,
+        owner_user_username: 'testuser',
+        owner_user_uuid: 'user-uuid-456',
+        app_owner_uid: 'owner-app-uid-789',
+        filetypes: '["txt", "doc"]',
+        ...overrides,
+    });
+
+    beforeEach(() => {
+        // Reset mocks
+        vi.clearAllMocks();
+
+        // Mock database
+        mockDb = {
+            read: vi.fn(),
+            case: vi.fn().mockImplementation(({ sqlite }) => sqlite),
+        };
+
+        // Mock services
+        mockServices = {
+            get: vi.fn().mockImplementation((serviceName) => {
+                if ( serviceName === 'database' ) {
+                    return {
+                        get: vi.fn().mockReturnValue(mockDb),
+                    };
+                }
+                return null;
+            }),
+        };
+
+        // Create AppService instance
+        appService = new AppService({
+            services: mockServices,
+            config: {},
+            name: 'app-service',
+            args: {},
+            context: {
+                get: vi.fn().mockReturnValue(mockServices),
+            },
+        });
+
+        // Manually call _init to set up the service
+        appService.repository = {};
+        appService.db = mockDb;
+    });
+
+    describe('#read', () => {
+        it('should read an app by uid', async () => {
+            const mockRow = createMockAppRow();
+            mockDb.read.mockResolvedValue([mockRow]);
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+            const result = await crudQ.read.call(appService, { uid: 'app-uid-123' });
+
+            expect(mockDb.read).toHaveBeenCalledTimes(1);
+            expect(mockDb.read).toHaveBeenCalledWith(
+                expect.stringContaining('WHERE apps.uid = ?'),
+                ['app-uid-123']
+            );
+            expect(result).toBeDefined();
+            expect(result.uid).toBe('app-uid-123');
+            expect(result.name).toBe('test-app');
+            expect(result.title).toBe('Test App');
+        });
+
+        it('should read an app by complex id (name)', async () => {
+            const mockRow = createMockAppRow();
+            mockDb.read.mockResolvedValue([mockRow]);
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+            const result = await crudQ.read.call(appService, { id: { name: 'test-app' } });
+
+            expect(mockDb.read).toHaveBeenCalledTimes(1);
+            expect(mockDb.read).toHaveBeenCalledWith(
+                expect.stringContaining('WHERE apps.name = ?'),
+                ['test-app']
+            );
+            expect(result).toBeDefined();
+            expect(result.name).toBe('test-app');
+        });
+
+        it('should return undefined when no app is found', async () => {
+            mockDb.read.mockResolvedValue([]);
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+            const result = await crudQ.read.call(appService, { uid: 'nonexistent-uid' });
+
+            expect(result).toBeUndefined();
+        });
+
+        it('should throw an error when neither uid nor id is provided', async () => {
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+            
+            await expect(crudQ.read.call(appService, {})).rejects.toThrow(
+                'read requires either uid or id'
+            );
+        });
+
+        it('should throw an error for invalid complex id keys', async () => {
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+            
+            await expect(
+                crudQ.read.call(appService, { id: { invalidKey: 'value' } })
+            ).rejects.toThrow('Invalid complex id keys');
+        });
+
+        it('should correctly coerce boolean fields from database', async () => {
+            const mockRow = createMockAppRow({
+                approved_for_incentive_program: 1,
+                approved_for_listing: '1',
+                approved_for_opening_items: 0,
+                background: '0',
+                godmode: 1,
+                maximize_on_start: '1',
+                protected: 0,
+            });
+            mockDb.read.mockResolvedValue([mockRow]);
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+            const result = await crudQ.read.call(appService, { uid: 'app-uid-123' });
+
+            expect(result.approved_for_incentive_program).toBe(true);
+            expect(result.approved_for_listing).toBe(true);
+            expect(result.approved_for_opening_items).toBe(false);
+            expect(result.background).toBe(false);
+            expect(result.godmode).toBe(true);
+            expect(result.maximize_on_start).toBe(true);
+            expect(result.protected).toBe(false);
+        });
+
+        it('should parse filetypes JSON and strip leading dots', async () => {
+            const mockRow = createMockAppRow({
+                filetypes: '[".txt", ".doc", "pdf"]',
+            });
+            mockDb.read.mockResolvedValue([mockRow]);
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+            const result = await crudQ.read.call(appService, { uid: 'app-uid-123' });
+
+            expect(result.filetype_associations).toEqual(['txt', 'doc', 'pdf']);
+        });
+
+        it('should filter out null values in filetypes array', async () => {
+            const mockRow = createMockAppRow({
+                filetypes: '[".txt", null, "pdf"]',
+            });
+            mockDb.read.mockResolvedValue([mockRow]);
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+            const result = await crudQ.read.call(appService, { uid: 'app-uid-123' });
+
+            expect(result.filetype_associations).toEqual(['txt', 'pdf']);
+        });
+
+        it('should have owner parameter', async () => {
+            const mockRow = createMockAppRow();
+            mockDb.read.mockResolvedValue([mockRow]);
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+            const result = await crudQ.read.call(appService, { uid: 'app-uid-123' });
+
+            expect(result.owner).toEqual({
+                username: 'testuser',
+                uuid: 'user-uuid-456',
+            });
+        });
+
+        it('should include app_owner in the result', async () => {
+            const mockRow = createMockAppRow();
+            mockDb.read.mockResolvedValue([mockRow]);
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+            const result = await crudQ.read.call(appService, { uid: 'app-uid-123' });
+
+            expect(result.app_owner).toEqual({
+                uid: 'owner-app-uid-789',
+            });
+        });
+
+        it('should fetch icon with size when icon_size param is provided', async () => {
+            const mockRow = createMockAppRow();
+            mockDb.read.mockResolvedValue([mockRow]);
+
+            const mockIconService = {
+                get_icon_stream: vi.fn().mockResolvedValue({
+                    get_data_url: vi.fn().mockResolvedValue('data:image/png;base64,abc123'),
+                }),
+            };
+
+            appService.context = {
+                get: vi.fn().mockImplementation((key) => {
+                    if ( key === 'services' ) {
+                        return {
+                            get: vi.fn().mockImplementation((name) => {
+                                if ( name === 'app-icon' ) return mockIconService;
+                                return null;
+                            }),
+                        };
+                    }
+                    return null;
+                }),
+            };
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+            const result = await crudQ.read.call(appService, {
+                uid: 'app-uid-123',
+                params: { icon_size: 64 },
+            });
+
+            expect(mockIconService.get_icon_stream).toHaveBeenCalledWith({
+                app_uid: 'app-uid-123',
+                app_icon: 'icon.png',
+                size: 64,
+            });
+            expect(result.icon).toBe('data:image/png;base64,abc123');
+        });
+
+        it('should keep original icon when icon service throws', async () => {
+            const mockRow = createMockAppRow();
+            mockDb.read.mockResolvedValue([mockRow]);
+
+            const mockErrorService = {
+                report: vi.fn(),
+            };
+
+            const mockIconService = {
+                get_icon_stream: vi.fn().mockRejectedValue(new Error('Icon fetch failed')),
+            };
+
+            appService.context = {
+                get: vi.fn().mockImplementation((key) => {
+                    if ( key === 'services' ) {
+                        return {
+                            get: vi.fn().mockImplementation((name) => {
+                                if ( name === 'app-icon' ) return mockIconService;
+                                if ( name === 'error-service' ) return mockErrorService;
+                                return null;
+                            }),
+                        };
+                    }
+                    return null;
+                }),
+            };
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+            const result = await crudQ.read.call(appService, {
+                uid: 'app-uid-123',
+                params: { icon_size: 64 },
+            });
+
+            expect(mockErrorService.report).toHaveBeenCalledWith(
+                'AppES:read_transform',
+                expect.objectContaining({ source: expect.any(Error) })
+            );
+            expect(result.icon).toBe('icon.png');
+        });
+
+        it('should include raw row data in the result', async () => {
+            const mockRow = createMockAppRow();
+            mockDb.read.mockResolvedValue([mockRow]);
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+            const result = await crudQ.read.call(appService, { uid: 'app-uid-123' });
+
+            expect(result.raw).toEqual(mockRow);
+        });
+    });
+
+    describe('#select', () => {
+        it('should select all apps with default parameters', async () => {
+            const mockRows = [
+                createMockAppRow({ id: 1, uid: 'app-1', name: 'app-one' }),
+                createMockAppRow({ id: 2, uid: 'app-2', name: 'app-two' }),
+            ];
+            mockDb.read.mockResolvedValue(mockRows);
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+            const result = await crudQ.select.call(appService, {});
+
+            expect(mockDb.read).toHaveBeenCalledTimes(1);
+            expect(mockDb.read).toHaveBeenCalledWith(
+                expect.not.stringContaining('WHERE'),
+                []
+            );
+            expect(result).toHaveLength(2);
+            expect(result[0].uid).toBe('app-1');
+            expect(result[1].uid).toBe('app-2');
+        });
+
+        it('should filter by user-can-edit predicate', async () => {
+            const mockUser = { id: 42 };
+            Context.get.mockReturnValue(mockUser);
+
+            const mockRows = [createMockAppRow()];
+            mockDb.read.mockResolvedValue(mockRows);
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+            const result = await crudQ.select.call(appService, {
+                predicate: ['user-can-edit'],
+            });
+
+            expect(mockDb.read).toHaveBeenCalledWith(
+                expect.stringContaining('WHERE apps.owner_user_id=?'),
+                [42]
+            );
+            expect(result).toHaveLength(1);
+        });
+
+        it('should throw error when predicate is not an array', async () => {
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+
+            await expect(
+                crudQ.select.call(appService, { predicate: 'invalid' })
+            ).rejects.toThrow('predicate must be an array');
+        });
+
+        it('should correctly coerce boolean fields for all selected apps', async () => {
+            const mockRows = [
+                createMockAppRow({
+                    id: 1,
+                    approved_for_listing: 1,
+                    godmode: 0,
+                }),
+                createMockAppRow({
+                    id: 2,
+                    approved_for_listing: '0',
+                    godmode: '1',
+                }),
+            ];
+            mockDb.read.mockResolvedValue(mockRows);
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+            const result = await crudQ.select.call(appService, {});
+
+            expect(result[0].approved_for_listing).toBe(true);
+            expect(result[0].godmode).toBe(false);
+            expect(result[1].approved_for_listing).toBe(false);
+            expect(result[1].godmode).toBe(true);
+        });
+
+        it('should parse filetypes for all selected apps', async () => {
+            const mockRows = [
+                createMockAppRow({ id: 1, filetypes: '[".txt"]' }),
+                createMockAppRow({ id: 2, filetypes: '[".pdf", ".doc"]' }),
+            ];
+            mockDb.read.mockResolvedValue(mockRows);
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+            const result = await crudQ.select.call(appService, {});
+
+            expect(result[0].filetype_associations).toEqual(['txt']);
+            expect(result[1].filetype_associations).toEqual(['pdf', 'doc']);
+        });
+
+        it('should fetch icons with size for all apps when icon_size is provided', async () => {
+            const mockRows = [
+                createMockAppRow({ id: 1, uid: 'app-1', icon: 'icon1.png' }),
+                createMockAppRow({ id: 2, uid: 'app-2', icon: 'icon2.png' }),
+            ];
+            mockDb.read.mockResolvedValue(mockRows);
+
+            const mockIconService = {
+                get_icon_stream: vi.fn().mockImplementation(({ app_uid }) => ({
+                    get_data_url: vi.fn().mockResolvedValue(`data:image/png;base64,${app_uid}`),
+                })),
+            };
+
+            appService.context = {
+                get: vi.fn().mockImplementation((key) => {
+                    if ( key === 'services' ) {
+                        return {
+                            get: vi.fn().mockImplementation((name) => {
+                                if ( name === 'app-icon' ) return mockIconService;
+                                return null;
+                            }),
+                        };
+                    }
+                    return null;
+                }),
+            };
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+            const result = await crudQ.select.call(appService, {
+                params: { icon_size: 32 },
+            });
+
+            expect(mockIconService.get_icon_stream).toHaveBeenCalledTimes(2);
+            expect(result[0].icon).toBe('data:image/png;base64,app-1');
+            expect(result[1].icon).toBe('data:image/png;base64,app-2');
+        });
+
+        it('should return empty array when no apps exist', async () => {
+            mockDb.read.mockResolvedValue([]);
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+            const result = await crudQ.select.call(appService, {});
+
+            expect(result).toEqual([]);
+        });
+
+        it('should have owner parameter for all selected apps', async () => {
+            const mockRows = [
+                createMockAppRow({
+                    id: 1,
+                    owner_user_username: 'user1',
+                    owner_user_uuid: 'uuid-1',
+                }),
+                createMockAppRow({
+                    id: 2,
+                    owner_user_username: 'user2',
+                    owner_user_uuid: 'uuid-2',
+                }),
+            ];
+            mockDb.read.mockResolvedValue(mockRows);
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+            const result = await crudQ.select.call(appService, {});
+
+            expect(result[0].owner).toEqual({
+                username: 'user1',
+                uuid: 'uuid-1',
+            });
+            expect(result[1].owner).toEqual({
+                username: 'user2',
+                uuid: 'uuid-2',
+            });
+        });
+
+        it('should handle filetypes that are not strings', async () => {
+            const mockRows = [
+                createMockAppRow({ id: 1, filetypes: '[".txt", 123]' }),
+            ];
+            mockDb.read.mockResolvedValue(mockRows);
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+
+            await expect(crudQ.select.call(appService, {})).rejects.toThrow(
+                'expected filetypesAsJSON[1] to be a string'
+            );
+        });
+
+        it('should handle malformed filetypes JSON', async () => {
+            const mockRows = [
+                createMockAppRow({ id: 1, filetypes: 'not valid json' }),
+            ];
+            mockDb.read.mockResolvedValue(mockRows);
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+
+            await expect(crudQ.select.call(appService, {})).rejects.toThrow(
+                'failed to get app filetype associations'
+            );
+        });
+
+        it('should use database case for SQL dialect differences', async () => {
+            mockDb.read.mockResolvedValue([]);
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+            await crudQ.select.call(appService, {});
+
+            expect(mockDb.case).toHaveBeenCalledWith({
+                mysql: expect.stringContaining('JSON_ARRAYAGG'),
+                sqlite: expect.stringContaining('json_group_array'),
+            });
+        });
+    });
+
+    describe('#build_complex_id_where (via #read)', () => {
+        it('should accept "name" as a valid redundant identifier', async () => {
+            mockDb.read.mockResolvedValue([createMockAppRow()]);
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+            await crudQ.read.call(appService, { id: { name: 'test' } });
+
+            expect(mockDb.read).toHaveBeenCalledWith(
+                expect.stringContaining('apps.name = ?'),
+                ['test']
+            );
+        });
+
+        it('should reject identifiers not in REDUNDANT_IDENTIFIERS', async () => {
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+
+            await expect(
+                crudQ.read.call(appService, { id: { title: 'test' } })
+            ).rejects.toThrow('Invalid complex id keys: title');
+        });
+    });
+});
+

--- a/src/backend/src/modules/data-access/AppService.test.js
+++ b/src/backend/src/modules/data-access/AppService.test.js
@@ -8,12 +8,54 @@ vi.mock('../../util/context.js', () => ({
     },
 }));
 
+// Mock the helpers module
+vi.mock('../../helpers.js', () => ({
+    app_name_exists: vi.fn(),
+    refresh_apps_cache: vi.fn(),
+}));
+
+// Mock the Actor module
+vi.mock('../../services/auth/Actor.js', () => ({
+    UserActorType: class UserActorType {},
+    AppUnderUserActorType: class AppUnderUserActorType {},
+}));
+
+// Mock the validation module
+vi.mock('./lib/validation.js', () => ({
+    validate_string: vi.fn(),
+    validate_url: vi.fn(),
+    validate_image_base64: vi.fn(),
+    validate_json: vi.fn(),
+    validate_array_of_strings: vi.fn(),
+}));
+
+// Mock config
+vi.mock('../../config.js', () => ({
+    default: {
+        app_name_max_length: 100,
+        app_name_regex: /^[a-z0-9-]+$/,
+        app_title_max_length: 200,
+        static_hosting_domain: 'puter.site',
+    },
+}));
+
+import { app_name_exists, refresh_apps_cache } from '../../helpers.js';
+import { AppUnderUserActorType, UserActorType } from '../../services/auth/Actor.js';
 import { Context } from '../../util/context.js';
+import {
+    validate_string,
+    validate_url
+} from './lib/validation.js';
 
 describe('AppService', () => {
     let appService;
     let mockDb;
+    let mockDbWrite;
     let mockServices;
+    let mockEventService;
+    let mockPermissionService;
+    let mockPuterSiteService;
+    let mockOldAppNameService;
 
     // Helper to create a mock database row
     const createMockAppRow = (overrides = {}) => ({
@@ -43,14 +85,65 @@ describe('AppService', () => {
         ...overrides,
     });
 
+    // Helper to create a mock actor
+    const createMockUserActor = (userId = 1) => ({
+        type: Object.assign(new UserActorType(), { user: { id: userId } }),
+    });
+
+    const createMockAppUnderUserActor = (userId = 1, appId = 100) => ({
+        type: Object.assign(new AppUnderUserActorType(), {
+            user: { id: userId },
+            app: { id: appId, uid: 'creator-app-uid' },
+        }),
+    });
+
+    // Helper to setup Context.get mock for create/update tests
+    const setupContextForWrite = (actor, user = { id: 1 }) => {
+        Context.get.mockImplementation((key) => {
+            if ( key === 'actor' ) return actor;
+            if ( key === 'user' ) return user;
+            return null;
+        });
+    };
+
     beforeEach(() => {
         // Reset mocks
         vi.clearAllMocks();
 
-        // Mock database
+        // Reset helper mocks
+        app_name_exists.mockResolvedValue(false);
+        refresh_apps_cache.mockReturnValue(undefined);
+
+        // Mock database (read)
         mockDb = {
             read: vi.fn(),
             case: vi.fn().mockImplementation(({ sqlite }) => sqlite),
+        };
+
+        // Mock database (write)
+        mockDbWrite = {
+            write: vi.fn().mockResolvedValue({ insertId: 1 }),
+        };
+
+        // Mock event service
+        mockEventService = {
+            emit: vi.fn().mockResolvedValue(undefined),
+        };
+
+        // Mock permission service
+        mockPermissionService = {
+            check: vi.fn().mockResolvedValue(false),
+        };
+
+        // Mock puter-site service
+        mockPuterSiteService = {
+            get_subdomain: vi.fn().mockResolvedValue(null),
+        };
+
+        // Mock old-app-name service
+        mockOldAppNameService = {
+            check_app_name: vi.fn().mockResolvedValue(null),
+            remove_name: vi.fn().mockResolvedValue(undefined),
         };
 
         // Mock services
@@ -58,9 +151,16 @@ describe('AppService', () => {
             get: vi.fn().mockImplementation((serviceName) => {
                 if ( serviceName === 'database' ) {
                     return {
-                        get: vi.fn().mockReturnValue(mockDb),
+                        get: vi.fn().mockImplementation((mode) => {
+                            if ( mode === 'write' ) return mockDbWrite;
+                            return mockDb;
+                        }),
                     };
                 }
+                if ( serviceName === 'event' ) return mockEventService;
+                if ( serviceName === 'permission' ) return mockPermissionService;
+                if ( serviceName === 'puter-site' ) return mockPuterSiteService;
+                if ( serviceName === 'old-app-name' ) return mockOldAppNameService;
                 return null;
             }),
         };
@@ -79,6 +179,7 @@ describe('AppService', () => {
         // Manually call _init to set up the service
         appService.repository = {};
         appService.db = mockDb;
+        appService.db_write = mockDbWrite;
     });
 
     describe('#read', () => {
@@ -292,15 +393,6 @@ describe('AppService', () => {
             expect(result.icon).toBe('icon.png');
         });
 
-        it('should include raw row data in the result', async () => {
-            const mockRow = createMockAppRow();
-            mockDb.read.mockResolvedValue([mockRow]);
-
-            const crudQ = AppService.IMPLEMENTS['crud-q'];
-            const result = await crudQ.read.call(appService, { uid: 'app-uid-123' });
-
-            expect(result.raw).toEqual(mockRow);
-        });
     });
 
     describe('#select', () => {
@@ -521,6 +613,629 @@ describe('AppService', () => {
             await expect(
                 crudQ.read.call(appService, { id: { title: 'test' } })
             ).rejects.toThrow('Invalid complex id keys: title');
+        });
+    });
+
+    describe('#create', () => {
+        it('should create an app with valid input', async () => {
+            setupContextForWrite(createMockUserActor(1));
+
+            // Mock the read after insert
+            mockDb.read.mockResolvedValue([createMockAppRow({
+                uid: expect.stringContaining('app-'),
+                name: 'new-app',
+                title: 'New App',
+                index_url: 'https://example.com/new',
+            })]);
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+            const result = await crudQ.create.call(appService, {
+                object: {
+                    name: 'new-app',
+                    title: 'New App',
+                    index_url: 'https://example.com/new',
+                },
+            });
+
+            expect(mockDbWrite.write).toHaveBeenCalledWith(
+                expect.stringContaining('INSERT INTO apps'),
+                expect.arrayContaining(['new-app', 'New App', 'https://example.com/new'])
+            );
+            expect(refresh_apps_cache).toHaveBeenCalled();
+        });
+
+        it('should throw forbidden for non-user actors', async () => {
+            // Mock an invalid actor type
+            Context.get.mockImplementation((key) => {
+                if ( key === 'actor' ) return { type: {} };
+                return null;
+            });
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+
+            await expect(crudQ.create.call(appService, {
+                object: {
+                    name: 'test-app',
+                    title: 'Test',
+                    index_url: 'https://example.com',
+                },
+            })).rejects.toThrow();
+        });
+
+        it('should throw field_missing when name is not provided', async () => {
+            setupContextForWrite(createMockUserActor(1));
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+
+            await expect(crudQ.create.call(appService, {
+                object: {
+                    title: 'Test',
+                    index_url: 'https://example.com',
+                },
+            })).rejects.toThrow();
+        });
+
+        it('should throw field_missing when title is not provided', async () => {
+            setupContextForWrite(createMockUserActor(1));
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+
+            await expect(crudQ.create.call(appService, {
+                object: {
+                    name: 'test-app',
+                    index_url: 'https://example.com',
+                },
+            })).rejects.toThrow();
+        });
+
+        it('should throw field_missing when index_url is not provided', async () => {
+            setupContextForWrite(createMockUserActor(1));
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+
+            await expect(crudQ.create.call(appService, {
+                object: {
+                    name: 'test-app',
+                    title: 'Test',
+                },
+            })).rejects.toThrow();
+        });
+
+        it('should remove protected fields from input', async () => {
+            setupContextForWrite(createMockUserActor(1));
+            mockDb.read.mockResolvedValue([createMockAppRow()]);
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+            await crudQ.create.call(appService, {
+                object: {
+                    name: 'test-app',
+                    title: 'Test',
+                    index_url: 'https://example.com',
+                    last_review: '2024-01-01', // protected field
+                },
+            });
+
+            // The INSERT should not include last_review
+            expect(mockDbWrite.write).toHaveBeenCalledWith(
+                expect.stringContaining('INSERT INTO apps'),
+                expect.not.arrayContaining(['2024-01-01'])
+            );
+        });
+
+        it('should remove read_only fields from input', async () => {
+            setupContextForWrite(createMockUserActor(1));
+            mockDb.read.mockResolvedValue([createMockAppRow()]);
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+            await crudQ.create.call(appService, {
+                object: {
+                    name: 'test-app',
+                    title: 'Test',
+                    index_url: 'https://example.com',
+                    approved_for_listing: true, // read_only field
+                    godmode: true, // read_only field
+                },
+            });
+
+            // These fields should not appear in the INSERT
+            const writeCall = mockDbWrite.write.mock.calls[0];
+            expect(writeCall[0]).not.toContain('approved_for_listing');
+            expect(writeCall[0]).not.toContain('godmode');
+        });
+
+        it('should handle name conflict with dedupe_name option', async () => {
+            setupContextForWrite(createMockUserActor(1));
+            mockDb.read.mockResolvedValue([createMockAppRow()]);
+
+            // First check returns true (name exists), second returns false
+            app_name_exists
+                .mockResolvedValueOnce(true)  // 'new-app' exists
+                .mockResolvedValueOnce(false); // 'new-app-1' doesn't exist
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+            await crudQ.create.call(appService, {
+                object: {
+                    name: 'new-app',
+                    title: 'New App',
+                    index_url: 'https://example.com',
+                },
+                options: { dedupe_name: true },
+            });
+
+            // Should have inserted with deduped name
+            expect(mockDbWrite.write).toHaveBeenCalledWith(
+                expect.stringContaining('INSERT INTO apps'),
+                expect.arrayContaining(['new-app-1'])
+            );
+        });
+
+        it('should throw error when name conflict without dedupe_name', async () => {
+            setupContextForWrite(createMockUserActor(1));
+            app_name_exists.mockResolvedValue(true);
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+
+            await expect(crudQ.create.call(appService, {
+                object: {
+                    name: 'existing-app',
+                    title: 'Test',
+                    index_url: 'https://example.com',
+                },
+            })).rejects.toThrow();
+        });
+
+        it('should set app_owner when actor is AppUnderUserActorType', async () => {
+            setupContextForWrite(createMockAppUnderUserActor(1, 100));
+            mockDb.read.mockResolvedValue([createMockAppRow()]);
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+            await crudQ.create.call(appService, {
+                object: {
+                    name: 'test-app',
+                    title: 'Test',
+                    index_url: 'https://example.com',
+                },
+            });
+
+            // Should include app_owner in the INSERT
+            expect(mockDbWrite.write).toHaveBeenCalledWith(
+                expect.stringContaining('app_owner'),
+                expect.arrayContaining([100])
+            );
+        });
+
+        it('should emit app.new-icon event when icon is provided', async () => {
+            setupContextForWrite(createMockUserActor(1));
+            mockDb.read.mockResolvedValue([createMockAppRow()]);
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+            await crudQ.create.call(appService, {
+                object: {
+                    name: 'test-app',
+                    title: 'Test',
+                    index_url: 'https://example.com',
+                    icon: 'data:image/png;base64,abc123',
+                },
+            });
+
+            expect(mockEventService.emit).toHaveBeenCalledWith(
+                'app.new-icon',
+                expect.objectContaining({
+                    data_url: 'data:image/png;base64,abc123',
+                })
+            );
+        });
+
+        it('should handle filetype_associations', async () => {
+            setupContextForWrite(createMockUserActor(1));
+            mockDb.read.mockResolvedValue([createMockAppRow()]);
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+            await crudQ.create.call(appService, {
+                object: {
+                    name: 'test-app',
+                    title: 'Test',
+                    index_url: 'https://example.com',
+                    filetype_associations: ['txt', 'pdf'],
+                },
+            });
+
+            // Should have three write calls: INSERT app, DELETE old associations, INSERT new associations
+            // (DELETE is called even for create since #update_filetype_associations always clears first)
+            expect(mockDbWrite.write).toHaveBeenCalledTimes(3);
+            expect(mockDbWrite.write).toHaveBeenCalledWith(
+                expect.stringContaining('DELETE FROM app_filetype_association'),
+                [1]
+            );
+            expect(mockDbWrite.write).toHaveBeenCalledWith(
+                expect.stringContaining('INSERT INTO app_filetype_association'),
+                expect.arrayContaining([1, 'txt', 1, 'pdf'])
+            );
+        });
+
+        it('should call validate_string for name and title', async () => {
+            setupContextForWrite(createMockUserActor(1));
+            mockDb.read.mockResolvedValue([createMockAppRow()]);
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+            await crudQ.create.call(appService, {
+                object: {
+                    name: 'test-app',
+                    title: 'Test Title',
+                    index_url: 'https://example.com',
+                },
+            });
+
+            expect(validate_string).toHaveBeenCalledWith('test-app', expect.objectContaining({ key: 'name' }));
+            expect(validate_string).toHaveBeenCalledWith('Test Title', expect.objectContaining({ key: 'title' }));
+        });
+
+        it('should call validate_url for index_url', async () => {
+            setupContextForWrite(createMockUserActor(1));
+            mockDb.read.mockResolvedValue([createMockAppRow()]);
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+            await crudQ.create.call(appService, {
+                object: {
+                    name: 'test-app',
+                    title: 'Test',
+                    index_url: 'https://example.com/app',
+                },
+            });
+
+            expect(validate_url).toHaveBeenCalledWith('https://example.com/app', expect.objectContaining({ key: 'index_url' }));
+        });
+
+        it('should generate a UID with app- prefix', async () => {
+            setupContextForWrite(createMockUserActor(1));
+            mockDb.read.mockResolvedValue([createMockAppRow()]);
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+            await crudQ.create.call(appService, {
+                object: {
+                    name: 'test-app',
+                    title: 'Test',
+                    index_url: 'https://example.com',
+                },
+            });
+
+            const writeCall = mockDbWrite.write.mock.calls[0];
+            const values = writeCall[1];
+            const uidValue = values[0]; // uid is first value
+            expect(uidValue).toMatch(/^app-[0-9a-f-]{36}$/);
+        });
+    });
+
+    describe('#update', () => {
+        beforeEach(() => {
+            // Default: return an existing app for updates
+            mockDb.read.mockResolvedValue([createMockAppRow({
+                owner_user_id: 1,
+            })]);
+        });
+
+        it('should update an app with valid input', async () => {
+            setupContextForWrite(createMockUserActor(1));
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+            const result = await crudQ.update.call(appService, {
+                object: { uid: 'app-uid-123', title: 'Updated Title' },
+            });
+
+            expect(mockDbWrite.write).toHaveBeenCalledWith(
+                expect.stringContaining('UPDATE apps SET'),
+                expect.arrayContaining(['Updated Title', 'app-uid-123'])
+            );
+        });
+
+        it('should throw entity_not_found when app does not exist', async () => {
+            setupContextForWrite(createMockUserActor(1));
+            mockDb.read.mockResolvedValue([]);
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+
+            await expect(crudQ.update.call(appService, {
+                object: { uid: 'nonexistent-uid', title: 'Test' },
+            })).rejects.toThrow();
+        });
+
+        it('should throw forbidden when user does not own the app', async () => {
+            // User 2 trying to update app owned by user 1
+            setupContextForWrite(createMockUserActor(2), { id: 2 });
+            mockDb.read.mockResolvedValue([createMockAppRow({
+                owner_user_id: 1,
+            })]);
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+
+            await expect(crudQ.update.call(appService, {
+                object: { uid: 'app-uid-123', title: 'Hacked Title' },
+            })).rejects.toThrow();
+        });
+
+        it('should allow update when user has write-all-owners permission', async () => {
+            setupContextForWrite(createMockUserActor(2), { id: 2 });
+            mockDb.read.mockResolvedValue([createMockAppRow({
+                owner_user_id: 1,
+            })]);
+            mockPermissionService.check.mockResolvedValue(true);
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+            await crudQ.update.call(appService, {
+                object: { uid: 'app-uid-123', title: 'Admin Update' },
+            });
+
+            expect(mockDbWrite.write).toHaveBeenCalledWith(
+                expect.stringContaining('UPDATE apps SET'),
+                expect.arrayContaining(['Admin Update'])
+            );
+        });
+
+        it('should remove protected fields from update', async () => {
+            setupContextForWrite(createMockUserActor(1));
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+            await crudQ.update.call(appService, {
+                object: {
+                    uid: 'app-uid-123',
+                    title: 'Updated',
+                    last_review: '2024-12-01', // protected field
+                },
+            });
+
+            const writeCall = mockDbWrite.write.mock.calls[0];
+            expect(writeCall[0]).not.toContain('last_review');
+        });
+
+        it('should remove read_only fields from update', async () => {
+            setupContextForWrite(createMockUserActor(1));
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+            await crudQ.update.call(appService, {
+                object: {
+                    uid: 'app-uid-123',
+                    title: 'Updated',
+                    approved_for_listing: true,
+                    godmode: true,
+                },
+            });
+
+            const writeCall = mockDbWrite.write.mock.calls[0];
+            expect(writeCall[0]).not.toContain('approved_for_listing');
+            expect(writeCall[0]).not.toContain('godmode');
+        });
+
+        it('should handle name change with conflict', async () => {
+            setupContextForWrite(createMockUserActor(1));
+            app_name_exists.mockResolvedValue(true);
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+
+            await expect(crudQ.update.call(appService, {
+                object: { uid: 'app-uid-123', name: 'taken-name' },
+            })).rejects.toThrow();
+        });
+
+        it('should allow name change with dedupe_name option', async () => {
+            setupContextForWrite(createMockUserActor(1));
+            app_name_exists
+                .mockResolvedValueOnce(true)   // 'new-name' exists
+                .mockResolvedValueOnce(false); // 'new-name-1' doesn't exist
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+            await crudQ.update.call(appService, {
+                object: { uid: 'app-uid-123', name: 'new-name' },
+                options: { dedupe_name: true },
+            });
+
+            expect(mockDbWrite.write).toHaveBeenCalledWith(
+                expect.stringContaining('UPDATE apps SET'),
+                expect.arrayContaining(['new-name-1'])
+            );
+        });
+
+        it('should allow reclaiming old app name', async () => {
+            setupContextForWrite(createMockUserActor(1));
+            app_name_exists.mockResolvedValue(true);
+            mockOldAppNameService.check_app_name.mockResolvedValue({
+                id: 99,
+                app_uid: 'app-uid-123', // Same app
+            });
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+            await crudQ.update.call(appService, {
+                object: { uid: 'app-uid-123', name: 'old-name' },
+            });
+
+            expect(mockOldAppNameService.remove_name).toHaveBeenCalledWith(99);
+            expect(mockDbWrite.write).toHaveBeenCalled();
+        });
+
+        it('should not update name if unchanged', async () => {
+            setupContextForWrite(createMockUserActor(1));
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+            await crudQ.update.call(appService, {
+                object: { uid: 'app-uid-123', name: 'test-app' }, // Same as existing
+            });
+
+            // Should only have the read for ID, no name in update
+            const writeCall = mockDbWrite.write.mock.calls.find(
+                call => call[0].includes('UPDATE')
+            );
+            if ( writeCall ) {
+                expect(writeCall[1]).not.toContain('test-app');
+            }
+        });
+
+        it('should emit app.new-icon event when icon changes', async () => {
+            setupContextForWrite(createMockUserActor(1));
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+            await crudQ.update.call(appService, {
+                object: {
+                    uid: 'app-uid-123',
+                    icon: 'data:image/png;base64,newicon',
+                },
+            });
+
+            expect(mockEventService.emit).toHaveBeenCalledWith(
+                'app.new-icon',
+                expect.objectContaining({
+                    app_uid: 'app-uid-123',
+                    data_url: 'data:image/png;base64,newicon',
+                })
+            );
+        });
+
+        it('should emit app.rename event when name changes', async () => {
+            setupContextForWrite(createMockUserActor(1));
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+            await crudQ.update.call(appService, {
+                object: { uid: 'app-uid-123', name: 'renamed-app' },
+            });
+
+            expect(mockEventService.emit).toHaveBeenCalledWith(
+                'app.rename',
+                expect.objectContaining({
+                    app_uid: 'app-uid-123',
+                    new_name: 'renamed-app',
+                    old_name: 'test-app',
+                })
+            );
+        });
+
+        it('should update filetype_associations', async () => {
+            setupContextForWrite(createMockUserActor(1));
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+            await crudQ.update.call(appService, {
+                object: {
+                    uid: 'app-uid-123',
+                    filetype_associations: ['doc', 'xls'],
+                },
+            });
+
+            // Should delete old associations
+            expect(mockDbWrite.write).toHaveBeenCalledWith(
+                expect.stringContaining('DELETE FROM app_filetype_association'),
+                [1]
+            );
+
+            // Should insert new associations
+            expect(mockDbWrite.write).toHaveBeenCalledWith(
+                expect.stringContaining('INSERT INTO app_filetype_association'),
+                expect.arrayContaining([1, 'doc', 1, 'xls'])
+            );
+        });
+
+        it('should call refresh_apps_cache after update', async () => {
+            setupContextForWrite(createMockUserActor(1));
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+            await crudQ.update.call(appService, {
+                object: { uid: 'app-uid-123', title: 'Updated' },
+            });
+
+            expect(refresh_apps_cache).toHaveBeenCalledWith(
+                { uid: 'app-uid-123' },
+                expect.objectContaining({ uuid: 'app-uid-123' })
+            );
+        });
+
+        it('should validate fields when provided', async () => {
+            setupContextForWrite(createMockUserActor(1));
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+            await crudQ.update.call(appService, {
+                object: {
+                    uid: 'app-uid-123',
+                    name: 'updated-name',
+                    title: 'Updated Title',
+                    description: 'Updated description',
+                    index_url: 'https://updated.com',
+                },
+            });
+
+            expect(validate_string).toHaveBeenCalledWith('updated-name', expect.objectContaining({ key: 'name' }));
+            expect(validate_string).toHaveBeenCalledWith('Updated Title', expect.objectContaining({ key: 'title' }));
+            expect(validate_string).toHaveBeenCalledWith('Updated description', expect.objectContaining({ key: 'description' }));
+            expect(validate_url).toHaveBeenCalledWith('https://updated.com', expect.objectContaining({ key: 'index_url' }));
+        });
+
+        it('should check subdomain ownership when index_url changes to puter.site', async () => {
+            setupContextForWrite(createMockUserActor(1));
+            mockPuterSiteService.get_subdomain.mockResolvedValue(null);
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+
+            await expect(crudQ.update.call(appService, {
+                object: {
+                    uid: 'app-uid-123',
+                    index_url: 'https://mysite.puter.site',
+                },
+            })).rejects.toThrow();
+        });
+
+        it('should allow index_url change when subdomain is owned', async () => {
+            setupContextForWrite(createMockUserActor(1));
+            mockPuterSiteService.get_subdomain.mockResolvedValue({ user_id: 1 });
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+            await crudQ.update.call(appService, {
+                object: {
+                    uid: 'app-uid-123',
+                    index_url: 'https://mysite.puter.site',
+                },
+            });
+
+            expect(mockDbWrite.write).toHaveBeenCalledWith(
+                expect.stringContaining('UPDATE apps SET'),
+                expect.arrayContaining(['https://mysite.puter.site'])
+            );
+        });
+    });
+
+    describe('#upsert', () => {
+        it('should call create when entity does not exist', async () => {
+            setupContextForWrite(createMockUserActor(1));
+
+            // First read returns empty (entity doesn't exist)
+            mockDb.read
+                .mockResolvedValueOnce([])  // lookup
+                .mockResolvedValue([createMockAppRow()]); // read after create
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+            await crudQ.upsert.call(appService, {
+                object: {
+                    name: 'new-app',
+                    title: 'New App',
+                    index_url: 'https://example.com',
+                },
+            });
+
+            expect(mockDbWrite.write).toHaveBeenCalledWith(
+                expect.stringContaining('INSERT INTO apps'),
+                expect.any(Array)
+            );
+        });
+
+        it('should call update when entity exists', async () => {
+            setupContextForWrite(createMockUserActor(1));
+
+            // Read returns existing entity
+            mockDb.read.mockResolvedValue([createMockAppRow()]);
+
+            const crudQ = AppService.IMPLEMENTS['crud-q'];
+            await crudQ.upsert.call(appService, {
+                object: { uid: 'app-uid-123', title: 'Updated Title' },
+            });
+
+            expect(mockDbWrite.write).toHaveBeenCalledWith(
+                expect.stringContaining('UPDATE apps SET'),
+                expect.any(Array)
+            );
         });
     });
 });

--- a/src/backend/src/modules/data-access/AppService.test.js
+++ b/src/backend/src/modules/data-access/AppService.test.js
@@ -217,13 +217,14 @@ describe('AppService', () => {
             expect(result.name).toBe('test-app');
         });
 
-        it('should return undefined when no app is found', async () => {
+        it('should throw entity_not_found when no app is found', async () => {
             mockDb.read.mockResolvedValue([]);
 
             const crudQ = AppService.IMPLEMENTS['crud-q'];
-            const result = await crudQ.read.call(appService, { uid: 'nonexistent-uid' });
 
-            expect(result).toBeUndefined();
+            await expect(crudQ.read.call(appService, { uid: 'nonexistent-uid' })).rejects.toMatchObject({
+                fields: { code: 'entity_not_found' },
+            });
         });
 
         it('should throw an error when neither uid nor id is provided', async () => {
@@ -1257,10 +1258,7 @@ describe('AppService', () => {
         it('should call create when entity does not exist', async () => {
             setupContextForWrite(createMockUserActor(1));
 
-            // First read returns empty (entity doesn't exist)
-            mockDb.read
-                .mockResolvedValueOnce([])  // lookup
-                .mockResolvedValue([createMockAppRow()]); // read after create
+            mockDb.read.mockResolvedValue([createMockAppRow()]);
 
             const crudQ = AppService.IMPLEMENTS['crud-q'];
             await crudQ.upsert.call(appService, {

--- a/src/backend/src/modules/data-access/lib/coercion.js
+++ b/src/backend/src/modules/data-access/lib/coercion.js
@@ -1,0 +1,28 @@
+// These utility functions describe how values stored in the database
+// are to be understood as their higher-level counterparts.
+
+import { CoercionTypeError } from './error.js';
+
+/**
+ * MySQL lets us store `1` (an integer) or `0` (also an integer) as
+ * the closest parallel to a boolean "true or false" value.
+ * Sqlite lets us store `"1"` (a string) or `0` (also a string) as
+ * the closest parallel to a boolean "true of false" value.
+ *
+ * So we define a function here called `as_bool` that will make
+ * `"0"` or `0` become `false`, and `"1"` or `1` become `true`.
+ *
+ * @param {any} value - The value to coerce to a boolean.
+ * @returns {boolean} The coerced boolean value.
+ */
+export const as_bool = value => {
+    if ( value === undefined ) return false;
+    if ( value === 0 ) value = false;
+    if ( value === 1 ) value = true;
+    if ( value === '0' ) value = false;
+    if ( value === '1' ) value = true;
+    if ( typeof value !== 'boolean' ) {
+        throw new CoercionTypeError({ expected: 'boolean', got: typeof value });
+    }
+    return value;
+};

--- a/src/backend/src/modules/data-access/lib/error.js
+++ b/src/backend/src/modules/data-access/lib/error.js
@@ -1,0 +1,11 @@
+/**
+ * Replaces `OMTypeError` from ES/OM implementation.
+ * This might be removed or replaced in the future.
+ */
+export class CoercionTypeError extends Error {
+    constructor ({ expected, got }) {
+        const message = `expected ${expected}, got ${got}`;
+        super(message);
+        this.name = 'CoercionTypeError';
+    }
+}

--- a/src/backend/src/modules/data-access/lib/filter.js
+++ b/src/backend/src/modules/data-access/lib/filter.js
@@ -1,0 +1,10 @@
+// These utility functions describe how to produce an object safe
+// for transfer that came from a "raw" object.
+
+export const user_to_client = raw_user => {
+    return {
+        username: raw_user.username,
+        // This `uuid` is not an internal-only ID.
+        uuid: raw_user.uuid,
+    };
+};

--- a/src/backend/src/modules/data-access/lib/sqlutil.js
+++ b/src/backend/src/modules/data-access/lib/sqlutil.js
@@ -1,0 +1,21 @@
+/**
+ * When columns are selected from a joined table and prefixed:
+ *
+ *   SELECT joined_table.* AS joined_table_
+ *
+ * This function is able to extract the object from the result:
+ *
+ * extract_from_prefix(row, 'joined_table_') // columns of joined_table
+ *
+ * @param {*} row
+ * @param {*} prefix
+ */
+export const extract_from_prefix = (row, prefix) => {
+    const result = {};
+    for ( const [key, value] of Object.entries(row) ) {
+        if ( key.startsWith(prefix) ) {
+            result[key.replace(prefix, '')] = value;
+        }
+    }
+    return result;
+};

--- a/src/backend/src/modules/data-access/lib/validation.js
+++ b/src/backend/src/modules/data-access/lib/validation.js
@@ -1,0 +1,97 @@
+import validator from 'validator';
+import APIError from '../../../api/APIError.js';
+
+/**
+ * Validates a string value with optional maxlen and regex constraints.
+ * @param {string} value - The value to validate
+ * @param {object} meta - Metadata for the validation
+ * @param {string} meta.key - The field name (for error messages)
+ * @param {number} [meta.maxlen] - Maximum length allowed
+ * @param {RegExp} [meta.regex] - Regex pattern the string must match
+ */
+export const validate_string = (value, { key, maxlen, regex }) => {
+    if ( typeof value !== 'string' ) {
+        throw APIError.create('field_invalid', null, { key });
+    }
+    if ( maxlen !== undefined && value.length > maxlen ) {
+        throw APIError.create('field_too_long', null, { key, max_length: maxlen });
+    }
+    if ( regex !== undefined && !regex.test(value) ) {
+        throw APIError.create('field_invalid', null, { key });
+    }
+};
+
+/**
+ * Validates an image-base64 value (data URL for images).
+ * Checks for proper prefix and XSS characters.
+ * @param {string} value - The value to validate
+ * @param {object} meta - Metadata for the validation
+ * @param {string} meta.key - The field name (for error messages)
+ */
+export const validate_image_base64 = (value, { key }) => {
+    if ( typeof value !== 'string' ) {
+        throw APIError.create('field_invalid', null, { key });
+    }
+    if ( ! value.startsWith('data:image/') ) {
+        throw APIError.create('field_invalid', null, { key });
+    }
+    // XSS character check from image-base64 prop type
+    const xss_chars = ['<', '>', '&', '"', "'", '`'];
+    if ( xss_chars.some(char => value.includes(char)) ) {
+        throw APIError.create('field_invalid', null, { key });
+    }
+};
+
+/**
+ * Validates a URL value with optional maxlen constraint.
+ * Uses the validator library, allowing localhost.
+ * @param {string} value - The value to validate
+ * @param {object} meta - Metadata for the validation
+ * @param {string} meta.key - The field name (for error messages)
+ * @param {number} [meta.maxlen] - Maximum length allowed
+ */
+export const validate_url = (value, { key, maxlen }) => {
+    if ( typeof value !== 'string' ) {
+        throw APIError.create('field_invalid', null, { key });
+    }
+    if ( maxlen !== undefined && value.length > maxlen ) {
+        throw APIError.create('field_too_long', null, { key, max_length: maxlen });
+    }
+    // URL validation using validator library (same as url prop type)
+    let valid = validator.isURL(value);
+    if ( ! valid ) {
+        valid = validator.isURL(value, { host_whitelist: ['localhost'] });
+    }
+    if ( ! valid ) {
+        throw APIError.create('field_invalid', null, { key });
+    }
+};
+
+/**
+ * Validates a JSON value (must be an object or array).
+ * @param {*} value - The value to validate
+ * @param {object} meta - Metadata for the validation
+ * @param {string} meta.key - The field name (for error messages)
+ */
+export const validate_json = (value, { key }) => {
+    if ( typeof value !== 'object' ) {
+        throw APIError.create('field_invalid', null, { key });
+    }
+};
+
+/**
+ * Validates an array where each element is a string.
+ * @param {*} value - The value to validate
+ * @param {object} meta - Metadata for the validation
+ * @param {string} meta.key - The field name (for error messages)
+ */
+export const validate_array_of_strings = (value, { key }) => {
+    if ( ! Array.isArray(value) ) {
+        throw APIError.create('field_invalid', null, { key });
+    }
+    for ( const item of value ) {
+        if ( typeof item !== 'string' ) {
+            throw APIError.create('field_invalid', null, { key });
+        }
+    }
+};

--- a/src/backend/src/util/context.js
+++ b/src/backend/src/util/context.js
@@ -20,232 +20,250 @@ import { AsyncLocalStorage } from 'async_hooks';
 import { randomUUID } from 'crypto';
 import { v4 as uuidv4 } from 'uuid';
 
-export const context_config = {};
+// Singleton pattern to ensure ESM and CJS loads share the same class instance in vitest
+const CONTEXT_SINGLETON_KEY = Symbol.for('puter.context.module');
 
-export class Context {
-    static testId = randomUUID();
+let Context;
+let ContextExpressMiddleware;
+let context_config;
 
-    static USE_NAME_FALLBACK = {};
-    static next_name_ = 0;
-    static other_next_names_ = {};
+if ( globalThis[CONTEXT_SINGLETON_KEY] ) {
+    // Use existing singleton
+    ({ Context, ContextExpressMiddleware, context_config } = globalThis[CONTEXT_SINGLETON_KEY]);
+} else {
+    // Define classes for the first time
+    context_config = {};
 
-    // Context hooks should be registered via service (ContextService.js)
-    static context_hooks_ = {
-        pre_create: [],
-        post_create: [],
-        pre_arun: [],
-    };
+    Context = class Context {
+        static testId = randomUUID();
 
-    static contextAsyncLocalStorage = new AsyncLocalStorage();
-    static __last_context_key = 0;
-    static make_context_key (opt_human_readable) {
-        let k = `_:${++this.__last_context_key}`;
-        if ( opt_human_readable ) {
-            k += `:${opt_human_readable}`;
-        }
-        return k;
-    }
-    static create (values, opt_name) {
-        return new Context(values, undefined, opt_name);
-    }
-    static get (key, { allow_fallback } = {}) {
-        const existingContext = this.contextAsyncLocalStorage.getStore()?.get('context');
-        if ( ! existingContext ) {
-            if ( context_config.strict && !allow_fallback ) {
-                throw new Error('FAILED TO GET THE CORRECT CONTEXT');
+        static USE_NAME_FALLBACK = {};
+        static next_name_ = 0;
+        static other_next_names_ = {};
+
+        // Context hooks should be registered via service (ContextService.js)
+        static context_hooks_ = {
+            pre_create: [],
+            post_create: [],
+            pre_arun: [],
+        };
+
+        static contextAsyncLocalStorage = new AsyncLocalStorage();
+        static __last_context_key = 0;
+        static make_context_key (opt_human_readable) {
+            let k = `_:${++this.__last_context_key}`;
+            if ( opt_human_readable ) {
+                k += `:${opt_human_readable}`;
             }
-            const rootFallback =  this.root.sub({}, this.USE_NAME_FALLBACK);
-            if ( key ) {
-                return rootFallback.get(key);
-            }
-            return rootFallback;
+            return k;
         }
-        if ( key ) {
-            return existingContext.get(key);
+        static create (values, opt_name) {
+            return new Context(values, undefined, opt_name);
         }
-        return existingContext;
-    }
-    static set (k, v) {
-        const x = this.contextAsyncLocalStorage.getStore()?.get('context');
-        if ( x ) return x.set(k, v);
-    }
-    static root = new Context({}, undefined, 'root');
-    static describe () {
-        return this.get().describe();
-    }
-    static arun (...a) {
-        return this.get().arun(...a);
-    }
-    static sub (values, opt_name) {
-        return this.get().sub(values, opt_name);
-    }
-
-    #dead = false;
-
-    /**
-     * Clears this context's values and unlinks from its parent. This context
-     * will become empty. This is to ensure contexts that aren't used anymore
-     * get garbage collected. This was added to prevent memory leaks due to
-     * ECMAP, where currently we're not sure what's holding a reference back
-     * to the ECMAP (or perhaps its subcontext).
-     */
-    unlink () {
-        // Settings `values_` to an empty object should clear any references
-        // that were inside it while avoiding errors if .get() happens to be
-        // called by a lingering asynchronous function.
-        this.values_ = {};
-        this.#dead = true;
-    }
-
-    get (k) {
-        return this.values_[k];
-    }
-    set (k, v) {
-        if ( this.#dead ) return;
-        this.values_[k] = v;
-    }
-    sub (values, opt_name) {
-        if ( typeof values === 'string' ) {
-            opt_name = values;
-            values = {};
-        }
-        const name = opt_name ?? this.name ?? this.get('name');
-        for ( const hook of this.constructor.context_hooks_.pre_create ) {
-            hook({ values, name });
-        }
-        return new Context(values, this, opt_name);
-    }
-    get values () {
-        return this.values_;
-    }
-
-    /**
-     * @untested
-     */
-    get_proxy_object () {
-        return new Proxy(this.values_, {
-            get: (target, prop) => {
-                return this.get(prop);
-            },
-            set: (target, prop, value) => {
-                this.set(prop, value);
-                return true;
-            },
-        });
-    }
-
-    constructor (imm_values, opt_parent, opt_name) {
-        const values = { ...imm_values };
-        imm_values = null;
-
-        opt_parent = opt_parent || Context.root;
-
-        this.trace_name = opt_name ?? undefined;
-        this.name = (() => {
-            if ( opt_name === this.constructor.USE_NAME_FALLBACK ) {
-                opt_name = 'F';
-            }
-            if ( opt_name ) {
-                const name_numbers = this.constructor.other_next_names_;
-                if ( ! Object.prototype.hasOwnProperty.call(name_numbers, opt_name) ) {
-                    name_numbers[opt_name] = 0;
+        static get (key, { allow_fallback } = {}) {
+            const existingContext = this.contextAsyncLocalStorage.getStore()?.get('context');
+            if ( ! existingContext ) {
+                if ( context_config.strict && !allow_fallback ) {
+                    throw new Error('FAILED TO GET THE CORRECT CONTEXT');
                 }
-                const num = ++name_numbers[opt_name];
-                return `{${opt_name}:${num}}`;
+                const rootFallback =  this.root.sub({}, this.USE_NAME_FALLBACK);
+                if ( key ) {
+                    return rootFallback.get(key);
+                }
+                return rootFallback;
             }
-            return `${++this.constructor.next_name_}`;
-        })();
-        this.parent_ = opt_parent;
+            if ( key ) {
+                return existingContext.get(key);
+            }
+            return existingContext;
+        }
+        static set (k, v) {
+            const x = this.contextAsyncLocalStorage.getStore()?.get('context');
+            if ( x ) return x.set(k, v);
+        }
+        static root = new Context({}, undefined, 'root');
+        static describe () {
+            return this.get().describe();
+        }
+        static arun (...a) {
+            return this.get().arun(...a);
+        }
+        static sub (values, opt_name) {
+            return this.get().sub(values, opt_name);
+        }
 
-        if ( opt_parent ) {
-            Object.setPrototypeOf(values, opt_parent.values_);
-            for ( const k in values ) {
-                const parent_val = opt_parent.values_[k];
-                if ( parent_val instanceof Context ) {
-                    if ( ! (values[k] instanceof Context) ) {
-                        values[k] = parent_val.sub(values[k]);
+        #dead = false;
+
+        /**
+         * Clears this context's values and unlinks from its parent. This context
+         * will become empty. This is to ensure contexts that aren't used anymore
+         * get garbage collected. This was added to prevent memory leaks due to
+         * ECMAP, where currently we're not sure what's holding a reference back
+         * to the ECMAP (or perhaps its subcontext).
+         */
+        unlink () {
+            // Settings `values_` to an empty object should clear any references
+            // that were inside it while avoiding errors if .get() happens to be
+            // called by a lingering asynchronous function.
+            this.values_ = {};
+            this.#dead = true;
+        }
+
+        get (k) {
+            return this.values_[k];
+        }
+        set (k, v) {
+            if ( this.#dead ) return;
+            this.values_[k] = v;
+        }
+        sub (values, opt_name) {
+            if ( typeof values === 'string' ) {
+                opt_name = values;
+                values = {};
+            }
+            const name = opt_name ?? this.name ?? this.get('name');
+            for ( const hook of this.constructor.context_hooks_.pre_create ) {
+                hook({ values, name });
+            }
+            return new Context(values, this, opt_name);
+        }
+        get values () {
+            return this.values_;
+        }
+
+        /**
+         * @untested
+         */
+        get_proxy_object () {
+            return new Proxy(this.values_, {
+                get: (target, prop) => {
+                    return this.get(prop);
+                },
+                set: (target, prop, value) => {
+                    this.set(prop, value);
+                    return true;
+                },
+            });
+        }
+
+        constructor (imm_values, opt_parent, opt_name) {
+            const values = { ...imm_values };
+            imm_values = null;
+
+            opt_parent = opt_parent || Context.root;
+
+            this.trace_name = opt_name ?? undefined;
+            this.name = (() => {
+                if ( opt_name === this.constructor.USE_NAME_FALLBACK ) {
+                    opt_name = 'F';
+                }
+                if ( opt_name ) {
+                    const name_numbers = this.constructor.other_next_names_;
+                    if ( ! Object.prototype.hasOwnProperty.call(name_numbers, opt_name) ) {
+                        name_numbers[opt_name] = 0;
+                    }
+                    const num = ++name_numbers[opt_name];
+                    return `{${opt_name}:${num}}`;
+                }
+                return `${++this.constructor.next_name_}`;
+            })();
+            this.parent_ = opt_parent;
+
+            if ( opt_parent ) {
+                Object.setPrototypeOf(values, opt_parent.values_);
+                for ( const k in values ) {
+                    const parent_val = opt_parent.values_[k];
+                    if ( parent_val instanceof Context ) {
+                        if ( ! (values[k] instanceof Context) ) {
+                            values[k] = parent_val.sub(values[k]);
+                        }
                     }
                 }
             }
+
+            this.values_ = values;
         }
+        async arun (...args) {
+            let cb = args.shift();
 
-        this.values_ = values;
-    }
-    async arun (...args) {
-        let cb = args.shift();
+            let hints = {};
+            if ( typeof cb === 'object' ) {
+                hints = cb;
+                cb = args.shift();
+            }
 
-        let hints = {};
-        if ( typeof cb === 'object' ) {
-            hints = cb;
-            cb = args.shift();
-        }
+            if ( typeof cb === 'string' ) {
+                const sub_context = this.sub(cb);
+                return await sub_context.arun({ trace: true }, ...args);
+            }
 
-        if ( typeof cb === 'string' ) {
-            const sub_context = this.sub(cb);
-            return await sub_context.arun({ trace: true }, ...args);
-        }
+            const replace_callback = new_cb => {
+                cb = new_cb;
+            };
 
-        const replace_callback = new_cb => {
-            cb = new_cb;
-        };
+            for ( const hook of this.constructor.context_hooks_.pre_arun ) {
+                hook({
+                    hints,
+                    name: this.name ?? this.get('name'),
+                    trace_name: this.trace_name,
+                    replace_callback,
+                    callback: cb,
+                });
+            }
 
-        for ( const hook of this.constructor.context_hooks_.pre_arun ) {
-            hook({
-                hints,
-                name: this.name ?? this.get('name'),
-                trace_name: this.trace_name,
-                replace_callback,
-                callback: cb,
+            const als = this.constructor.contextAsyncLocalStorage;
+            return await als.run(new Map(), async () => {
+                als.getStore().set('context', this);
+                return await cb();
             });
         }
+        abind (cb) {
+            return async (...args) => {
+                return await this.arun(async () => {
+                    return await cb(...args);
+                });
+            };
+        }
 
-        const als = this.constructor.contextAsyncLocalStorage;
-        return await als.run(new Map(), async () => {
-            als.getStore().set('context', this);
-            return await cb();
-        });
-    }
-    abind (cb) {
-        return async (...args) => {
-            return await this.arun(async () => {
-                return await cb(...args);
+        describe () {
+            return `Context(${this.describe_()})`;
+        }
+        describe_ () {
+            if ( ! this.parent_ ) return '[R]';
+            return `${this.parent_.describe_()}->${this.name}`;
+        }
+
+        static async allow_fallback (cb) {
+            const x = this.get(undefined, { allow_fallback: true });
+            return await x.arun(async () => {
+                return await cb();
             });
-        };
-    }
+        }
+    };
 
-    describe () {
-        return `Context(${this.describe_()})`;
-    }
-    describe_ () {
-        if ( ! this.parent_ ) return '[R]';
-        return `${this.parent_.describe_()}->${this.name}`;
-    }
+    ContextExpressMiddleware = class ContextExpressMiddleware {
+        constructor ({ parent }) {
+            this.parent_ = parent;
+        }
+        install (app) {
+            app.use(this.run.bind(this));
+        }
+        async run (req, res, next) {
+            return await this.parent_.sub({
+                req,
+                res,
+                trace_request: uuidv4(),
+            }, 'req').arun(async () => {
+                const ctx = Context.get();
+                req.ctx = ctx;
+                res.locals.ctx = ctx;
+                next();
+            });
+        }
+    };
 
-    static async allow_fallback (cb) {
-        const x = this.get(undefined, { allow_fallback: true });
-        return await x.arun(async () => {
-            return await cb();
-        });
-    }
+    // Store singleton
+    globalThis[CONTEXT_SINGLETON_KEY] = { Context, ContextExpressMiddleware, context_config };
 }
 
-export class ContextExpressMiddleware {
-    constructor ({ parent }) {
-        this.parent_ = parent;
-    }
-    install (app) {
-        app.use(this.run.bind(this));
-    }
-    async run (req, res, next) {
-        return await this.parent_.sub({
-            req,
-            res,
-            trace_request: uuidv4(),
-        }, 'req').arun(async () => {
-            const ctx = Context.get();
-            req.ctx = ctx;
-            res.locals.ctx = ctx;
-            next();
-        });
-    }
-}
+export { Context, context_config, ContextExpressMiddleware };

--- a/src/backend/src/util/esmcontext.js
+++ b/src/backend/src/util/esmcontext.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2026-present Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// Bridge file to ensure ES modules and CommonJS modules use the same Context instance
+// This file uses require() to load context.js, ensuring compatibility with
+// CommonJS modules that also require() context.js
+const { Context, ContextExpressMiddleware } = require('./context.js');
+
+module.exports = {
+    Context,
+    ContextExpressMiddleware,
+};

--- a/src/backend/vitest.config.ts
+++ b/src/backend/vitest.config.ts
@@ -5,7 +5,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig(({ mode }) => ({
     test: {
         globals: true,
-        setupFiles: [],
+        setupFiles: ['./vitest.setup.js'],
         coverage: {
             provider: 'v8',
             reporter: ['text', 'json', 'json-summary', 'html', 'lcov'],

--- a/src/backend/vitest.setup.js
+++ b/src/backend/vitest.setup.js
@@ -1,0 +1,5 @@
+// Vitest setup file - runs before all test files
+// Initializes globalThis.kv which is required by PermissionService and other services
+
+import { kv } from './src/util/kvSingleton';
+globalThis.kv = kv;


### PR DESCRIPTION
### Scope

This PR covers implementing the `apps` driver, which will replace the `es:apps` driver.
- Later, `es:subdomains` and `es:notifications` will separately be moved away from the EntityStorage system.
- This PR only covers `es:apps`.

### Process/Convention Notes
- This PR is regularly rebased on `main`.
- Commits are intended to be well-formed, so this PR should be merged with the "Rebase and merge" option.

### Method Implementations
- [x] `apps.select()`
- [x] `apps.read()`
- [x] `apps.create()`
- [x] `apps.update()`
- [x] `apps.upsert()`
- [x] `apps.delete()`

### Regression Discovery
- [x] Write regression tests `.select()` to test `es:app` -> `app`
- [x] Write regression tests `.read()` to test `es:app` -> `app`
- [x] Write regression tests `.create()` to test `es:app` -> `app`
- [x] Write regression tests `.update()` to test `es:app` -> `app`
- [x] Write regression tests `.upsert()` to test `es:app` -> `app`
- [x] Write regression tests `.delete()` to test `es:app` -> `app`

### Regression Fixes

- [x] in read, `es:app` throws error vs `app` returns undefined
- [x] SQL syntax error in `app`
- [x] Return format of `delete` differs

### Other Tasks
- [x] Test/implement protected apps support
- [x] Manual access policy testing