### PR TITLE
fix: Enable godmode for dev-center to open worker files in editor

### DIFF
--- a/src/backend/src/services/database/SqliteDatabaseAccessService.js
+++ b/src/backend/src/services/database/SqliteDatabaseAccessService.js
@@ -167,6 +167,9 @@ class SqliteDatabaseAccessService extends BaseDatabaseAccessService {
             [39, [
                 '0043_add_dt.sql',
             ]],
+            [40, [
+                '0044_dev-center-godmode.sql',
+            ]],
         ];
 
         // Database upgrade logic

--- a/src/backend/src/services/database/sqlite_setup/0044_dev-center-godmode.sql
+++ b/src/backend/src/services/database/sqlite_setup/0044_dev-center-godmode.sql
@@ -1,0 +1,4 @@
+-- Enable godmode for dev-center app to allow launching editor with file_paths
+-- This fixes issue #2218 where worker files couldn't be opened from DEV Center
+
+UPDATE `apps` SET `godmode`=1 WHERE `uid`='app-0b37f054-07d4-4627-8765-11bd23e889d4';


### PR DESCRIPTION
## Fix: Enable godmode for dev-center to open worker files in editor

**Fixes #2218**

### Problem
The DEV Center was unable to open worker files in the text editor. When users clicked on a worker's file path in the DEV Center, the editor would open with an empty file instead of displaying the worker's code.

### Root Cause
The issue was identified in the file opening flow:

1. `workers.js` uses `puter.ui.launchApp()` with the `file_paths` parameter to open worker files in the editor
2. `ExecService.js` requires the calling app to have `godmode=1` permissions to use the `file_paths` parameter
3. The dev-center app was configured with `godmode=0` in the database

Without godmode permissions, the `file_paths` parameter was silently ignored, causing the editor to launch without any file loaded.

### Solution
- Added database migration `0044_dev-center-godmode.sql` to set `godmode=1` for the dev-center app
- Updated `SqliteDatabaseAccessService.js` to include the new migration in the migration sequence

### Changes
- `src/backend/src/services/database/sqlite_setup/0044_dev-center-godmode.sql` (new file)
- `src/backend/src/services/database/SqliteDatabaseAccessService.js` (modified)

### Testing
After this change:
- Users can click on a worker's file path in the DEV Center
- The editor will open with the correct worker file content loaded
- The file path parameter is properly processed due to godmode permissions