### PR TITLE
Remove debug logs and improve query coalescing timeout

### DIFF
--- a/extensions/puterfs/PuterFSProvider.js
+++ b/extensions/puterfs/PuterFSProvider.js
@@ -345,7 +345,6 @@ export default class PuterFSProvider {
             } : {}),
         };
 
-        console.log('raw fsentry', raw_fsentry);
         const entryOp = await this.fsEntryController.insert(raw_fsentry);
 
         await entryOp.awaitDone();
@@ -668,7 +667,6 @@ export default class PuterFSProvider {
      * @returns {Promise<FSNode>}
      */
     async write_new ({ context, parent, name, file }) {
-        console.log('calling write new');
         const {
             tmp, fsentry_tmp, message, actor: inputActor, app_id,
         } = context.values;

--- a/src/backend/src/modules/web/WebServerService.js
+++ b/src/backend/src/modules/web/WebServerService.js
@@ -110,7 +110,6 @@ class WebServerService extends BaseService {
         const services = this.services;
         await services.emit('start.webserver');
         await services.emit('ready.webserver');
-        console.log('in case you care, ready.webserver hooks are done');
     }
 
     /**


### PR DESCRIPTION
Removed unnecessary console.log statements from PuterFSProvider.js and WebServerService.js. Increased PENDING_QUERY_TTL to 3 seconds and added a timeout mechanism for coalesced queries in get_app to prevent indefinite waiting.