### PR TITLE
Remove flux schnell-free

### DIFF
--- a/src/backend/src/services/MeteringService/costMaps/togetherCostMap.ts
+++ b/src/backend/src/services/MeteringService/costMaps/togetherCostMap.ts
@@ -25,7 +25,6 @@ export const TOGETHER_COST_MAP = {
     'together-image:black-forest-labs/FLUX.1-krea-dev': 0.025 * 100_000_000,
     'together-image:black-forest-labs/FLUX.1-pro': 0.05 * 100_000_000,
     'together-image:black-forest-labs/FLUX.1-schnell': 0.0027 * 100_000_000,
-    'together-image:black-forest-labs/FLUX.1-schnell-Free': 0,
     'together-image:black-forest-labs/FLUX.1.1-pro': 0.05 * 100_000_000,
     'together-image:black-forest-labs/FLUX.2-pro': 0.03 * 100_000_000,
     'together-image:black-forest-labs/FLUX.2-flex': 0.03 * 100_000_000,

--- a/src/backend/src/services/ai/image/providers/TogetherImageGenerationProvider/models.ts
+++ b/src/backend/src/services/ai/image/providers/TogetherImageGenerationProvider/models.ts
@@ -308,15 +308,6 @@ export const TOGETHER_IMAGE_GENERATION_MODELS: IImageModel[] = [
         costs: { '1MP': 0.19 },
     },
     {
-        id: 'togetherai:black-forest-labs/FLUX.1-schnell-Free',
-        aliases: ['black-forest-labs/FLUX.1-schnell-Free', 'FLUX.1-schnell-Free'],
-        costs_currency: 'usd-cents',
-        index_cost_key: '1MP',
-        name: 'black-forest-labs/FLUX.1-schnell-Free',
-        allowedQualityLevels: [''],
-        costs: { '1MP': 0 },
-    },
-    {
         id: 'togetherai:black-forest-labs/FLUX.2-max',
         aliases: ['black-forest-labs/FLUX.2-max', 'FLUX.2-max'],
         costs_currency: 'usd-cents',


### PR DESCRIPTION
- the FLUX.1-schnell-Free model is no longer offered by together
- source: https://www.together.ai/models/flux-1-schnell
- we also have user report the issue to us
- removing it from the list, as to not confuse the user
<img width="850" height="232" alt="image" src="https://github.com/user-attachments/assets/557f899c-d616-475f-bb8d-435b660670ed" />