### PR TITLE
feat(puter.js): make home directory default cwd

### DIFF
--- a/src/backend/src/helpers.js
+++ b/src/backend/src/helpers.js
@@ -383,7 +383,7 @@ async function get_app (options) {
 
         cacheApp(app);
         resolveQuery(app);
-    } catch (err) {
+    } catch ( err ) {
         rejectQuery(err);
         throw err;
     } finally {
@@ -1522,6 +1522,9 @@ async function suggest_app_for_fsentry (fsentry, options) {
 
     // return list
     const suggested_apps = await Promise.all(suggested_apps_promises);
+    if ( suggested_apps.some(app => app && app.name === 'editor') ) {
+        suggested_apps.push(await get_app({ name: 'codeapp' }));
+    }
     return suggested_apps.filter((suggested_app, pos, self) => {
         // Remove any null values caused by calling `get_app()` for apps that don't exist.
         // This happens on self-host because we don't include `code`, among others.

--- a/src/puter-js/src/modules/FileSystem/utils/getAbsolutePathForApp.js
+++ b/src/puter-js/src/modules/FileSystem/utils/getAbsolutePathForApp.js
@@ -1,8 +1,8 @@
 import path from '../../../lib/path.js';
 
 const getAbsolutePathForApp = (relativePath) => {
-    // if we are in the gui environment, return the relative path as is
-    if ( puter.env === 'gui' )
+    // preserve previous behavior for falsy values when env is gui
+    if ( puter.env === 'gui' && !relativePath )
     {
         return relativePath;
     }
@@ -15,8 +15,12 @@ const getAbsolutePathForApp = (relativePath) => {
 
     // If relativePath is not provided, or it's not starting with a slash or tilde,
     // it means it's a relative path. In that case, prepend the app's root directory.
-    if ( !relativePath || (!relativePath.startsWith('/') && !relativePath.startsWith('~') && puter.appID) ) {
-        relativePath = path.join('~/AppData', puter.appID, relativePath);
+    if ( !relativePath || (!relativePath.startsWith('/') && !relativePath.startsWith('~')) ) {
+        if ( puter.appID ) {
+            relativePath = path.join('~/AppData', puter.appID, relativePath);
+        } else {
+            relativePath = path.join('~/', relativePath);
+        }
     }
 
     return relativePath;


### PR DESCRIPTION
Make the home directory (AKA "~") the default CWD for puter.js, making relative paths work in environments other than app environments (i.e. gui or worker environments).