### PR TITLE
feat(data-access): move puter.js read to app driver

### DIFF
--- a/src/puter-js/src/modules/Apps.js
+++ b/src/puter-js/src/modules/Apps.js
@@ -190,7 +190,7 @@ class Apps {
         if ( typeof args[0] === 'object' && args[0] !== null ) {
             options.params = args[0];
         }
-        return this.#addUserIterationToApp(await utils.make_driver_method(['uid'], 'puter-apps', 'es:app', 'read').call(this, options));
+        return this.#addUserIterationToApp(await utils.make_driver_method(['uid'], 'puter-apps', 'app', 'read').call(this, options));
     };
 
     delete = async (...args) => {


### PR DESCRIPTION
This is the first functional migration from ths `es:app` driver to the `app` driver. Any call to `puter.apps.get` will go through `es:app` after this change.