### PR TITLE
Revert "feat(data-access): move puter.js read to app driver"

### DIFF
--- a/src/puter-js/src/modules/Apps.js
+++ b/src/puter-js/src/modules/Apps.js
@@ -190,7 +190,7 @@ class Apps {
         if ( typeof args[0] === 'object' && args[0] !== null ) {
             options.params = args[0];
         }
-        return this.#addUserIterationToApp(await utils.make_driver_method(['uid'], 'puter-apps', 'app', 'read').call(this, options));
+        return this.#addUserIterationToApp(await utils.make_driver_method(['uid'], 'puter-apps', 'es:app', 'read').call(this, options));
     };
 
     delete = async (...args) => {


### PR DESCRIPTION
This reverts commit 2139551abf13569e4d0b998f764765dac1390ad8.

It looks like this breaks dev-center because the file associations aren't properly sent. I will need to investigate this.