### PR TITLE
fix: skip CI tests when only docs are changed (#2335)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,12 @@ name: test
 on:
   push:
     branches: ["main"]
+    paths-ignore:
+      - "src/docs/**"
   pull_request:
     branches: ["main"]
+    paths-ignore:
+      - "src/docs/**"
 
 jobs:
   test-backend:


### PR DESCRIPTION
## Description
Skip test workflows (backend tests, API tests, vitest) when only documentation files in `src/docs/` are modified.

## Changes
- Added `paths-ignore: ["src/docs/**"]` to both `push` and `pull_request` triggers in `.github/workflows/test.yml`

## Why This Change?
After moving puter.js docs to this repo, CI workflows run unnecessarily for docs-only changes, wasting resources and time.

## Testing
- Documentation-only changes will now skip all test jobs
- Code changes continue to trigger full test suite as before

Fixes #2335
