### PR TITLE
docs: add example for streaming with function calling

### DIFF
--- a/src/docs/src/AI/chat.md
+++ b/src/docs/src/AI/chat.md
@@ -270,6 +270,88 @@ List of OpenAI models that support the web search can be found in their [API com
 </html>
 ```
 
+<strong class="example-title">Streaming Function Calling</strong>
+
+```html;ai-streaming-function-calling
+<html>
+<body>
+    <script src="https://js.puter.com/v2/"></script>
+    <script>
+        // Define the tool
+        const tools = [{
+            type: "function",
+            function: {
+                name: "get_weather",
+                description: "Get current weather for a location",
+                parameters: {
+                    type: "object",
+                    properties: {
+                        location: { type: "string", description: "City name" }
+                    },
+                    required: ["location"]
+                }
+            }
+        }];
+
+        // Mock weather function
+        function getWeather(location) {
+            return `The weather in ${location} is 22°C and Sunny.`;
+        }
+
+        (async () => {
+            const question = "What's the weather in Paris?";
+            puter.print(`Question: ${question}<br/>`);
+
+            // 1. Call AI with stream: true AND tools
+            const response = await puter.ai.chat(question, { 
+                tools,
+                stream: true 
+            });
+
+            // 2. Iterate through the stream
+            for await (const part of response) {
+                
+                // Standard Text Stream
+                if (part.type === 'text') {
+                    puter.print(part.text);
+                }
+                
+                // Tool Call Detected
+                else if (part.type === 'tool_use') {
+                    const toolCall = part;
+                    const funcName = toolCall.name;
+                    const args = toolCall.input; // Already parsed: { location: "Paris" }
+
+                    puter.print(`<br/>[System] Calling tool: ${funcName} with args: ${JSON.stringify(args)}<br/>`);
+
+                    // Execute the local function
+                    let result;
+                    if (funcName === 'get_weather') {
+                        result = getWeather(args.location);
+                    }
+
+                    // Send the tool result back to the AI to get the final answer
+                    const finalResponse = await puter.ai.chat([
+                        { role: "user", content: question },
+                        { role: "assistant", tool_calls: [{
+                            id: toolCall.id,
+                            type: "function",
+                            function: { name: funcName, arguments: JSON.stringify(args) }
+                        }]},
+                        { role: "tool", tool_call_id: toolCall.id, content: result }
+                    ], { stream: true });
+
+                    for await (const finalPart of finalResponse) {
+                        if (finalPart.text) puter.print(finalPart.text);
+                    }
+                }
+            }
+        })();
+    </script>
+</body>
+</html>
+```
+
 <strong class="example-title">Web Search</strong>
 
 ```html;ai-web-search
@@ -432,86 +514,3 @@ List of OpenAI models that support the web search can be found in their [API com
 </body>
 </html>
 ```
-
-<strong class="example-title">Streaming Function Calls</strong>
-
-```html;ai-streaming-function-calling
-<html>
-<body>
-    <script src="https://js.puter.com/v2/"></script>
-    <script>
-        // Define the tool
-        const tools = [{
-            type: "function",
-            function: {
-                name: "get_weather",
-                description: "Get current weather for a location",
-                parameters: {
-                    type: "object",
-                    properties: {
-                        location: { type: "string", description: "City name" }
-                    },
-                    required: ["location"]
-                }
-            }
-        }];
-
-        // Mock weather function
-        function getWeather(location) {
-            return `The weather in ${location} is 22°C and Sunny.`;
-        }
-
-        (async () => {
-            const question = "What's the weather in Paris?";
-            puter.print(`Question: ${question}<br/>`);
-
-            // 1. Call AI with stream: true AND tools
-            const response = await puter.ai.chat(question, { 
-                tools,
-                stream: true 
-            });
-
-            // 2. Iterate through the stream
-            for await (const part of response) {
-                
-                // CASE A: Standard Text Stream
-                // The AI is talking to the user (e.g. "Checking the weather...")
-                if (part.type === 'text') {
-                    puter.print(part.text);
-                }
-                
-                // CASE B: Tool Call Detected
-                // Puter sends this as a SINGLE complete object. No need to buffer chunks.
-                else if (part.type === 'tool_use') {
-                    const toolCall = part;
-                    const funcName = toolCall.name;
-                    const args = toolCall.input; // Already parsed: { location: "Paris" }
-
-                    puter.print(`<br/>[System] Calling tool: ${funcName} with args: ${JSON.stringify(args)}<br/>`);
-
-                    // Execute the local function
-                    let result;
-                    if (funcName === 'get_weather') {
-                        result = getWeather(args.location);
-                    }
-
-                    // Send the tool result back to the AI to get the final answer
-                    const finalResponse = await puter.ai.chat([
-                        { role: "user", content: question },
-                        { role: "assistant", tool_calls: [{
-                            id: toolCall.id,
-                            type: "function",
-                            function: { name: funcName, arguments: JSON.stringify(args) }
-                        }]},
-                        { role: "tool", tool_call_id: toolCall.id, content: result }
-                    ], { stream: true });
-
-                    for await (const finalPart of finalResponse) {
-                        if (finalPart.text) puter.print(finalPart.text);
-                    }
-                }
-            }
-        })();
-    </script>
-</body>
-</html>

--- a/src/docs/src/examples.js
+++ b/src/docs/src/examples.js
@@ -68,6 +68,12 @@ const examples = [
                 source: '/playground/examples/ai-function-calling.html',
             },
             {
+                title: 'Streaming Function Calls',
+                description: 'Run AI function calling with streaming using Puter.js. Try out AI examples directly in Puter.js playground.',
+                slug: 'ai-streaming-function-calling',
+                source: '/playground/examples/ai-streaming-function-calling.html',
+            },
+            {
                 title: 'Web Search',
                 description: 'Perform web search using AI to generate accurate and up-to-date information. Try out this example in Puter.js playground.',
                 slug: 'ai-web-search',

--- a/src/docs/src/playground/examples/ai-streaming-function-calling.html
+++ b/src/docs/src/playground/examples/ai-streaming-function-calling.html
@@ -1,0 +1,77 @@
+<html>
+<body>
+    <script src="https://js.puter.com/v2/"></script>
+    <script>
+        // Define the tool
+        const tools = [{
+            type: "function",
+            function: {
+                name: "get_weather",
+                description: "Get current weather for a location",
+                parameters: {
+                    type: "object",
+                    properties: {
+                        location: { type: "string", description: "City name" }
+                    },
+                    required: ["location"]
+                }
+            }
+        }];
+
+        // Mock weather function
+        function getWeather(location) {
+            return `The weather in ${location} is 22°C and Sunny.`;
+        }
+
+        (async () => {
+            const question = "What's the weather in Paris?";
+            puter.print(`Question: ${question}<br/>`);
+
+            // 1. Call AI with stream: true AND tools
+            const response = await puter.ai.chat(question, { 
+                tools,
+                stream: true 
+            });
+
+            // 2. Iterate through the stream
+            for await (const part of response) {
+                
+                // Standard Text Stream
+                if (part.type === 'text') {
+                    puter.print(part.text);
+                }
+                
+                // Tool Call Detected
+                else if (part.type === 'tool_use') {
+                    const toolCall = part;
+                    const funcName = toolCall.name;
+                    const args = toolCall.input; // Already parsed: { location: "Paris" }
+
+                    puter.print(`<br/>[System] Calling tool: ${funcName} with args: ${JSON.stringify(args)}<br/>`);
+
+                    // Execute the local function
+                    let result;
+                    if (funcName === 'get_weather') {
+                        result = getWeather(args.location);
+                    }
+
+                    // Send the tool result back to the AI to get the final answer
+                    const finalResponse = await puter.ai.chat([
+                        { role: "user", content: question },
+                        { role: "assistant", tool_calls: [{
+                            id: toolCall.id,
+                            type: "function",
+                            function: { name: funcName, arguments: JSON.stringify(args) }
+                        }]},
+                        { role: "tool", tool_call_id: toolCall.id, content: result }
+                    ], { stream: true });
+
+                    for await (const finalPart of finalResponse) {
+                        if (finalPart.text) puter.print(finalPart.text);
+                    }
+                }
+            }
+        })();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Description
This PR adds a missing example to the `puter.ai.chat()` documentation demonstrating how to handle **Function Calling** when `stream: true` is enabled.

Fixes #2360

## Context
Currently, the docs cover "Function Calling" and "Streaming" separately. Developers trying to combine them might assume they need to manually accumulate partial JSON strings (standard behavior for OpenAI/Anthropic SDKs).

However, after analyzing `services/ai/utils/Streaming.js` in the backend, I confirmed that `AIChatToolUseStream` buffers and parses the tool call internally. It only emits a chunk to the client when the tool call is complete.

## Changes
- Updated `src/docs/src/AI/chat.md`.
- Added a new code example that:
  1. Requests a chat completion with `{ stream: true, tools: [...] }`.
  2. Iterates through the stream.
  3. Listens for the `part.type === 'tool_use'` event.
  4. Accesses the fully parsed `part.input` object directly (simplifying the client-side logic).