### PR TITLE
dev(backend): add broadcast webhook endpoint

### DIFF
--- a/doc/contributors/extensions/README.md
+++ b/doc/contributors/extensions/README.md
@@ -87,3 +87,7 @@ See [events.md](./events.md)
 ## Definitions
 
 See [definitions.md](./definitions.md)
+
+## Bundled extensions
+
+- [dev-console](./dev-console.md) – Dev socket for running backend commands locally (opt-in via `DEVCONSOLE=1`).

--- a/doc/contributors/extensions/dev-console.md
+++ b/doc/contributors/extensions/dev-console.md
@@ -1,0 +1,21 @@
+# dev-console extension
+
+The **dev-console** extension provides a **dev socket** so you can run backend commands on a local Puter instance (e.g. commands registered in [CommandService](../../../src/backend/src/services/CommandService.js)).
+
+## Enabling
+
+The extension is **opt-in**. Set the environment variable `DEVCONSOLE=1` when starting Puter. The `npm run dev` script already does this:
+
+```bash
+npm run dev
+```
+
+With `DEVCONSOLE=1`, the extension registers a `dev-socket` service that creates a UNIX socket and runs command lines through CommandService.
+
+## Usage
+
+See [Backend – dev socket](../../../src/backend/doc/dev_socket.md) for how to connect (e.g. `rlwrap nc -U ./dev.sock`) and run commands like `help`, `logs:indent`, etc.
+
+## Location
+
+The extension lives in `extensions/dev-console/`. It only registers the dev-socket service when `DEVCONSOLE=1`; otherwise the extension loads but does nothing, so it does not affect default runs.

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -1,9 +1,13 @@
-# Extension System Development Guide]
+# Extension System Development Guide
 
 ## Where to find documentation
 
 ### Here
 Documentation for extensions is [here](src/backend/doc/extensions/README.md).
+
+### Bundled extensions
+
+- **dev-console** (`extensions/dev-console/`) – Dev socket for running backend commands locally. Opt-in via `DEVCONSOLE=1` (e.g. `npm run dev`). See [Backend – dev socket](src/backend/doc/dev_socket.md).
 
 ### Not Here
 

--- a/mods/mods_available/dev-socket/main.js
+++ b/mods/mods_available/dev-socket/main.js
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2024-present Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import fs from 'node:fs';
+import net from 'node:net';
+import path from 'node:path';
+
+const SOCKET_NAME = 'dev.sock';
+const WELCOME = [
+    'Puter dev socket – enter a command (e.g. help) and press Enter.',
+    'Close the connection with Ctrl+C or by typing exit.',
+    '',
+].join('\n');
+
+function getSocketDir () {
+    if ( process.env.PUTER_DEV_SOCKET_DIR ) {
+        return process.env.PUTER_DEV_SOCKET_DIR;
+    }
+    const volatileRuntime = path.join(process.cwd(), 'volatile', 'runtime');
+    if ( fs.existsSync(volatileRuntime) ) {
+        return volatileRuntime;
+    }
+    return process.cwd();
+}
+
+extension.on('init', async () => {
+    if ( process.env.DEVCONSOLE !== '1' ) {
+        return;
+    }
+
+    const commands = extension.import('service:commands');
+    const socketDir = getSocketDir();
+    const socketPath = path.join(socketDir, SOCKET_NAME);
+
+    try {
+        if ( fs.existsSync(socketPath) ) {
+            fs.unlinkSync(socketPath);
+        }
+        fs.mkdirSync(socketDir, { recursive: true });
+    } catch ( err ) {
+        console.warn('dev-socket: could not prepare socket path', socketPath, err.message);
+        return;
+    }
+
+    const server = net.createServer((socket) => {
+        socket.setEncoding('utf8');
+        socket.write(`${WELCOME }\n> `);
+        let buffer = '';
+        socket.on('data', (chunk) => {
+            buffer += chunk;
+            const lines = buffer.split(/\r?\n/);
+            buffer = lines.pop() ?? '';
+            for ( const line of lines ) {
+                const trimmed = line.trim();
+                if ( trimmed === '' ) continue;
+                if ( trimmed.toLowerCase() === 'exit' ) {
+                    socket.end();
+                    return;
+                }
+                const log = {
+                    log: (msg) => {
+                        socket.write(`${String(msg) }\n`);
+                    },
+                    error: (msg) => {
+                        socket.write(`${String(msg) }\n`);
+                    },
+                };
+                commands.executeRawCommand(trimmed, log).then(() => {
+                    socket.write('> ');
+                }).catch((err) => {
+                    log.error(err?.message ?? err);
+                    socket.write('> ');
+                });
+            }
+        });
+        socket.on('end', () => {
+        });
+        socket.on('error', () => {
+        });
+    });
+
+    server.listen(socketPath, () => {
+        console.log('dev-socket: socket listening at', socketPath);
+    });
+    server.on('error', (err) => {
+        console.warn('dev-socket: socket error', err.message);
+    });
+});

--- a/mods/mods_available/dev-socket/package.json
+++ b/mods/mods_available/dev-socket/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@heyputer/extension-dev-console",
+  "version": "1.0.0",
+  "description": "Dev socket for running backend commands locally (opt-in via DEVCONSOLE=1)",
+  "main": "main.js",
+  "type": "module",
+  "private": true
+}

--- a/src/backend/.gitignore
+++ b/src/backend/.gitignore
@@ -144,6 +144,9 @@ keys
 # credentials
 creds*
 
+# test-webhook persisted key
+tools/.test-webhook-config.json
+
 # thumbnai-service
 thumbnail-service
 

--- a/src/backend/doc/dev_socket.md
+++ b/src/backend/doc/dev_socket.md
@@ -1,15 +1,32 @@
 ## Backend - dev socket
 
 The "dev socket" allows you to interact with Puter's backend by running commands.
-It's a UNIX socket created in Puter's runtime directory
-(typically `./volatile/runtime`, or `/var/puter` for production instances).
+It's a UNIX socket that lets you run commands registered with
+[CommandService](../../src/services/CommandService.js) (e.g. `help`, `logs:indent`, `params:get`, etc.).
 
-When in the runtime directory, you can connect to the socket with your tool
-of choice. For example, using `nc` as well as `rlwrap` to get readline history:
+### Enabling the dev socket
+
+The dev socket is provided by the **dev-console extension** and is **opt-in**. To enable it:
+
+1. Set the environment variable `DEVCONSOLE=1` when starting Puter (e.g. `npm run dev` already does this).
+2. The extension lives in `extensions/dev-console/` and registers a `dev-socket` service when `DEVCONSOLE=1`.
+
+### Socket location
+
+The socket is created in a directory chosen as follows (in order):
+
+- `PUTER_DEV_SOCKET_DIR` if set
+- `./volatile/runtime` if it exists (typical local dev)
+- otherwise the process current working directory
+
+The socket file is named `dev.sock`.
+
+### Connecting
+
+When in that directory, connect with your tool of choice. For example, using `nc` and `rlwrap` for readline history:
 
 ```
 rlwrap nc -U ./dev.sock
 ```
 
-If it is successful you will see a message with instructions. At this point
-you may enter a command. Enter the `help` command to see a list of commands.
+If it is successful you will see a message with instructions. Enter a command (e.g. `help`) and press Enter.

--- a/src/backend/doc/extensions/README.md
+++ b/src/backend/doc/extensions/README.md
@@ -72,6 +72,10 @@ key-value store, and in-memory cache.
 ### Adding Features to Puter
 - [Implementing Drivers](./pages/drivers.md)
 
+### Bundled extensions
+
+- **dev-console** – When `DEVCONSOLE=1` is set (e.g. `npm run dev`), the dev-console extension registers a UNIX socket (`dev.sock`) so you can run backend commands (see [CommandService](../../src/services/CommandService.js)) from a terminal. See [Backend – dev socket](../dev_socket.md).
+
 ## Extensions - Planned Features
 
 Extensions are under refactor currently. This is the checklist:

--- a/src/backend/src/modules/broadcast/BroadcastService.js
+++ b/src/backend/src/modules/broadcast/BroadcastService.js
@@ -20,6 +20,8 @@ const BaseService = require('../../services/BaseService');
 const { CLink } = require('./connection/CLink');
 const { SLink } = require('./connection/SLink');
 const { Context } = require('../../util/context');
+const { Endpoint } = require('../../util/expressutil');
+const crypto = require('crypto');
 
 class BroadcastService extends BaseService {
     static MODULES = {
@@ -31,20 +33,37 @@ class BroadcastService extends BaseService {
         this.peers_ = [];
         this.connections_ = [];
         this.trustedPublicKeys_ = {};
+        this.peersByKey_ = {};
+        this.webhookPeers_ = [];
+        this.incomingLastNonceByPeer_ = new Map();
     }
 
     async _init () {
         const peers = this.config.peers ?? [];
+        const replayWindowSeconds = this.config.webhook_replay_window_seconds ?? 300;
+
         for ( const peer_config of peers ) {
             this.trustedPublicKeys_[peer_config.key] = true;
-            const peer = new CLink({
-                keys: this.config.keys,
-                config: peer_config,
-                log: this.log,
-            });
-            this.peers_.push(peer);
-            peer.connect();
+            this.peersByKey_[peer_config.key] = {
+                webhook_secret: peer_config.webhook_secret,
+                webhook_url: peer_config.webhook_url,
+                webhook: !!peer_config.webhook,
+            };
+
+            if ( peer_config.webhook ) {
+                this.webhookPeers_.push(peer_config);
+            } else {
+                const peer = new CLink({
+                    keys: this.config.keys,
+                    config: peer_config,
+                    log: this.log,
+                });
+                this.peers_.push(peer);
+                peer.connect();
+            }
         }
+
+        this.webhookReplayWindowSeconds_ = replayWindowSeconds;
 
         this._register_commands(this.services.get('commands'));
 
@@ -62,6 +81,122 @@ class BroadcastService extends BaseService {
                 //
             }
         }
+    }
+
+    async ['__on_install.routes'] (_, { app }) {
+        const svc_web = this.services.get('web-server');
+        svc_web.allow_undefined_origin('/broadcast/webhook');
+
+        Endpoint({
+            route: '/broadcast/webhook',
+            methods: ['POST'],
+            handler: this.handleWebhookRequest_.bind(this),
+        }).attach(app);
+    }
+
+    handleWebhookRequest_ (req, res) {
+        const rawBody = req.rawBody;
+        if ( rawBody === undefined || rawBody === null ) {
+            res.status(400).send({ error: { message: 'Missing or invalid body' } });
+            return;
+        }
+
+        const body = req.body;
+        if ( !body || typeof body !== 'object' ) {
+            res.status(400).send({ error: { message: 'Invalid JSON body' } });
+            return;
+        }
+
+        // Validate required properties
+        const { key, data, meta } = body;
+        if ( key === undefined || key === null ) {
+            res.status(400).send({ error: { message: 'Missing key' } });
+            return;
+        }
+        if ( data === undefined ) {
+            res.status(400).send({ error: { message: 'Missing data' } });
+            return;
+        }
+        if ( meta === undefined ) {
+            res.status(400).send({ error: { message: 'Missing meta' } });
+            return;
+        }
+
+        const peerId = req.headers['x-broadcast-peer-id'];
+        if ( ! peerId ) {
+            res.status(403).send({ error: { message: 'Missing X-Broadcast-Peer-Id' } });
+            return;
+        }
+
+        const peer = this.peersByKey_[peerId];
+        if ( !peer || !peer.webhook_secret ) {
+            res.status(403).send({ error: { message: 'Unknown peer or webhook not configured' } });
+            return;
+        }
+
+        // Timestamp avoids nonce-reuse after a restart
+        const timestampHeader = req.headers['x-broadcast-timestamp'];
+        if ( ! timestampHeader ) {
+            res.status(400).send({ error: { message: 'Missing X-Broadcast-Timestamp' } });
+            return;
+        }
+        const timestamp = Number(timestampHeader);
+        if ( Number.isNaN(timestamp) ) {
+            res.status(400).send({ error: { message: 'Invalid X-Broadcast-Timestamp' } });
+            return;
+        }
+        const nowSeconds = Math.floor(Date.now() / 1000);
+        const window = this.webhookReplayWindowSeconds_;
+        if ( timestamp < nowSeconds - window || timestamp > nowSeconds + 60 ) {
+            res.status(400).send({ error: { message: 'Timestamp out of window' } });
+            return;
+        }
+
+        // Nonce avoids replay attacks
+        const nonceHeader = req.headers['x-broadcast-nonce'];
+        if ( nonceHeader === undefined || nonceHeader === null || nonceHeader === '' ) {
+            res.status(400).send({ error: { message: 'Missing X-Broadcast-Nonce' } });
+            return;
+        }
+        const nonce = Number(nonceHeader);
+        if ( Number.isNaN(nonce) ) {
+            res.status(400).send({ error: { message: 'Invalid X-Broadcast-Nonce' } });
+            return;
+        }
+        const lastNonce = this.incomingLastNonceByPeer_.get(peerId) ?? -1;
+        if ( nonce <= lastNonce ) {
+            res.status(403).send({ error: { message: 'Duplicate or stale nonce' } });
+            return;
+        }
+
+        // We verify a signature to ensure the message came from an authorized peer
+        const signatureHeader = req.headers['x-broadcast-signature'];
+        if ( ! signatureHeader ) {
+            res.status(403).send({ error: { message: 'Missing X-Broadcast-Signature' } });
+            return;
+        }
+
+        const payloadToSign = `${timestamp}.${nonce}.${rawBody}`;
+        const expectedHmac = crypto.createHmac('sha256', peer.webhook_secret).update(payloadToSign).digest('hex');
+        const signatureBuffer = Buffer.from(signatureHeader, 'hex');
+        const expectedBuffer = Buffer.from(expectedHmac, 'hex');
+        if ( signatureBuffer.length !== expectedBuffer.length || !crypto.timingSafeEqual(signatureBuffer, expectedBuffer) ) {
+            res.status(403).send({ error: { message: 'Invalid signature' } });
+            return;
+        }
+
+        this.incomingLastNonceByPeer_.set(peerId, nonce);
+
+        // We emit the event sent to this webhook endpoint so other services
+        // can react to it. We set the `from_outside` flag to avoid feedback.
+        const svc_event = this.services.get('event');
+        const metaOut = { ...meta, from_outside: true };
+        const context = Context.get(undefined, { allow_fallback: true });
+        context.arun(async () => {
+            await svc_event.emit(key, data, metaOut);
+        });
+
+        res.status(200).send({ ok: true });
     }
 
     async ['__on_install.websockets'] () {

--- a/src/backend/src/modules/broadcast/BroadcastService.js
+++ b/src/backend/src/modules/broadcast/BroadcastService.js
@@ -235,6 +235,7 @@ class BroadcastService extends BaseService {
         const signature = crypto.createHmac('sha256', mySecretKey).update(payloadToSign).digest('hex');
 
         const myPublicKey = this.config.webhook?.key ?? '';
+        this.log.debug('Sending webhook message to peer', { peerId });
         const response = await fetch(url, {
             method: 'POST',
             headers: {
@@ -297,6 +298,7 @@ class BroadcastService extends BaseService {
                 id: 'test',
                 description: 'send a test message',
                 handler: async () => {
+                    this.log.info('broadcast service test command was run');
                     this.on_event('test', {
                         contents: 'I am a test message',
                     }, {});

--- a/src/backend/tools/README.md
+++ b/src/backend/tools/README.md
@@ -1,5 +1,20 @@
 # Backend Tools Directory
 
+## Manual Test for Broadcast Webhook Support
+
+`test-webhook.js` can be used for manual testing the `/broadcast/webhook` endpoint.
+It prints a one-off peer config (peer id and `webhook_secret`) for you to add to your instance’s broadcast config,
+then prompts for the instance base URL and sends an event with key `"test"`.
+
+**Usage** (from repo root):
+
+```bash
+node src/backend/tools/test-webhook.js
+```
+
+Add the printed peer to your config under `broadcast.peers`, restart the instance, then run the script and enter the instance URL
+(your Puter API URL, such as `http://api.puter.localhost:4100`) when prompted.
+
 ## Test Kernel
 
 The **Test Kernel** is a drop-in replacement for Puter's main kernel. Instead of

--- a/src/backend/tools/test-webhook.js
+++ b/src/backend/tools/test-webhook.js
@@ -1,0 +1,224 @@
+/*
+ * Copyright (C) 2024-present Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+const readline = require('readline');
+
+const CONFIG_PATH = path.join(__dirname, '.test-webhook-config.json');
+
+function randomHex (bytes) {
+    return crypto.randomBytes(bytes).toString('hex');
+}
+
+function loadConfig () {
+    try {
+        const raw = fs.readFileSync(CONFIG_PATH, 'utf8');
+        const data = JSON.parse(raw);
+        if ( data && typeof data.key === 'string' && typeof data.webhook_secret === 'string' ) {
+            const out = {
+                key: data.key,
+                webhook_secret: data.webhook_secret,
+                nonce: typeof data.nonce === 'number' ? data.nonce : 0,
+            };
+            if ( typeof data.instance_url === 'string' && data.instance_url.trim() !== '' ) {
+                out.instance_url = data.instance_url.trim().replace(/\/+$/, '');
+            }
+            return out;
+        }
+    } catch (e) {
+        const is_not_found = e.code === 'ENOENT';
+        if ( ! is_not_found ) {
+            console.error('Saved config exists but could not be read:', e);
+        }
+    }
+    return null;
+}
+
+/**
+ * Saves a dotfile beside the script so new configuration doesn't need to be
+ * re-entered into Puter every time this script is used.
+ * @param {*} peerId - The peer ID to save.
+ * @param {*} webhookSecret - The webhook secret to save.
+ * @param {*} nonce - The nonce to save.
+ * @param {*} instanceUrl - The instance URL to save.
+ */
+function saveConfig (peerId, webhookSecret, nonce, instanceUrl) {
+    const payload = {
+        key: peerId,
+        webhook_secret: webhookSecret,
+        nonce,
+    };
+    if ( typeof instanceUrl === 'string' && instanceUrl.trim() !== '' ) {
+        payload.instance_url = instanceUrl.trim().replace(/\/+$/, '');
+    }
+    fs.writeFileSync(CONFIG_PATH, JSON.stringify(payload, null, 2), 'utf8');
+}
+
+/**
+ * This wrapper around readline.question is used to promisify the interface
+ * and remove whitespace from the input.
+ *
+ * @param {*} rl
+ * @param {*} question
+ * @param {*} defaultAnswer
+ * @returns {Promise<string>} - The trimmed answer.
+ */
+function ask (rl, question, defaultAnswer = '') {
+    const prompt = defaultAnswer ? `${question} [${defaultAnswer}]: ` : `${question} `;
+    return new Promise((resolve) => {
+        rl.question(prompt, (answer) => {
+            const trimmed = answer.trim();
+            resolve(trimmed !== '' ? trimmed : defaultAnswer);
+        });
+    });
+}
+
+async function main () {
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+
+    let peerId;
+    let webhookSecret;
+    let nonce;
+    const existing = loadConfig();
+
+    if ( existing ) {
+        const useExisting = await ask(rl, 'Existing key found. Use it? (y/n)', 'y');
+        const noAnswers = ['n', 'no'];
+        if ( noAnswers.includes(useExisting.toLowerCase()) ) {
+            peerId = `test-webhook-${randomHex(8)}`;
+            webhookSecret = randomHex(32);
+            nonce = 0;
+            saveConfig(peerId, webhookSecret, nonce, existing.instance_url);
+            console.log('');
+            console.log('New key generated.');
+            console.log('');
+            console.log('Add the following peer to your Puter instance config so it can accept');
+            console.log('webhooks from this test script. In your config file (e.g. config.json),');
+            console.log('under the "broadcast" section, add a "peers" array (if missing) and');
+            console.log('include this entry:');
+            console.log('');
+            console.log(JSON.stringify({
+                key: peerId,
+                webhook_secret: webhookSecret,
+            }, null, 2));
+            console.log('');
+            console.log('Example config structure:');
+            console.log('  "broadcast": {');
+            console.log('    "peers": [');
+            console.log('      { "key": "<above key>", "webhook_secret": "<above secret>" }');
+            console.log('    ]');
+            console.log('  }');
+            console.log('');
+            console.log('Restart your Puter instance after updating the config.');
+            console.log('');
+        } else {
+            peerId = existing.key;
+            webhookSecret = existing.webhook_secret;
+            nonce = existing.nonce;
+            console.log('');
+            console.log('Using existing key:', peerId);
+            console.log('');
+        }
+    } else {
+        peerId = `test-webhook-${randomHex(8)}`;
+        webhookSecret = randomHex(32);
+        nonce = 0;
+        saveConfig(peerId, webhookSecret, nonce, undefined);
+        console.log('');
+        console.log('Add the following peer to your Puter instance config so it can accept');
+        console.log('webhooks from this test script. In your config file (e.g. config.json),');
+        console.log('under the "broadcast" section, add a "peers" array (if missing) and');
+        console.log('include this entry:');
+        console.log('');
+        console.log(JSON.stringify({
+            key: peerId,
+            webhook_secret: webhookSecret,
+        }, null, 2));
+        console.log('');
+        console.log('Example config structure:');
+        console.log('  "broadcast": {');
+        console.log('    "peers": [');
+        console.log('      { "key": "<above key>", "webhook_secret": "<above secret>" }');
+        console.log('    ]');
+        console.log('  }');
+        console.log('');
+        console.log('Restart your Puter instance after updating the config.');
+        console.log('');
+    }
+
+    const defaultUrl = existing && existing.instance_url ? existing.instance_url : '';
+    const baseUrl = await ask(rl, 'Instance base URL (e.g. http://api.puter.localhost:4100)', defaultUrl);
+    const url = baseUrl.trim().replace(/\/+$/, '');
+    if ( ! url ) {
+        console.error('Please provide a URL.');
+        rl.close();
+        process.exit(1);
+    }
+
+    const webhookUrl = `${url}/broadcast/webhook`;
+    const timestamp = Math.floor(Date.now() / 1000);
+    const body = {
+        key: 'test',
+        data: { contents: 'I am a test message from test-webhook.js' },
+        meta: {},
+    };
+    const rawBody = JSON.stringify(body);
+    const payloadToSign = `${timestamp}.${nonce}.${rawBody}`;
+    const signature = crypto.createHmac('sha256', webhookSecret).update(payloadToSign).digest('hex');
+
+    try {
+        const res = await fetch(webhookUrl, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-Broadcast-Peer-Id': peerId,
+                'X-Broadcast-Timestamp': String(timestamp),
+                'X-Broadcast-Nonce': String(nonce),
+                'X-Broadcast-Signature': signature,
+            },
+            body: rawBody,
+        });
+
+        rl.close();
+
+        if ( res.ok ) {
+            saveConfig(peerId, webhookSecret, nonce + 1, url);
+            console.log('');
+            console.log('Test event sent successfully. Status:', res.status);
+            const text = await res.text();
+            if ( text ) console.log('Response:', text);
+            process.exit(0);
+        } else {
+            const text = await res.text();
+            console.error('');
+            console.error('Request failed. Status:', res.status, res.statusText);
+            if ( text ) console.error('Response:', text);
+            process.exit(1);
+        }
+    } catch ( err ) {
+        rl.close();
+        console.error('');
+        console.error('Request failed:', err.message);
+        process.exit(1);
+    }
+}
+
+main();


### PR DESCRIPTION
This commit adds the "receive" side of webhook support for BroadcastService, which will eventually make broadcasting stateless and not requiring of persistent connections.

Some specific considerations taken into account include:
- incremental nonce to prevent replay attacks
- request timestamp to prevent nonce-reuse after restarting
- HMAC signature to ensure authorized peer

Known limitations:
- if instances run indefinitely, eventually the nonce value would wrap around to zero and broadcasts would stop working. It is assumed that 9 quintillion requests in the lifetime of an instance is reasonably impossible.