### PR TITLE
fix: range headers in file.js

### DIFF
--- a/src/backend/tools/.test-webhook-config.json
+++ b/src/backend/tools/.test-webhook-config.json
@@ -1,0 +1,6 @@
+{
+  "key": "test-webhook-66999928605bc47b",
+  "webhook_secret": "9c193c4e111780a42b3d27661779adebba03c132078847490eb61639ce73288c",
+  "nonce": 13,
+  "instance_url": "http://api.puter.localhost:4100"
+}


### PR DESCRIPTION
Range header support was mostly incorrect, which brought to surface undefined behavior in OnlyOffice which resulted in a request hanging. This was the cause of the `pdf-editor` app hanging for a while when opening it with a new file.