### PR TITLE
Ability to revoke access tokens

### DIFF
--- a/src/backend/src/routers/auth/revoke-access-token.js
+++ b/src/backend/src/routers/auth/revoke-access-token.js
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2024-present Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+const APIError = require('../../api/APIError');
+const eggspress = require('../../api/eggspress');
+const { Context } = require('../../util/context');
+
+/**
+ * Coerces a read-URL string to the token (JWT) from its query.
+ * Works for absolute or relative URLs (e.g. .../token-read?uid=...&token=...).
+ * Returns the given value unchanged if it does not look like a read URL.
+ */
+function tokenOrUuidFromInput (value) {
+    if ( typeof value !== 'string' || !value.trim() ) {
+        return value;
+    }
+    const s = value.trim();
+    console.log('s?', s);
+    if ( s.includes('/token-read') ) {
+        try {
+            const url = new URL(s);
+            const token = url.searchParams.get('token');
+            console.log('token?', token);
+            return token ?? s;
+        } catch (_) {
+            return s;
+        }
+    }
+    return s;
+}
+
+module.exports = eggspress('/auth/revoke-access-token', {
+    subdomain: 'api',
+    auth2: true,
+    allowedMethods: ['POST'],
+}, async (req, res, next) => {
+    const x = Context.get();
+    const svc_auth = x.get('services').get('auth');
+
+    const raw = req.body.tokenOrUuid;
+    if ( raw === undefined || raw === null ) {
+        throw APIError.create('field_missing', null, { key: 'tokenOrUuid' });
+    }
+    const tokenOrUuid = tokenOrUuidFromInput(raw);
+
+    await svc_auth.revoke_access_token(tokenOrUuid);
+
+    res.json({ ok: true });
+});

--- a/src/backend/src/services/PuterAPIService.js
+++ b/src/backend/src/services/PuterAPIService.js
@@ -50,6 +50,7 @@ class PuterAPIService extends BaseService {
         app.use(require('../routers/auth/check-app'));
         app.use(require('../routers/auth/app-uid-from-origin'));
         app.use(require('../routers/auth/create-access-token'));
+        app.use(require('../routers/auth/revoke-access-token'));
         app.use(require('../routers/auth/delete-own-user'));
         app.use(require('../routers/auth/configure-2fa'));
         app.use(require('../routers/drivers/call'));

--- a/src/backend/src/services/auth/ACLService.js
+++ b/src/backend/src/services/auth/ACLService.js
@@ -425,7 +425,8 @@ class ACLService extends BaseService {
         // Access tokens only work if the authorizer has permission
         if ( actor.type instanceof AccessTokenActorType ) {
             const authorizer = actor.type.authorizer;
-            return await this._check_fsNode(authorizer, fsNode, mode);
+            const authorizer_perm = await this._check_fsNode(authorizer, fsNode, mode);
+            if ( ! authorizer_perm ) return false;
         }
 
         // Hard rule: if app-under-user is accessing appdata directory, allow

--- a/src/backend/src/services/auth/AuthService.js
+++ b/src/backend/src/services/auth/AuthService.js
@@ -475,6 +475,8 @@ class AuthService extends BaseService {
             [token_uid],
         );
         /* eslint-enable */
+        const svc_permission = this.services.get('permission');
+        svc_permission.invalidate_permission_scan_cache_for_access_token(token_uid);
     }
 
     /**

--- a/src/backend/src/services/auth/PermissionService.js
+++ b/src/backend/src/services/auth/PermissionService.js
@@ -237,6 +237,24 @@ class PermissionService extends BaseService {
         return reading;
     }
 
+    /**
+     * Removes permission-scan cache entries for an access token.
+     * Used when revoking an access token so stale scan results are not served.
+     * Only keys for this token are removed (see PermissionUtil.permission_scan_cache_pattern_for_access_token).
+     *
+     * @param {string} token_uid - The access token UUID.
+     */
+    invalidate_permission_scan_cache_for_access_token (token_uid) {
+        const kv = this.modules.memKVMap;
+        if ( ! kv?.keys ) return;
+        const pattern = PermissionUtil.permission_scan_cache_pattern_for_access_token(token_uid);
+        const keys = kv.keys(pattern);
+        if ( ! Array.isArray(keys) ) return;
+        for ( const key of keys ) {
+            kv.del(key);
+        }
+    }
+
     async validateUserPerms ({ actor, permissions }) {
 
         const flatPermsReading = await this.#flat_validateUserPerms({ actor, permissions });

--- a/src/backend/src/services/auth/permissionUtils.mjs
+++ b/src/backend/src/services/auth/permissionUtils.mjs
@@ -80,6 +80,19 @@ export const PermissionUtil =  {
     },
 
     /**
+     * Glob pattern for permission-scan cache keys belonging to a given access token.
+     * Cache keys are built as join('permission-scan', actor.uid, 'options-list', ...);
+     * for access tokens, actor.uid ends with ':' + token_uid (token_uid is not escaped).
+     * Use with kv.keys() to list only entries for that token when invalidating.
+     *
+     * @param {string} token_uid - The access token UUID.
+     * @returns {string} A glob pattern matching only that token's permission-scan cache keys.
+     */
+    permission_scan_cache_pattern_for_access_token (token_uid) {
+        return `permission-scan:*${token_uid}:options-list:*`;
+    },
+
+    /**
      * Converts a permission reading structure into an array of option objects.
      * Recursively traverses the reading tree to collect all options with their associated path and data.
      * @param {Array<Object>} reading - The permission reading structure to convert.

--- a/src/puter-js/src/modules/FileSystem/index.js
+++ b/src/puter-js/src/modules/FileSystem/index.js
@@ -1,6 +1,6 @@
+import path from '../../lib/path.js';
 import io from '../../lib/socket.io/socket.io.esm.min.js';
 import * as utils from '../../lib/utils.js';
-import path from '../../lib/path.js';
 
 // Constants
 //
@@ -8,21 +8,22 @@ import path from '../../lib/path.js';
 const LAST_VALID_TS = 'last_valid_ts';
 
 // Operations
+import FSItem from '../FSItem.js';
 import copy from './operations/copy.js';
+import deleteFSEntry from './operations/deleteFSEntry.js';
+import getReadURL from './operations/getReadUrl.js';
 import mkdir from './operations/mkdir.js';
 import move from './operations/move.js';
 import read from './operations/read.js';
 import readdir from './operations/readdir.js';
 import rename from './operations/rename.js';
+import revokeReadURL from './operations/revokeReadUrl.js';
 import sign from './operations/sign.js';
 import space from './operations/space.js';
 import stat from './operations/stat.js';
 import symlink from './operations/symlink.js';
 import upload from './operations/upload.js';
 import write from './operations/write.js';
-import FSItem from '../FSItem.js';
-import deleteFSEntry from './operations/deleteFSEntry.js';
-import getReadURL from './operations/getReadUrl.js';
 
 export class PuterJSFileSystemModule {
 
@@ -40,6 +41,7 @@ export class PuterJSFileSystemModule {
     sign = sign;
     symlink = symlink;
     getReadURL = getReadURL;
+    revokeReadURL = revokeReadURL;
     readdir = readdir;
     stat = stat;
 

--- a/src/puter-js/src/modules/FileSystem/operations/revokeReadUrl.js
+++ b/src/puter-js/src/modules/FileSystem/operations/revokeReadUrl.js
@@ -1,0 +1,36 @@
+import * as utils from '../../../lib/utils.js';
+
+/**
+ * Revokes a read URL (or the access token / token UUID used by it).
+ * After revocation, the URL will no longer allow reading the file.
+ *
+ * @param {string} urlOrTokenOrUuid - The read URL (e.g. from getReadURL), the JWT access token, or the token UUID.
+ * @returns {Promise<void>}
+ */
+const revokeReadURL = async function (urlOrTokenOrUuid) {
+    return new Promise(async (resolve, reject) => {
+        if ( !puter.authToken && puter.env === 'web' ) {
+            try {
+                await puter.ui.authenticateWithPuter();
+            } catch (e) {
+                reject('Authentication failed.');
+                return;
+            }
+        }
+        try {
+            const xhr = utils.initXhr('/auth/revoke-access-token', this.APIOrigin, this.authToken);
+
+            utils.setupXhrEventHandlers(xhr, () => {
+            }, () => {
+            }, () => resolve(), reject);
+
+            xhr.send(JSON.stringify({
+                tokenOrUuid: typeof urlOrTokenOrUuid === 'string' ? urlOrTokenOrUuid.trim() : String(urlOrTokenOrUuid),
+            }));
+        } catch (e) {
+            reject(e);
+        }
+    });
+};
+
+export default revokeReadURL;


### PR DESCRIPTION
Adds `puter.fs.revokeReadURL(readURL)`; example:

```javascript
readURL = await puter.fs.getReadURL('/admin/Desktop/something.txt');

// Try going to `readURL` - you will see the file

puter.fs.revokeReadURL(readURL)

// Try going to `readURL` - you will see a "not found" error
```