### PR TITLE
fix: auto-collapse playground menu on mobile (#2430)

### DIFF
--- a/src/docs/src/playground/assets/js/app.js
+++ b/src/docs/src/playground/assets/js/app.js
@@ -87,7 +87,6 @@ document.addEventListener('keydown', function (e) {
     }
 });
 
-document.getElementById('code');
 var run = document.getElementById('run');
 run.addEventListener('click', function () {
     loadStringInIframe(editor.getValue());


### PR DESCRIPTION
This PR improves the user experience of the Puter.js Playground on mobile devices. Previously, when a user selected an example from the sidebar menu in mobile view, the menu would remain open and cover the editor, requiring the user to manually click the toggle button to close it.

The sidebar now automatically collapses once a link is clicked, allowing the user to see the selected example immediately.

### Changes

*   **UX Improvement**: Added a check in app.js to automatically collapse the sidebar when a .sidebar-item is clicked if the window width is 768px or less.
    
*   **Code Polish**:
    
    *   Added /\* global \*/ comments to avoid linting errors for external libraries like Monaco and Clarity.
        
    *   Simplified popstate handling by using window.location.reload() instead of re-assigning window.location.href.
        
    *   Removed an unused variable (code) in app.js.

### demo vid of the changes made

https://github.com/user-attachments/assets/d1352608-8027-49fb-8ddb-226bbb7d9c37

