### PR TITLE
fix: ensure cache invalidation when verifying OTP

### DIFF
--- a/src/backend/src/routers/auth/configure-2fa.js
+++ b/src/backend/src/routers/auth/configure-2fa.js
@@ -87,7 +87,7 @@ module.exports = eggspress('/auth/configure-2fa/:action', {
     // this should never be used to verify the user's 2FA code
     // for authentication purposes.
     actions.test = async () => {
-        const user = req.user;
+        const user = await get_user({ id: req.user.id, force: true });
         const svc_otp = x.get('services').get('otp');
         const code = req.body.code;
         const ok = svc_otp.verify(user.username, user.otp_secret, code);


### PR DESCRIPTION
It is possible this broke after redis caching was employed because it broke the expectation that assignments to attributes on cached objects would remain for future accesses on said objects. This has not been confirmed as the cause.