### PR TITLE
Fix gemini 3 pro image model name

### DIFF
--- a/src/backend/src/services/ai/image/providers/GeminiImageGenerationProvider/models.ts
+++ b/src/backend/src/services/ai/image/providers/GeminiImageGenerationProvider/models.ts
@@ -69,9 +69,9 @@ export const GEMINI_IMAGE_GENERATION_MODELS: IImageModel[] = [
         costs_currency: 'usd-cents',
         index_cost_key: '1K:1x1',
         aliases: [
-            'gemini-3-flash-image-preview', 'gemini-3-flash-image',
-            'google/gemini-3-flash-image-preview', 'google/gemini-3-flash-image',
-            'google:google/gemini-3-flash-image-preview',
+            'gemini-3-pro-image-preview', 'gemini-3-pro-image',
+            'google/gemini-3-pro-image-preview', 'google/gemini-3-pro-image',
+            'google:google/gemini-3-pro-image-preview',
         ],
         allowedQualityLevels: ['1K', '2K', '4K'],
         allowedRatios: [


### PR DESCRIPTION
Fixes #2443 

- there is no "gemini-3-flash-image" model
- it should be gemini-3-pro-image