### PR TITLE
Fix: When a maximized window gets resized, Puter apps should be resized as well

### DIFF
--- a/src/gui/src/globals.js
+++ b/src/gui/src/globals.js
@@ -180,7 +180,7 @@ $(window).on( 'resize', function () {
     window.desktop_width = new_desktop_width;
 
     // Update all maximized windows to fit the new viewport
-    $('.window-app[data-is_maximized="1"]').each(function () {
+    $('.window[data-is_maximized="1"]').each(function () {
         window.update_maximized_window_for_taskbar(this);
     });
 });


### PR DESCRIPTION
Fixes #2471 

When global resize listener is triggered, go through all mazimized windows and re-apply their maximize functionality.