### PR TITLE
Add permission requests for directories of subdomains associated with apps owned by the user

### DIFF
--- a/src/backend/src/api/APIError.js
+++ b/src/backend/src/api/APIError.js
@@ -155,7 +155,9 @@ class APIError {
         },
         'forbidden': {
             status: 403,
-            message: 'Permission denied.',
+            message: ({ debug_reason }) => (process.env.DEBUG && debug_reason)
+                ? `Permission denied: ${debug_reason}`
+                : 'Permission denied.',
         },
         'immutable': {
             status: 403,

--- a/src/backend/src/routers/auth/request-app-root-dir.js
+++ b/src/backend/src/routers/auth/request-app-root-dir.js
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2024-present Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+const eggspress = require('../../api/eggspress');
+const APIError = require('../../api/APIError');
+const { AppUnderUserActorType } = require('../../services/auth/Actor');
+const { Context } = require('../../util/context');
+const { validate_fields } = require('../../util/validutil');
+const { get_app } = require('../../helpers');
+const { NodeInternalIDSelector } = require('../../filesystem/node/selectors');
+const { HLStat } = require('../../filesystem/hl_operations/hl_stat');
+const { PermissionUtil } = require('../../services/auth/permissionUtils.mjs');
+const { quot } = require('@heyputer/putility').libs.string;
+
+module.exports = eggspress('/auth/request-app-root-dir', {
+    subdomain: 'api',
+    auth2: true,
+    allowedMethods: ['POST'],
+}, async (req, res) => {
+    const context = Context.get();
+    const actor = context.get('actor');
+
+    if ( ! (actor.type instanceof AppUnderUserActorType) ) {
+        throw APIError.create('forbidden', null, { debug_reason: 'not app actor' });
+    }
+
+    validate_fields({
+        app_uid: { type: 'string', optional: false },
+        access: { type: 'string', optional: false },
+    }, req.body);
+
+    const { app_uid: target_app_uid, access } = req.body;
+    if ( access !== 'read' && access !== 'write' ) {
+        throw APIError.create('field_invalid', null, {
+            key: 'access',
+            expected: "'read' or 'write'",
+            got: access,
+        });
+    }
+
+    if ( ! target_app_uid ) {
+        throw APIError.create('field_invalid', null, {
+            key: 'resource_request_code',
+            expected: 'app_uid',
+            got: target_app_uid,
+        });
+    }
+
+    const target_app = await get_app({ uid: target_app_uid });
+    if ( ! target_app ) {
+        throw APIError.create('entity_not_found', null, { identifier: `app:${target_app_uid}` });
+    }
+
+    if ( target_app.owner_user_id !== actor.type.user.id ) {
+        throw APIError.create('forbidden', null, {
+            debug_reason: 'Expected to match: ' +
+                `${quot(target_app.owner_user_id)} and ${quot(actor.type.user.id)}`,
+        });
+    }
+
+    const svc_app = context.get('services').get('app');
+    const root_dir_id = await svc_app.getAppRootDirId(target_app);
+    const svc_fs = context.get('services').get('filesystem');
+    const node = await svc_fs.node(new NodeInternalIDSelector('mysql', root_dir_id));
+    await node.fetchEntry();
+    if ( ! node.found ) {
+        throw APIError.create('subject_does_not_exist');
+    }
+
+    const node_uid = await node.get('uid');
+    const fs_perm = PermissionUtil.join('fs', node_uid, access);
+    const svc_permission = context.get('services').get('permission');
+    const has_perm = await svc_permission.check(actor, fs_perm);
+    if ( ! has_perm ) {
+        throw APIError.create('permission_denied', null, { permission: fs_perm });
+    }
+
+    const hl_stat = new HLStat();
+    const stat_result = await hl_stat.run({
+        subject: node,
+        user: actor.type.user,
+        return_subdomains: false,
+        return_permissions: false,
+        return_shares: false,
+        return_versions: false,
+        return_size: true,
+    });
+
+    res.json(stat_result);
+});

--- a/src/backend/src/services/PermissionAPIService.js
+++ b/src/backend/src/services/PermissionAPIService.js
@@ -53,6 +53,7 @@ class PermissionAPIService extends BaseService {
         app.use(require('../routers/auth/revoke-user-group'));
         app.use(require('../routers/auth/list-permissions').default);
         app.use(require('../routers/auth/check-permissions.js'));
+        app.use(require('../routers/auth/request-app-root-dir'));
 
         Endpoint(require('../routers/auth/check-app-acl.endpoint.js')).but({
             route: '/auth/check-app-acl',

--- a/src/backend/src/services/auth/PermissionService.js
+++ b/src/backend/src/services/auth/PermissionService.js
@@ -1191,7 +1191,10 @@ class PermissionService extends BaseService {
      * @param {PermissionRewriter} rewriter - The permission rewriter to register
      */
     register_rewriter (rewriter) {
-        if ( ! (rewriter instanceof PermissionRewriter) ) {
+        const is_permission_rewriter = rewriter instanceof PermissionRewriter
+            // Hack for ESM/CJS interop issue in unit tests.
+            || rewriter?.constructor?.name === 'PermissionRewriter';
+        if ( ! is_permission_rewriter ) {
             throw new Error('rewriter must be a PermissionRewriter');
         }
 

--- a/src/backend/src/services/auth/permissionUtils.mjs
+++ b/src/backend/src/services/auth/permissionUtils.mjs
@@ -1,6 +1,11 @@
 import { MANAGE_PERM_PREFIX } from './permissionConts.mjs';
 
 /**
+ * De-facto placeholder permission for permission rewrites that do not grant any access.
+ */
+export const PERMISSION_FOR_NOTHING_IN_PARTICULAR = 'permission-for-nothing-in-particular';
+
+/**
 * The PermissionUtil class provides utility methods for handling
 * permission strings and operations, including splitting, joining,
 * escaping, and unescaping permission components. It also includes
@@ -90,6 +95,21 @@ export const PermissionUtil =  {
      */
     permission_scan_cache_pattern_for_access_token (token_uid) {
         return `permission-scan:*${token_uid}:options-list:*`;
+    },
+
+    /**
+     * Exact key prefix for permission-scan cache entries belonging to a given app-under-user actor.
+     * Cache keys are built as join('permission-scan', actor.uid, 'options-list', ...);
+     * for app-under-user, actor.uid is 'app-under-user:{user_uuid}:{app_uid}' (colon-escaped in the key).
+     * Use with Redis SCAN MATCH prefix + '*' to delete only that actor's cache entries.
+     *
+     * @param {string} user_uuid - The user's UUID.
+     * @param {string} app_uid - The app UID.
+     * @returns {string} The exact key prefix for that actor's permission-scan cache keys.
+     */
+    permission_scan_cache_prefix_for_app_under_user (user_uuid, app_uid) {
+        const actor_uid = `app-under-user:${user_uuid}:${app_uid}`;
+        return this.join('permission-scan', actor_uid, 'options-list');
     },
 
     /**

--- a/src/gui/src/UI/UIWindowRequestPermission.js
+++ b/src/gui/src/UI/UIWindowRequestPermission.js
@@ -145,7 +145,7 @@ async function setup_window_events (el_window, options, resolve) {
 
 /**
  * Generates user-friendly description of permission string in HTML format.
- * 
+ *
  * @param {string} permission - The permission string to describe
  * @returns {string} The user-friendly description of the permission in HTML format
  */
@@ -231,7 +231,17 @@ async function get_permission_description (permission) {
         }
     }
 
-    return null
+    if ( parts[0] === 'app-root-dir' ) {
+        // Format: app-root-dir:resource_request_code:access
+        if ( parts[2] === 'read' ) {
+            return i18n('perm_app_root_dir_read');
+        }
+        if ( parts[2] === 'write' ) {
+            return i18n('perm_app_root_dir_write');
+        }
+    }
+
+    return null;
 }
 
 /**

--- a/src/gui/src/i18n/translations/en.js
+++ b/src/gui/src/i18n/translations/en.js
@@ -116,7 +116,6 @@ const en = {
         desktop_background_fit: 'Fit',
         developers: 'Developers',
         dir_published_as_website: '%strong% has been published to:',
-        directory_depth_limit_exceeded: 'Cannot create folder. The maximum directory depth has been reached. Please create the folder in a higher-level directory.',
         disable_2fa: 'Disable 2FA',
         disable_2fa_confirm: 'Are you sure you want to disable 2FA?',
         disable_2fa_instructions: 'Enter your password to disable 2FA.',
@@ -169,7 +168,6 @@ const en = {
         item: 'item',
         items_in_trash_cannot_be_renamed: 'This item can\'t be renamed because it\'s in the trash. To rename this item, first drag it out of the Trash.',
         jpeg_image: 'JPEG image',
-        add_to_desktop: 'Add to Desktop',
         keep_in_taskbar: 'Keep in Taskbar',
         language: 'Language',
         license: 'License',
@@ -203,6 +201,7 @@ const en = {
         no_dir_associated_with_site: 'No directory associated with this address.',
         no_websites_published: 'You have not published any websites yet. Right click on a folder to get started.',
         ok: 'OK',
+        or: 'or',
         open: 'Open',
         new_window: 'New Window',
         open_in_ai: 'Open in AI',
@@ -482,6 +481,8 @@ const en = {
 
         // Signup Window
         'signup_confirm_password': 'Confirm Password',
+        sign_in_with_google: 'Sign in with Google',
+        sign_up_with_google: 'Sign up with Google',
 
         // Login Window
         'login_email_username_required': 'Email or username is required',
@@ -549,6 +550,8 @@ const en = {
         'perm_apps_write': 'manage your apps',
         'perm_subdomains_read': 'see your subdomains',
         'perm_subdomains_write': 'manage your subdomains',
+        'perm_app_root_dir_read': 'read the root directory of one of your apps',
+        'perm_app_root_dir_write': 'read and write to the root directory of one of your apps',
 
         'error_user_or_path_not_found': 'User or path not found.',
         'error_invalid_username': 'Invalid username.',


### PR DESCRIPTION
This allows an app to request permission to access the directory for one of the user's apps. The user must have permission to access the directory in order for the app to have permission. The subdomain associated with the app is determined in one of two ways:
1. Subdomain has an associated app set (typical deployment)
2. Subdomain URL matches (create a site and then set index url of an app)

Permission is checked primarily based on filesystem permission of the directory. App ownership is also checked as an additional precaution.