### PR TITLE
Dashboard dark mode fixes

### DIFF
--- a/src/gui/src/css/dashboard.css
+++ b/src/gui/src/css/dashboard.css
@@ -319,7 +319,38 @@ body {
 }
 
 .dashboard #storage-used-percent {
-  color: var(--dashboard-text-tertiary);
+  
+}
+
+@media (prefers-color-scheme: dark) {
+    .usage-table-fade-overlay {
+        background: linear-gradient(to bottom, rgba(30, 30, 30, 0) 0%, rgba(30, 30, 30, 0.85) 40%, rgba(30, 30, 30, 1) 100%);
+    }
+
+    #storage-bar-wrapper, .usage-progbar-wrapper {
+        background-color: var(--dashboard-input-background);
+    }
+
+    #storage-bar-host, .usage-progbar {
+        background: linear-gradient(#64748b, #8494ab, #64748b);
+    }
+
+
+    .dashboard-section-billing .billing-card {
+        background: var(--dashboard-card-background);
+    }
+
+    .dashboard-section-billing .billing-card h1 {
+        color: var(--dashboard-text);
+    }
+
+    .dashboard-section-billing .billing-card p {
+        color: var(--dashboard-text-secondary);
+    }
+
+    .dashboard-section-billing .billing-empty, .dashboard-section-billing .billing-error, .dashboard-section-billing .billing-loading {
+        color: var(--dashboard-text-muted);
+    }
 }
 
 /* Dashboard Apps */

--- a/src/gui/src/css/style.css
+++ b/src/gui/src/css/style.css
@@ -5661,7 +5661,7 @@ html.dark-mode .usage-table-show-less:hover {
     top: 5px;
     right: 5px;
     border-radius: 5px;
-    background: linear-gradient(to bottom, #f8f8f8, var(--dashboard-border));
+    background: linear-gradient(to bottom, #f8f8f8, #e0e0e0);
     cursor: pointer;
 }
 .btn-show-ai svg{


### PR DESCRIPTION
Fixes #2511 

Fixed: puter.chat button has weird gradient when browser is dark mode
Fixed: The gradient and progress bar on the usage details page is not very pleasant and looks inverted
Fixed: The billing card on the billing tab is still light mode

The issue with the folder font color, was fixed with this PR I believe: https://github.com/HeyPuter/puter/pull/2508 at least I wasn't able to reproduce this one.