### PR TITLE
lint: fix eslint indentation for switch cases

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -25,12 +25,9 @@ export const rules = {
     '@stylistic/curly-newline': ['error', 'always'],
     '@stylistic/object-curly-spacing': ['error', 'always'],
     '@stylistic/indent': ['error', 4, {
-        ignoredNodes: [
-            'CallExpression',
-            'NewExpression',
-        ],
+        SwitchCase: 1,
         CallExpression: {
-            arguments: 4,
+            arguments: 1,
         },
     }],
     '@stylistic/indent-binary-ops': ['error', 4],
@@ -38,6 +35,7 @@ export const rules = {
     '@stylistic/semi': ['error', 'always'],
     '@stylistic/quotes': ['error', 'single', { 'avoidEscape': true }],
     '@stylistic/function-call-argument-newline': ['error', 'consistent'],
+    '@stylistic/function-paren-newline': ['error', 'multiline-arguments'],
     '@stylistic/arrow-spacing': ['error', { before: true, after: true }],
     '@stylistic/space-before-function-paren': 'error',
     '@stylistic/key-spacing': ['error', { 'beforeColon': false, 'afterColon': true }],

--- a/eslint/control-structure-spacing.js
+++ b/eslint/control-structure-spacing.js
@@ -125,6 +125,8 @@ export default {
             const closeParen = sourceCode.getLastToken(node, token => token.value === ')');
 
             if ( !openParen || !closeParen ) return;
+            // Defer multi-line call/new formatting to stylistic paren/argument rules.
+            if ( openParen.loc.start.line !== closeParen.loc.end.line ) return;
 
             const afterOpen = sourceCode.getTokenAfter(openParen);
             const beforeClose = sourceCode.getTokenBefore(closeParen);


### PR DESCRIPTION
also trying to preserve call indentations, but afraid its not exactly the same, but fairly close