### PR TITLE
Clarify expiration time unit in getReadURL.md

### DIFF
--- a/src/docs/src/FS/getReadURL.md
+++ b/src/docs/src/FS/getReadURL.md
@@ -21,7 +21,7 @@ The path to the file to read.
 
 #### `expiresIn` (Number) (Optional)
 
-The number of seconds until the URL expires. If not provided, the URL will expire in 24 hours.
+The number of milliseconds until the URL expires. If not provided, the URL will expire in 24 hours.
 
 ## Return value
 


### PR DESCRIPTION
Updated the documentation to specify that the expiration time is in milliseconds instead of seconds.