### PR TITLE
fix: bad copy with reference in UIItem

### DIFF
--- a/src/gui/src/UI/UIItem.js
+++ b/src/gui/src/UI/UIItem.js
@@ -111,9 +111,7 @@ async function UIItem (options) {
     const matching_appendto_count = $(options.appendTo).length;
     if ( matching_appendto_count > 1 ) {
         $(options.appendTo).each(function () {
-            const opts = options;
-            opts.appendTo = this;
-            UIItem(opts);
+            UIItem({ ...options, appendTo: this });
         });
         return;
     } else if ( matching_appendto_count === 0 ) {


### PR DESCRIPTION
UIItem makes a recursive call when there are multiple matching elements in the `options.appendTo` argument. When calling recursively, the `appendTo` property of the `options` object is mutated to a specific element before the call, which expects that each call to UIItem occurs synchronously. UIItem was made asynchronous by
9d598f7965ae89e2b0554de512971ffb76eb1e7f
which resulted in a bug causing duplicate item icons in one directory window instead of one item icon in each directory window after a file upload when multiple instances of a window at the same directory location exist.

Resolves #2514