### PR TITLE
dev(oidc): redirect to login/signup on error

### DIFF
--- a/src/gui/src/UI/UIWindowLogin.js
+++ b/src/gui/src/UI/UIWindowLogin.js
@@ -124,6 +124,9 @@ async function UIWindowLogin (options) {
                 resolve(false);
             },
             onAppend: function (this_window) {
+                if ( options.authError ) {
+                    $(this_window).find('.login-error-msg').html(options.authError).fadeIn();
+                }
                 $(this_window).find('.email_or_username').get(0).focus({ preventScroll: true });
             },
             window_class: 'window-login',
@@ -243,7 +246,7 @@ async function UIWindowLogin (options) {
                                 }),
                                 new CodeEntryView({
                                     _ref: me => code_entry = me,
-                                    async ['property.value'] (value, { component }) {
+                                    async 'property.value' (value, { component }) {
                                         let error_i18n_key = 'something_went_wrong';
                                         if ( ! value ) return;
                                         try {
@@ -293,7 +296,7 @@ async function UIWindowLogin (options) {
                                     },
                                 }),
                             ],
-                            ['event.focus'] () {
+                            'event.focus' () {
                                 code_entry.focus();
                             },
                         });
@@ -311,7 +314,7 @@ async function UIWindowLogin (options) {
                                 }),
                                 new RecoveryCodeEntryView({
                                     _ref: me => recovery_entry = me,
-                                    async ['property.value'] (value, { component }) {
+                                    async 'property.value' (value, { component }) {
                                         let error_i18n_key = 'something_went_wrong';
                                         if ( ! value ) return;
                                         try {

--- a/src/gui/src/UI/UIWindowSignup.js
+++ b/src/gui/src/UI/UIWindowSignup.js
@@ -130,6 +130,9 @@ function UIWindowSignup (options) {
             dominant: true,
             center: true,
             onAppend: function (el_window) {
+                if ( options.authError ) {
+                    $(el_window).find('.signup-error-msg').html(options.authError).fadeIn();
+                }
                 $(el_window).find('.username').get(0).focus({ preventScroll: true });
 
                 // Initialize Turnstile widget with callback to capture token
@@ -404,8 +407,9 @@ function UIWindowSignup (options) {
             let isPasswordVisible = inputField.attr('type') === 'text';
             inputField.attr('type', isPasswordVisible ? 'password' : 'text');
             $(this).find('.toggle-show-password-icon').attr(
-                            'src',
-                            isPasswordVisible ? window.icons['eye-open.svg'] : window.icons['eye-closed.svg']);
+                'src',
+                isPasswordVisible ? window.icons['eye-open.svg'] : window.icons['eye-closed.svg'],
+            );
         });
 
         //remove login window

--- a/src/gui/src/initgui.js
+++ b/src/gui/src/initgui.js
@@ -494,6 +494,14 @@ window.initgui = async function (options) {
     }
 
     //--------------------------------------------------------------------------------------
+    // Desktop background (early)
+    // Set before action=login/signup so OIDC error redirects show the background behind the form.
+    // -------------------------------------------------------------------------------------
+    if ( !window.is_fullpage_mode && !window.embedded_in_popup ) {
+        window.refresh_desktop_background();
+    }
+
+    //--------------------------------------------------------------------------------------
     // Action: Request Permission
     //--------------------------------------------------------------------------------------
     if ( action === 'request-permission' ) {
@@ -535,13 +543,23 @@ window.initgui = async function (options) {
     // Action: Login
     //--------------------------------------------------------------------------------------
     else if ( action === 'login' ) {
-        await UIWindowLogin();
+        const authError = window.url_query_params.get('message') || null;
+        const opts = window.url_query_params.has('auth_error') ? { authError } : {};
+        if ( ! window.is_auth() ) {
+            opts.window_options = { has_head: false };
+        }
+        await UIWindowLogin(Object.keys(opts).length ? opts : undefined);
     }
     //--------------------------------------------------------------------------------------
     // Action: Signup
     //--------------------------------------------------------------------------------------
     else if ( action === 'signup' ) {
-        await UIWindowSignup();
+        const authError = window.url_query_params.get('message') || null;
+        const opts = window.url_query_params.has('auth_error') ? { authError } : {};
+        if ( ! window.is_auth() ) {
+            opts.window_options = { has_head: false };
+        }
+        await UIWindowSignup(Object.keys(opts).length ? opts : undefined);
     }
     // -------------------------------------------------------------------------------------
     // If in embedded in a popup, it is important to check whether the opener app has a relationship with the user
@@ -867,12 +885,14 @@ window.initgui = async function (options) {
                                     }
                                     // upload
                                     try {
-                                        const res = await puter.fs.write(target_path,
-                                                        file_to_upload,
-                                                        {
-                                                            dedupeName: false,
-                                                            overwrite: overwrite,
-                                                        });
+                                        const res = await puter.fs.write(
+                                            target_path,
+                                            file_to_upload,
+                                            {
+                                                dedupeName: false,
+                                                overwrite: overwrite,
+                                            },
+                                        );
 
                                         let file_signature = await puter.fs.sign(app_uid, { uid: res.uid, action: 'write' });
                                         file_signature = file_signature.items;
@@ -1454,12 +1474,14 @@ window.initgui = async function (options) {
                                 }
                                 // upload
                                 try {
-                                    const res = await puter.fs.write(target_path,
-                                                    file_to_upload,
-                                                    {
-                                                        dedupeName: false,
-                                                        overwrite: overwrite,
-                                                    });
+                                    const res = await puter.fs.write(
+                                        target_path,
+                                        file_to_upload,
+                                        {
+                                            dedupeName: false,
+                                            overwrite: overwrite,
+                                        },
+                                    );
 
                                     let file_signature = await puter.fs.sign(app_uid, { uid: res.uid, action: 'write' });
                                     file_signature = file_signature.items;


### PR DESCRIPTION
Redirect to the login or signup page when there is an error signing in or creating an account using OIDC, instead of displaying the error on a new page. Alter the flow in cases where the suggested action is not the same as the initial action taken by the user (based on the error case).