### PR TITLE
fix(puter.js): give assignment to defaultGUIOrigin precedence

### DIFF
--- a/src/puter-js/src/index.js
+++ b/src/puter-js/src/index.js
@@ -101,6 +101,7 @@ const puterInit = (function () {
 
         #defaultAPIOrigin = 'https://api.puter.com';
         #defaultGUIOrigin = 'https://puter.com';
+        #overrideDefaultGUIOrigin = undefined;
 
         get defaultAPIOrigin () {
             return globalThis.PUTER_API_ORIGIN || globalThis.PUTER_API_ORIGIN_ENV || this.#defaultAPIOrigin;
@@ -110,10 +111,11 @@ const puterInit = (function () {
         }
 
         get defaultGUIOrigin () {
-            return globalThis.PUTER_ORIGIN || globalThis.PUTER_ORIGIN_ENV || this.#defaultGUIOrigin;
+            return this.#overrideDefaultGUIOrigin || globalThis.PUTER_ORIGIN || globalThis.PUTER_ORIGIN_ENV || this.#defaultGUIOrigin;
         }
         set defaultGUIOrigin (v) {
-            this.#defaultGUIOrigin = v;
+            // this.#defaultGUIOrigin = v;
+            this.#overrideDefaultGUIOrigin = v;
         }
 
         // An optional callback when the user is authenticated. This can be set by the app using the SDK.


### PR DESCRIPTION
This change gives precedence to the assignment of `defaultGUIOrigin` over global values typically set by the bundler. This is helpful when testing puter.js behavior in third-party sites with a locally running instance of Puter, where this value can be incorrect.

In the following code snippet, the behavior before this change is the output "default gui origin? https://puter.com". After this change, the output is "default gui origin? https://example.com" as expected.

```javascript
puter.defaultGUIOrigin = 'https://example.com';
console.log('default gui origin?', puter.defaultGUIOrigin);
```