### PR TITLE
fix: remove broadcast for cache updates

### DIFF
--- a/src/backend/src/clients/redis/cacheUpdate.ts
+++ b/src/backend/src/clients/redis/cacheUpdate.ts
@@ -100,7 +100,7 @@ export const emitOuterCacheUpdate = (
         payload.ttlSeconds = ttlSeconds;
     }
 
-    // TODO DS: find a way to invalidate through broadcast nicely
+    svc_event.emit('outer.cacheUpdate', payload);
 };
 
 export const setRedisCacheValue = async (
@@ -108,9 +108,6 @@ export const setRedisCacheValue = async (
     value: string | number,
     {
         ttlSeconds,
-        eventData,
-        eventService,
-        emitEvent = true,
     }: {
         ttlSeconds?: number,
         eventData?: unknown,
@@ -123,13 +120,4 @@ export const setRedisCacheValue = async (
     } else {
         await redisClient.set(key, value);
     }
-
-    emitOuterCacheUpdate({
-        cacheKey: [key],
-        data: eventData === undefined ? value : eventData,
-        ttlSeconds,
-    }, {
-        eventService,
-        emitEvent,
-    });
 };

--- a/src/backend/src/clients/redis/deleteRedisKeys.ts
+++ b/src/backend/src/clients/redis/deleteRedisKeys.ts
@@ -16,9 +16,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import { redisClient } from './redisSingleton.js';
-import { emitOuterCacheUpdate } from './cacheUpdate.js';
 import { EventService } from '../../services/EventService.js';
+import { redisClient } from './redisSingleton.js';
 
 type DeleteRedisKeysInput = string | number | null | undefined | DeleteRedisKeysInput[];
 interface DeleteRedisKeysOptions {
@@ -51,10 +50,9 @@ const flattenInputs = (inputs: DeleteRedisKeysInput[]): Array<string | number | 
 };
 
 export const deleteRedisKeys = async (...inputs: (DeleteRedisKeysInput | DeleteRedisKeysOptions)[]) => {
-    let options: DeleteRedisKeysOptions = {};
     const keysInput = [...inputs];
     if ( isDeleteOptions(keysInput[keysInput.length - 1]) ) {
-        options = keysInput.pop() as DeleteRedisKeysOptions;
+        keysInput.pop() as DeleteRedisKeysOptions;
     }
 
     const keys = flattenInputs(keysInput as DeleteRedisKeysInput[])
@@ -71,13 +69,6 @@ export const deleteRedisKeys = async (...inputs: (DeleteRedisKeysInput | DeleteR
     for ( const key of uniqueKeys ) {
         deleted += await redisClient.del(key);
     }
-
-    emitOuterCacheUpdate({
-        cacheKey: uniqueKeys,
-    }, {
-        eventService: options.eventService,
-        emitEvent: options.emitEvent ?? true,
-    });
 
     return deleted;
 };

--- a/src/backend/src/modules/apps/AppRedisCacheSpace.js
+++ b/src/backend/src/modules/apps/AppRedisCacheSpace.js
@@ -18,7 +18,6 @@
  */
 import { redisClient } from '../../clients/redis/redisSingleton.js';
 import { deleteRedisKeys } from '../../clients/redis/deleteRedisKeys.js';
-import { emitOuterCacheUpdate } from '../../clients/redis/cacheUpdate.js';
 
 const appFullNamespace = 'apps';
 const appLiteNamespace = 'apps:lite';
@@ -89,11 +88,6 @@ export const AppRedisCacheSpace = {
             .map(key => setKey(key, serialized, { ttlSeconds }));
         if ( writes.length ) {
             await Promise.all(writes);
-            emitOuterCacheUpdate({
-                cacheKey: cacheKeys,
-                data: app,
-                ttlSeconds,
-            });
         }
     },
     invalidateCachedApp: (app, {

--- a/src/backend/src/services/UserRedisCacheSpace.js
+++ b/src/backend/src/services/UserRedisCacheSpace.js
@@ -18,7 +18,6 @@
  */
 import { redisClient } from '../clients/redis/redisSingleton.js';
 import { deleteRedisKeys } from '../clients/redis/deleteRedisKeys.js';
-import { emitOuterCacheUpdate } from '../clients/redis/cacheUpdate.js';
 
 const userKeyPrefix = 'users';
 const defaultUserIdProperties = ['username', 'uuid', 'email', 'id', 'referral_code'];
@@ -69,11 +68,6 @@ const UserRedisCacheSpace = {
         }
         if ( writes.length ) {
             await Promise.all(writes);
-            emitOuterCacheUpdate({
-                cacheKey: cacheKeys,
-                data: user,
-                ttlSeconds,
-            });
         }
     },
     invalidateUser: async (user, props = defaultUserIdProperties) => {


### PR DESCRIPTION
this might spam listeners to also invalidate cache even if they don't have anything cached.

removing in favour of more granular broadcast moving forward