### PR TITLE
fix(gui): defer login event until listener registered

### DIFF
--- a/src/gui/src/initgui.js
+++ b/src/gui/src/initgui.js
@@ -1077,7 +1077,7 @@ window.initgui = async function (options) {
             });
         }
         if ( !reload_on_success && window.is_auth() ) {
-            document.dispatchEvent(new Event('login', { bubbles: true }));
+            window.__login_completed = true;
         }
     }
 
@@ -1576,6 +1576,11 @@ window.initgui = async function (options) {
         }
 
     });
+
+    if ( window.__login_completed ) {
+        document.dispatchEvent(new Event('login', { bubbles: true }));
+        window.__login_completed = false;
+    }
 
     $('.popover, .context-menu').on('remove', function () {
         $('.window-active .window-app-iframe').css('pointer-events', 'all');


### PR DESCRIPTION
Fixes an error introduced in 4b8c46e where the page load is attempted to be triggered by dispatching the login event, however the listener which handles loading the page has not yet been registered.