### PR TITLE
feat: add private app asset token auth helpers

### DIFF
--- a/src/backend/src/clients/redis/deleteRedisKeys.ts
+++ b/src/backend/src/clients/redis/deleteRedisKeys.ts
@@ -65,10 +65,8 @@ export const deleteRedisKeys = async (...inputs: (DeleteRedisKeysInput | DeleteR
 
     const uniqueKeys = [...new Set(keys)];
 
-    let deleted = 0;
-    for ( const key of uniqueKeys ) {
-        deleted += await redisClient.del(key);
-    }
+    const deleteResults = await Promise.allSettled(uniqueKeys.map(key => redisClient.del(key)));
+    const deleted = deleteResults.reduce((sum, promiseCount) => sum + (promiseCount.status === 'fulfilled' ? promiseCount.value : 0), 0);
 
     return deleted;
 };

--- a/src/backend/src/config.js
+++ b/src/backend/src/config.js
@@ -168,9 +168,11 @@ const computed_defaults = {
         ? config.origin
         : `${config.protocol }://api.${ config.domain }${maybe_port(config)}`,
     social_card: config => `${config.origin}/assets/img/screenshot.png`,
-    static_hosting_domain: config => `site.puter.localhost${ maybe_port(config)}`,
+    static_hosting_domain: config => `site.${ config.domain }${ maybe_port(config)}`,
     // Hostname-only fallback helps host matching code paths that compare against req.hostname.
-    static_hosting_domain_alt: () => 'site.puter.localhost',
+    static_hosting_domain_alt: (config) => `site.${ config.domain }`,
+    private_app_hosting_domain: config => `apps.${ config.domain }${maybe_port(config)}`,
+    private_app_hosting_domain_alt: config => `apps.${ config.domain }`, // Hostname-only fallback helps host matching code paths that compare against req.hostname.
 
 };
 

--- a/src/backend/src/routers/open_item.js
+++ b/src/backend/src/routers/open_item.js
@@ -78,12 +78,10 @@ module.exports = eggspress('/open_item', {
     // Note: We always grant write permission here. If the user only
     //       has read permission this is still safe; user permissions
     //       are always checked during an app access.
-    const PERMS = action === 'write' ? ['read', 'write'] : ['read'];
-    for ( const perm of PERMS ) {
-        const permission = `fs:${subject.uid}:${perm}`;
-        const svc_permission = Context.get('services').get('permission');
-        await svc_permission.grant_user_app_permission(actor, app.uid, permission, {}, { reason: 'open_item' });
-    }
+    const perm = action === 'write' ? 'write' : 'read';
+    const permission = `fs:${subject.uid}:${perm}`;
+    const svc_permission = Context.get('services').get('permission');
+    await svc_permission.grant_user_app_permission(actor, app.uid, permission, {}, { reason: 'open_item' });
 
     // Generate user-app token
     const svc_auth = Context.get('services').get('auth');

--- a/src/backend/src/services/BaseService.d.ts
+++ b/src/backend/src/services/BaseService.d.ts
@@ -1,35 +1,54 @@
 import type { ErrorService } from '@heyputer/backend/src/modules/core/ErrorService';
-import { DDBClient } from '../clients/dynamodb/DDBClient';
+import type { DriverService } from '@heyputer/backend/src/services/drivers/DriverService';
+import type { DynamoKVStore } from '@heyputer/backend/src/services/DynamoKVStore/DynamoKVStore';
+import type { DDBClient } from '../clients/dynamodb/DDBClient';
 import type { ServerHealthService } from '../modules/core/ServerHealthService/ServerHealthService';
-import { GroupService } from './auth/GroupService';
-import { SignupService} from './auth/SignupService';
-import { CleanEmailService } from './CleanEmailService';
-import { SqliteDatabaseAccessService } from './database/SqliteDatabaseAccessService';
-import { EventService } from './EventService';
-import { FeatureFlagService } from './FeatureFlagService';
-import { MeteringServiceWrapper } from './MeteringService/MeteringServiceWrapper.mjs';
+import type { WebServerService } from '../modules/web/WebServerService';
+import type { GroupService } from './auth/GroupService';
+import type { SignupService } from './auth/SignupService';
+import type { CleanEmailService } from './CleanEmailService';
+import type { SqliteDatabaseAccessService } from './database/SqliteDatabaseAccessService';
+import type { IDynamoKVStoreWrapper } from './DynamoKVStore/DynamoKVStoreWrapper';
+import type { Emailservice } from './EmailService';
+import type { EntityStoreService } from './EntityStoreService';
+import type { EventService } from './EventService';
+import type { FeatureFlagService } from './FeatureFlagService';
+import type { GetUserService } from './GetUserService';
+import type { MeteringService } from './MeteringService/MeteringService';
+import type { MeteringServiceWrapper } from './MeteringService/MeteringServiceWrapper.mjs';
 import type { SUService } from './SUService';
-import { UserService } from './UserService';
-import type{ DynamoKVStore } from '@heyputer/backend/src/services/DynamoKVStore/DynamoKVStore';
-import { DriverService } from '@heyputer/backend/src/services/drivers/DriverService';
+import type { UserService } from './UserService';
+
+export interface ServicesMap {
+    su: SUService;
+    user: UserService;
+    'get-user': GetUserService;
+    'web-server': WebServerService;
+    email: Emailservice;
+    'es:app': EntityStoreService;
+    meteringService: MeteringService & MeteringServiceWrapper;
+    'puter-kvstore': DynamoKVStore & IDynamoKVStoreWrapper;
+    database: SqliteDatabaseAccessService;
+    'server-health': ServerHealthService;
+    su: SUService;
+    dynamo: DDBClient;
+    user: UserService;
+    event: EventService;
+    signup: SignupService;
+    group: GroupService;
+    'feature-flag': FeatureFlagService;
+    'clean-email': CleanEmailService;
+    'error-service': ErrorService;
+    driver: DriverService;
+}
 
 export interface ServiceResources {
     services: {
-        get (name: 'meteringService'): MeteringServiceWrapper;
-        get (name: 'puter-kvstore'): DynamoKVStore;
-        get (name: 'database'): SqliteDatabaseAccessService;
-        get (name: 'server-health'): ServerHealthService;
-        get (name: 'su'): SUService;
-        get (name: 'dynamo'): DDBClient;
-        get (name: 'user'): UserService;
-        get (name: 'event'): EventService;
-        get (name: 'signup'): SignupService;
-        get (name: 'group'): GroupService;
-        get (name: 'feature-flag'): FeatureFlagService;
-        get (name: 'clean-email'): CleanEmailService;
-        get (name: 'error-service'): ErrorService;
-        get (name: 'driver'): DriverService;
-        get (name: string): unknown;
+        get<T extends `${keyof ServicesMap}` | (string & {})>(
+            name: T
+        ): T extends `${infer R extends keyof ServicesMap}`
+            ? ServicesMap[R]
+            : unknown;
     };
     config: Record<string, any> & { services?: Record<string, any>; server_id?: string };
     name?: string;

--- a/src/backend/src/services/DynamoKVStore/DynamoKVStoreWrapper.ts
+++ b/src/backend/src/services/DynamoKVStore/DynamoKVStoreWrapper.ts
@@ -45,7 +45,7 @@ class DynamoKVStoreServiceWrapper extends BaseService {
     }
 
     static IMPLEMENTS = {
-        ['puter-kvstore']: Object.getOwnPropertyNames(DynamoKVStore.prototype)
+        'puter-kvstore': Object.getOwnPropertyNames(DynamoKVStore.prototype)
             .filter(n => n !== 'constructor')
             .reduce((acc, fn) => ({
                 ...acc,

--- a/src/backend/src/services/auth/AuthService.privateAssetToken.test.ts
+++ b/src/backend/src/services/auth/AuthService.privateAssetToken.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import * as jwt from 'jsonwebtoken';
+import { AuthService } from './AuthService.js';
+
+type AuthServiceForPrivateTokenTests = AuthService & {
+    global_config: {
+        jwt_secret: string;
+        private_app_asset_token_ttl_seconds: number;
+        private_app_asset_cookie_name: string;
+        private_app_hosting_domain: string;
+    };
+    modules: {
+        jwt: {
+            sign: typeof jwt.sign;
+            verify: typeof jwt.verify;
+        };
+    };
+    uuid_fpe: {
+        encrypt: (value: string) => string;
+        decrypt: (value: string) => string;
+    };
+};
+
+const createAuthService = (): AuthServiceForPrivateTokenTests => {
+    const authService = Object.create(AuthService.prototype) as AuthServiceForPrivateTokenTests;
+    authService.global_config = {
+        jwt_secret: 'private-asset-test-secret',
+        private_app_asset_token_ttl_seconds: 3600,
+        private_app_asset_cookie_name: 'puter.private.asset.token',
+        private_app_hosting_domain: 'puter.app',
+    };
+    authService.modules = {
+        jwt: {
+            sign: jwt.sign.bind(jwt),
+            verify: jwt.verify.bind(jwt),
+        },
+    };
+    authService.uuid_fpe = {
+        encrypt: (value) => value,
+        decrypt: (value) => value,
+    };
+    return authService;
+};
+
+describe('AuthService private asset token helpers', () => {
+    it('creates and verifies private asset tokens with expected claims', () => {
+        const authService = createAuthService();
+        const appUid = 'app-7e2d3016-8d36-456a-9dc7-b75b0f4f7683';
+        const userUid = '4b0cecf8-dd6a-4eb5-bcc4-c76cc7e8d7f0';
+        const sessionUuid = 'f9000804-2fd3-4da5-819b-afc5296f90f7';
+
+        const token = authService.createPrivateAssetToken({
+            appUid,
+            userUid,
+            sessionUuid,
+            ttlSeconds: 120,
+        });
+
+        const claims = authService.verifyPrivateAssetToken(token, {
+            expectedAppUid: appUid,
+            expectedUserUid: userUid,
+            expectedSessionUuid: sessionUuid,
+        });
+
+        expect(claims.appUid).toBe(appUid);
+        expect(claims.userUid).toBe(userUid);
+        expect(claims.sessionUuid).toBe(sessionUuid);
+        expect(typeof claims.exp).toBe('number');
+    });
+
+    it('rejects tokens when expected user or app does not match', () => {
+        const authService = createAuthService();
+        const token = authService.createPrivateAssetToken({
+            appUid: 'app-9f1c10e3-9a7f-43fb-8671-af4918e65407',
+            userUid: '9885b80e-1a14-4c8d-9e3f-4fa5915b1136',
+        });
+
+        expect(() => authService.verifyPrivateAssetToken(token, {
+            expectedAppUid: 'app-aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        })).toThrow();
+
+        expect(() => authService.verifyPrivateAssetToken(token, {
+            expectedUserUid: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+        })).toThrow();
+    });
+
+    it('rejects non private-asset tokens', () => {
+        const authService = createAuthService();
+        const token = jwt.sign({
+            type: 'session',
+            uuid: '245f33f0-c07e-40e2-be22-5215752e3462',
+            user_uid: '6cce4692-3855-4ef8-af7d-5c2a02e6b6d8',
+        }, authService.global_config.jwt_secret, { expiresIn: 60 });
+
+        expect(() => authService.verifyPrivateAssetToken(token)).toThrow();
+    });
+
+    it('returns hardened cookie options with config-driven ttl and domain', () => {
+        const authService = createAuthService();
+        const options = authService.getPrivateAssetCookieOptions();
+
+        expect(authService.getPrivateAssetCookieName()).toBe('puter.private.asset.token');
+        expect(options.sameSite).toBe('none');
+        expect(options.secure).toBe(true);
+        expect(options.httpOnly).toBe(true);
+        expect(options.path).toBe('/');
+        expect(options.maxAge).toBe(3_600_000);
+        expect(options.domain).toBe('.puter.app');
+    });
+});

--- a/src/backend/src/services/auth/PermissionService.js
+++ b/src/backend/src/services/auth/PermissionService.js
@@ -518,7 +518,7 @@ class PermissionService extends BaseService {
         );
 
         // Invalidate permission-scan cache for this app-under-user so the next check sees the grant.
-        await this._schedule_invalidate_permission_scan_cache_for_app_under_user(actor.type.user.uuid, app.uid);
+        this._schedule_invalidate_permission_scan_cache_for_app_under_user(actor.type.user.uuid, app.uid);
     }
 
     /**


### PR DESCRIPTION
Add mint/verify helpers and hardened cookie option helpers for app-private-asset tokens in AuthService. Add focused tests for claims validation, mismatch denial, and cookie option defaults.