### PR TITLE
feat: add private app access extension event contract

### DIFF
--- a/extensions/api.d.ts
+++ b/extensions/api.d.ts
@@ -128,16 +128,16 @@ export interface ExtensionEventTypeMap {
         app_uid: string;
         action: 'updated' | 'deleted';
     };
-    'app.private-access.check': {
-        app_uid: string;
-        user_uid?: string | null;
-        request_host?: string;
-        request_path?: string;
+    'app.privateAccess.check': {
+        appUid: string;
+        userUid?: string | null;
+        requestHost?: string;
+        requestPath?: string;
         result: {
             allowed: boolean;
-            redirect_url?: string;
+            redirectUrl?: string;
             reason?: string;
-            checked_by?: string;
+            checkedBy?: string;
         };
     };
     'ai.prompt.validate': {

--- a/extensions/api.d.ts
+++ b/extensions/api.d.ts
@@ -128,6 +128,18 @@ export interface ExtensionEventTypeMap {
         app_uid: string;
         action: 'updated' | 'deleted';
     };
+    'app.private-access.check': {
+        app_uid: string;
+        user_uid?: string | null;
+        request_host?: string;
+        request_path?: string;
+        result: {
+            allowed: boolean;
+            redirect_url?: string;
+            reason?: string;
+            checked_by?: string;
+        };
+    };
     'ai.prompt.validate': {
         actor: Actor;
         actor,


### PR DESCRIPTION
Define app.private-access.check in extension API typings with mutable allow/redirect decision fields for entitlement handlers.