### PR TITLE
feat: add private app direct-login bootstrap page

### DIFF
--- a/src/backend/src/routers/hosting/puterSiteMiddleware.test.js
+++ b/src/backend/src/routers/hosting/puterSiteMiddleware.test.js
@@ -378,7 +378,7 @@ describe('PuterSiteMiddleware', () => {
             const mockReq = {
                 hostname: 'paid.puter.dev',
                 subdomains: [],
-                is_custom_domain: true,
+                is_custom_domain: false,
                 baseUrl: '',
                 path: '/index.html',
                 originalUrl: '/index.html',
@@ -478,7 +478,7 @@ describe('PuterSiteMiddleware', () => {
             const mockReq = {
                 hostname: 'paid.puter.dev',
                 subdomains: [],
-                is_custom_domain: true,
+                is_custom_domain: false,
                 baseUrl: '',
                 path: '/index.html',
                 originalUrl: '/index.html',


### PR DESCRIPTION
Serves a lightweight puter.js sign-in interstitial when private app identity is missing, then retries with a bootstrap token query param while preserving entitlement redirect behavior for authenticated denies.