### PR TITLE
fix: break loop when keys.length is 0

### DIFF
--- a/src/backend/src/services/auth/PermissionService.js
+++ b/src/backend/src/services/auth/PermissionService.js
@@ -285,6 +285,7 @@ class PermissionService extends BaseService {
             const [next_cursor, keys] = await redisClient.scan(cursor, 'MATCH', pattern, 'COUNT', 100);
             cursor = next_cursor;
             if ( keys?.length ) toDelete.push(...keys);
+            else break;
         } while ( cursor !== '0' );
         if ( toDelete.length ) await deleteRedisKeys(toDelete);
     }


### PR DESCRIPTION
I don't know if this is the correct thing to do, but `keys.length` appears to be `0` for every iteration when this goes haywire - i.e. loops an astonishing number of times for apparently no reason.