### PR TITLE
dev: get system user from SUService in AppIconService

### DIFF
--- a/src/backend/src/modules/apps/AppIconService.js
+++ b/src/backend/src/modules/apps/AppIconService.js
@@ -24,7 +24,7 @@ import { HLWrite } from '../../filesystem/hl_operations/hl_write.js';
 import { LLMkdir } from '../../filesystem/ll_operations/ll_mkdir.js';
 import { LLRead } from '../../filesystem/ll_operations/ll_read.js';
 import { NodePathSelector } from '../../filesystem/node/selectors.js';
-import { get_app, get_user } from '../../helpers.js';
+import { get_app } from '../../helpers.js';
 import BaseService from '../../services/BaseService.js';
 import { DB_READ, DB_WRITE } from '../../services/database/consts.js';
 import { Endpoint } from '../../util/expressutil.js';
@@ -365,7 +365,8 @@ export class AppIconService extends BaseService {
         );
         if ( existing[0] ) return existing[0];
 
-        const systemUser = await get_user({ username: 'system' });
+        const svcSu = this.services.get('su');
+        const systemUser = await svcSu.get_system_user();
         if ( ! systemUser?.id ) return null;
 
         const rootDirId = await dirAppIcons.get('mysql-id');
@@ -418,6 +419,8 @@ export class AppIconService extends BaseService {
     }
 
     shouldRedirectIconUrl ({ iconUrl, appUid, size }) {
+        if ( this.config.no_subdomain ) return false;
+
         if ( !iconUrl || this.isDataUrl(iconUrl) ) return false;
 
         const canRedirect =

--- a/src/backend/src/modules/apps/AppIconService.js
+++ b/src/backend/src/modules/apps/AppIconService.js
@@ -419,8 +419,6 @@ export class AppIconService extends BaseService {
     }
 
     shouldRedirectIconUrl ({ iconUrl, appUid, size }) {
-        if ( this.config.no_subdomain ) return false;
-
         if ( !iconUrl || this.isDataUrl(iconUrl) ) return false;
 
         const canRedirect =

--- a/src/backend/src/services/SUService.js
+++ b/src/backend/src/services/SUService.js
@@ -65,6 +65,16 @@ export class SUService extends BaseService {
     }
 
     /**
+     * Retrieves the system user instance (resolved during consolidation).
+     * Prefer this over calling get_user({ username: 'system' }) to avoid re-fetching.
+     *
+     * @returns {Promise<object>} A promise that resolves to the system user.
+     */
+    async get_system_user () {
+        return this.sys_user_;
+    }
+
+    /**
      * Retrieves the system actor instance.
      *
      * This method returns a promise that resolves to the system actor. The actor


### PR DESCRIPTION
Small first-boot-time optimization. The optimization itself doesn't matter (first boot is fast enough) - I just want SUService being used here so that if somebody uses this as a reference on how to get the system user they have the correct approach. Using SUService is better because the system user does not change and we never need to fetch it from the database after boot.