### PR TITLE
feat: phase 1 canonical app origin resolution

### DIFF
--- a/src/backend/src/modules/data-access/AppService.js
+++ b/src/backend/src/modules/data-access/AppService.js
@@ -1231,10 +1231,17 @@ export default class AppService extends BaseService {
 
     async #emit_change_events (object, old_app) {
         const svc_event = this.services.get('event');
+        const app = {
+            ...old_app,
+            ...object,
+            uid: old_app.uid,
+        };
 
         await svc_event.emit('app.changed', {
             app_uid: old_app.uid,
             action: 'updated',
+            app,
+            old_app,
         });
 
         // Emit icon change event

--- a/src/backend/src/om/entitystorage/AppES.js
+++ b/src/backend/src/om/entitystorage/AppES.js
@@ -240,9 +240,20 @@ class AppES extends BaseES {
             }
             if ( extra.old_entity ) {
                 const svc_event = this.context.get('services').get('event');
+                const [app] = await this.db.read(
+                    'SELECT * FROM apps WHERE uid = ? LIMIT 1',
+                    [await full_entity.get('uid')],
+                );
+                const old_app = {
+                    uid: await extra.old_entity.get('uid'),
+                    index_url: await extra.old_entity.get('index_url'),
+                    owner_user_id: await extra.old_entity.get('owner_user_id'),
+                };
                 await svc_event.emit('app.changed', {
                     app_uid: await full_entity.get('uid'),
                     action: 'updated',
+                    app,
+                    old_app,
                 });
             }
 

--- a/src/backend/src/om/entitystorage/AppES.js
+++ b/src/backend/src/om/entitystorage/AppES.js
@@ -247,7 +247,6 @@ class AppES extends BaseES {
                 const old_app = {
                     uid: await extra.old_entity.get('uid'),
                     index_url: await extra.old_entity.get('index_url'),
-                    owner_user_id: await extra.old_entity.get('owner_user_id'),
                 };
                 await svc_event.emit('app.changed', {
                     app_uid: await full_entity.get('uid'),

--- a/src/backend/src/services/auth/AuthService.js
+++ b/src/backend/src/services/auth/AuthService.js
@@ -20,6 +20,7 @@ const { Actor, UserActorType, AppUnderUserActorType, AccessTokenActorType, SiteA
 const { BaseService } = require('../BaseService');
 const { get_user, get_app } = require('../../helpers');
 const { Context } = require('../../util/context');
+const { kv } = require('../../util/kvSingleton');
 const APIError = require('../../api/APIError');
 const { setRedisCacheValue } = require('../../clients/redis/cacheUpdate.js');
 const { redisClient } = require('../../clients/redis/redisSingleton.js');
@@ -31,6 +32,7 @@ const crypto = require('crypto');
 const APP_ORIGIN_UUID_NAMESPACE = '33de3768-8ee0-43e9-9e73-db192b97a5d8';
 const APP_ORIGIN_CACHE_VERSION_KEY = 'auth:appOriginCanonicalization:version';
 const APP_ORIGIN_CACHE_KEY_PREFIX = 'auth:appOriginCanonicalization:origin';
+const APP_ORIGIN_LOCAL_CACHE_KEY_PREFIX = 'auth:appOriginCanonicalization:local';
 const DEFAULT_APP_ORIGIN_CANONICAL_CACHE_TTL_SECONDS = 300;
 const APP_ORIGIN_VERSION_MEMORY_TTL_MS = 5000;
 const DEFAULT_PRIVATE_APP_ASSET_TOKEN_TTL_SECONDS = 60 * 60;
@@ -74,7 +76,7 @@ class AuthService extends BaseService {
 
         this.tokenService = await this.services.get('token');
 
-        this.appOriginCanonicalizationLocalCache = new Map();
+        this.appOriginCanonicalizationLocalCacheNamespace = this.createAppOriginLocalCacheNamespace();
         this.appOriginCacheVersionMemo = {
             value: null,
             expiresAt: 0,
@@ -1041,24 +1043,43 @@ class AuthService extends BaseService {
         return `${APP_ORIGIN_CACHE_KEY_PREFIX}:${version}:${encodedOrigin}`;
     }
 
-    readLocalCanonicalAppUidFromCache (origin) {
-        const cachedResolution = this.appOriginCanonicalizationLocalCache.get(origin);
-        if ( ! cachedResolution ) return undefined;
+    createAppOriginLocalCacheNamespace () {
+        return `${APP_ORIGIN_LOCAL_CACHE_KEY_PREFIX}:${uuidLib.v4()}`;
+    }
 
-        if ( cachedResolution.expiresAt <= Date.now() ) {
-            this.appOriginCanonicalizationLocalCache.delete(origin);
+    getAppOriginLocalCacheNamespace () {
+        if (
+            typeof this.appOriginCanonicalizationLocalCacheNamespace !== 'string'
+            || !this.appOriginCanonicalizationLocalCacheNamespace
+        ) {
+            this.appOriginCanonicalizationLocalCacheNamespace = this.createAppOriginLocalCacheNamespace();
+        }
+        return this.appOriginCanonicalizationLocalCacheNamespace;
+    }
+
+    buildLocalCanonicalAppUidCacheKey (origin) {
+        const encodedOrigin = encodeURIComponent(origin);
+        return `${this.getAppOriginLocalCacheNamespace()}:${encodedOrigin}`;
+    }
+
+    readLocalCanonicalAppUidFromCache (origin) {
+        const localCacheKey = this.buildLocalCanonicalAppUidCacheKey(origin);
+        const cachedResolution = kv.get(localCacheKey);
+        if ( !cachedResolution || typeof cachedResolution !== 'object' ) {
             return undefined;
         }
-
+        if ( ! Object.prototype.hasOwnProperty.call(cachedResolution, 'appUid') ) {
+            return undefined;
+        }
         return cachedResolution.appUid;
     }
 
     writeLocalCanonicalAppUidToCache (origin, appUid) {
         const ttlSeconds = this.getAppOriginCanonicalCacheTtlSeconds();
-        this.appOriginCanonicalizationLocalCache.set(origin, {
+        const localCacheKey = this.buildLocalCanonicalAppUidCacheKey(origin);
+        kv.set(localCacheKey, {
             appUid: appUid ?? null,
-            expiresAt: Date.now() + ttlSeconds * 1000,
-        });
+        }, { EX: ttlSeconds });
     }
 
     async getAppOriginCacheVersion () {
@@ -1100,7 +1121,7 @@ class AuthService extends BaseService {
                 expiresAt: Date.now() + APP_ORIGIN_VERSION_MEMORY_TTL_MS,
             };
         }
-        this.appOriginCanonicalizationLocalCache.clear();
+        this.appOriginCanonicalizationLocalCacheNamespace = this.createAppOriginLocalCacheNamespace();
     }
 
     async readCanonicalAppUidFromRedisCache (origin, version) {

--- a/src/backend/src/services/auth/AuthService.js
+++ b/src/backend/src/services/auth/AuthService.js
@@ -23,6 +23,7 @@ const { Context } = require('../../util/context');
 const { kv } = require('../../util/kvSingleton');
 const APIError = require('../../api/APIError');
 const { setRedisCacheValue } = require('../../clients/redis/cacheUpdate.js');
+const { deleteRedisKeys } = require('../../clients/redis/deleteRedisKeys.js');
 const { redisClient } = require('../../clients/redis/redisSingleton.js');
 const { DB_READ, DB_WRITE } = require('../database/consts');
 const { UUIDFPE } = require('../../util/uuidfpe');
@@ -30,11 +31,9 @@ const uuidLib = require('uuid');
 const crypto = require('crypto');
 // This constant defines the namespace used for generating app UUIDs from their origins
 const APP_ORIGIN_UUID_NAMESPACE = '33de3768-8ee0-43e9-9e73-db192b97a5d8';
-const APP_ORIGIN_CACHE_VERSION_KEY = 'auth:appOriginCanonicalization:version';
 const APP_ORIGIN_CACHE_KEY_PREFIX = 'auth:appOriginCanonicalization:origin';
 const APP_ORIGIN_LOCAL_CACHE_KEY_PREFIX = 'auth:appOriginCanonicalization:local';
 const DEFAULT_APP_ORIGIN_CANONICAL_CACHE_TTL_SECONDS = 300;
-const APP_ORIGIN_VERSION_MEMORY_TTL_MS = 5000;
 const DEFAULT_PRIVATE_APP_ASSET_TOKEN_TTL_SECONDS = 60 * 60;
 const DEFAULT_PRIVATE_APP_ASSET_COOKIE_NAME = 'puter.private.asset.token';
 
@@ -77,14 +76,10 @@ class AuthService extends BaseService {
         this.tokenService = await this.services.get('token');
 
         this.appOriginCanonicalizationLocalCacheNamespace = this.createAppOriginLocalCacheNamespace();
-        this.appOriginCacheVersionMemo = {
-            value: null,
-            expiresAt: 0,
-        };
 
         const eventService = await this.services.get('event');
-        eventService.on('app.changed', async () => {
-            await this.bumpAppOriginCacheVersion();
+        eventService.on('app.changed', async (_meta, event = {}) => {
+            await this.invalidateCanonicalAppUidCacheFromAppChangeEvent(event);
         });
     }
 
@@ -1008,7 +1003,7 @@ class AuthService extends BaseService {
             [app_uid, name, title, description, index_url, owner_user_id],
         );
 
-        await this.bumpAppOriginCacheVersion();
+        await this.invalidateCanonicalAppUidCacheForOrigins([origin]);
 
         return this.get_user_app_token(app_uid);
     }
@@ -1038,9 +1033,9 @@ class AuthService extends BaseService {
         );
     }
 
-    buildAppOriginCanonicalCacheKey ({ origin, version }) {
+    buildAppOriginCanonicalCacheKey ({ origin }) {
         const encodedOrigin = encodeURIComponent(origin);
-        return `${APP_ORIGIN_CACHE_KEY_PREFIX}:${version}:${encodedOrigin}`;
+        return `${APP_ORIGIN_CACHE_KEY_PREFIX}:${encodedOrigin}`;
     }
 
     createAppOriginLocalCacheNamespace () {
@@ -1082,52 +1077,9 @@ class AuthService extends BaseService {
         }, { EX: ttlSeconds });
     }
 
-    async getAppOriginCacheVersion () {
-        const now = Date.now();
-        if (
-            this.appOriginCacheVersionMemo?.value
-            && this.appOriginCacheVersionMemo.expiresAt > now
-        ) {
-            return this.appOriginCacheVersionMemo.value;
-        }
-
-        let cacheVersion = '0';
-        try {
-            const redisCacheVersion = await redisClient.get(APP_ORIGIN_CACHE_VERSION_KEY);
-            if ( redisCacheVersion ) {
-                cacheVersion = `${redisCacheVersion}`;
-            }
-        } catch {
-            // Redis access is best-effort here; deterministic fallback remains safe.
-        }
-
-        this.appOriginCacheVersionMemo = {
-            value: cacheVersion,
-            expiresAt: now + APP_ORIGIN_VERSION_MEMORY_TTL_MS,
-        };
-        return cacheVersion;
-    }
-
-    async bumpAppOriginCacheVersion () {
-        try {
-            const nextVersion = await redisClient.incr(APP_ORIGIN_CACHE_VERSION_KEY);
-            this.appOriginCacheVersionMemo = {
-                value: `${nextVersion}`,
-                expiresAt: Date.now() + APP_ORIGIN_VERSION_MEMORY_TTL_MS,
-            };
-        } catch {
-            this.appOriginCacheVersionMemo = {
-                value: `${Date.now()}`,
-                expiresAt: Date.now() + APP_ORIGIN_VERSION_MEMORY_TTL_MS,
-            };
-        }
-        this.appOriginCanonicalizationLocalCacheNamespace = this.createAppOriginLocalCacheNamespace();
-    }
-
-    async readCanonicalAppUidFromRedisCache (origin, version) {
+    async readCanonicalAppUidFromRedisCache (origin) {
         const cacheKey = this.buildAppOriginCanonicalCacheKey({
             origin,
-            version,
         });
 
         try {
@@ -1149,10 +1101,9 @@ class AuthService extends BaseService {
         }
     }
 
-    async writeCanonicalAppUidToRedisCache (origin, version, appUid) {
+    async writeCanonicalAppUidToRedisCache (origin, appUid) {
         const cacheKey = this.buildAppOriginCanonicalCacheKey({
             origin,
-            version,
         });
 
         await setRedisCacheValue(
@@ -1172,11 +1123,7 @@ class AuthService extends BaseService {
             return localCachedAppUid;
         }
 
-        const cacheVersion = await this.getAppOriginCacheVersion();
-        const redisCachedAppUid = await this.readCanonicalAppUidFromRedisCache(
-            canonicalOrigin,
-            cacheVersion,
-        );
+        const redisCachedAppUid = await this.readCanonicalAppUidFromRedisCache(canonicalOrigin);
         if ( redisCachedAppUid !== undefined ) {
             this.writeLocalCanonicalAppUidToCache(canonicalOrigin, redisCachedAppUid);
             return redisCachedAppUid;
@@ -1185,11 +1132,78 @@ class AuthService extends BaseService {
         const canonicalAppUid = await this.lookupCanonicalAppUidFromOrigin(canonicalOrigin);
         this.writeLocalCanonicalAppUidToCache(canonicalOrigin, canonicalAppUid);
         try {
-            await this.writeCanonicalAppUidToRedisCache(canonicalOrigin, cacheVersion, canonicalAppUid);
+            await this.writeCanonicalAppUidToRedisCache(canonicalOrigin, canonicalAppUid);
         } catch {
             // Redis cache writes are best-effort.
         }
         return canonicalAppUid;
+    }
+
+    normalizeOriginForCanonicalAppUidCache (originCandidate) {
+        const normalizedOrigin = this._origin_from_url(originCandidate);
+        if ( normalizedOrigin === null ) return null;
+        return this.canonicalizeHostedAppOriginForUid(normalizedOrigin);
+    }
+
+    collectCanonicalCacheOriginsFromAppChangeEvent (event = {}) {
+        const originCandidates = [];
+        if ( event?.app?.index_url ) {
+            originCandidates.push(event.app.index_url);
+        }
+        if ( event?.old_app?.index_url ) {
+            originCandidates.push(event.old_app.index_url);
+        }
+        if ( event?.index_url ) {
+            originCandidates.push(event.index_url);
+        }
+        if ( event?.old_index_url ) {
+            originCandidates.push(event.old_index_url);
+        }
+
+        const canonicalOrigins = new Set();
+        for ( const originCandidate of originCandidates ) {
+            const normalizedCanonicalOrigin = this.normalizeOriginForCanonicalAppUidCache(originCandidate);
+            if ( normalizedCanonicalOrigin ) {
+                canonicalOrigins.add(normalizedCanonicalOrigin);
+            }
+        }
+
+        return [...canonicalOrigins];
+    }
+
+    async invalidateCanonicalAppUidCacheForOrigins (originCandidates = []) {
+        const canonicalOrigins = new Set();
+        for ( const originCandidate of originCandidates ) {
+            const normalizedCanonicalOrigin = this.normalizeOriginForCanonicalAppUidCache(originCandidate);
+            if ( normalizedCanonicalOrigin ) {
+                canonicalOrigins.add(normalizedCanonicalOrigin);
+            }
+        }
+
+        if ( canonicalOrigins.size === 0 ) return;
+
+        const localCacheKeys = [];
+        const redisCacheKeys = [];
+        for ( const canonicalOrigin of canonicalOrigins ) {
+            localCacheKeys.push(this.buildLocalCanonicalAppUidCacheKey(canonicalOrigin));
+            redisCacheKeys.push(this.buildAppOriginCanonicalCacheKey({ origin: canonicalOrigin }));
+        }
+
+        if ( localCacheKeys.length > 0 ) {
+            kv.del(...localCacheKeys);
+        }
+        if ( redisCacheKeys.length > 0 ) {
+            try {
+                await deleteRedisKeys(redisCacheKeys);
+            } catch {
+                // best-effort invalidation; cache TTL bounds stale reads.
+            }
+        }
+    }
+
+    async invalidateCanonicalAppUidCacheFromAppChangeEvent (event = {}) {
+        const canonicalOrigins = this.collectCanonicalCacheOriginsFromAppChangeEvent(event);
+        await this.invalidateCanonicalAppUidCacheForOrigins(canonicalOrigins);
     }
 
     buildIndexUrlCandidatesFromOrigin (origin) {

--- a/src/backend/src/services/auth/AuthService.js
+++ b/src/backend/src/services/auth/AuthService.js
@@ -21,12 +21,18 @@ const { BaseService } = require('../BaseService');
 const { get_user, get_app } = require('../../helpers');
 const { Context } = require('../../util/context');
 const APIError = require('../../api/APIError');
-const { DB_WRITE } = require('../database/consts');
+const { setRedisCacheValue } = require('../../clients/redis/cacheUpdate.js');
+const { redisClient } = require('../../clients/redis/redisSingleton.js');
+const { DB_READ, DB_WRITE } = require('../database/consts');
 const { UUIDFPE } = require('../../util/uuidfpe');
 const uuidLib = require('uuid');
 const crypto = require('crypto');
 // This constant defines the namespace used for generating app UUIDs from their origins
 const APP_ORIGIN_UUID_NAMESPACE = '33de3768-8ee0-43e9-9e73-db192b97a5d8';
+const APP_ORIGIN_CACHE_VERSION_KEY = 'auth:appOriginCanonicalization:version';
+const APP_ORIGIN_CACHE_KEY_PREFIX = 'auth:appOriginCanonicalization:origin';
+const DEFAULT_APP_ORIGIN_CANONICAL_CACHE_TTL_SECONDS = 300;
+const APP_ORIGIN_VERSION_MEMORY_TTL_MS = 5000;
 const DEFAULT_PRIVATE_APP_ASSET_TOKEN_TTL_SECONDS = 60 * 60;
 const DEFAULT_PRIVATE_APP_ASSET_COOKIE_NAME = 'puter.private.asset.token';
 
@@ -67,6 +73,17 @@ class AuthService extends BaseService {
         this.sessions = {};
 
         this.tokenService = await this.services.get('token');
+
+        this.appOriginCanonicalizationLocalCache = new Map();
+        this.appOriginCacheVersionMemo = {
+            value: null,
+            expiresAt: 0,
+        };
+
+        const eventService = await this.services.get('event');
+        eventService.on('app.changed', async () => {
+            await this.bumpAppOriginCacheVersion();
+        });
     }
 
     /**
@@ -956,7 +973,12 @@ class AuthService extends BaseService {
      */
     async get_user_app_token_from_origin (origin) {
         origin = this._origin_from_url(origin);
-        const app_uid = await this._app_uid_from_origin(origin);
+        if ( origin === null ) {
+            throw APIError.create('no_origin_for_app');
+        }
+
+        const canonicalAppUid = await this.resolveCanonicalAppUidFromOrigin(origin);
+        const app_uid = canonicalAppUid ?? await this._app_uid_from_origin(origin);
 
         // Determine if the app exists
         const apps = await this.db.read(
@@ -984,6 +1006,8 @@ class AuthService extends BaseService {
             [app_uid, name, title, description, index_url, owner_user_id],
         );
 
+        await this.bumpAppOriginCacheVersion();
+
         return this.get_user_app_token(app_uid);
     }
 
@@ -998,7 +1022,262 @@ class AuthService extends BaseService {
         if ( origin === null ) {
             throw APIError.create('no_origin_for_app');
         }
+        const canonicalAppUid = await this.resolveCanonicalAppUidFromOrigin(origin);
+        if ( canonicalAppUid ) {
+            return canonicalAppUid;
+        }
         return await this._app_uid_from_origin(origin);
+    }
+
+    getAppOriginCanonicalCacheTtlSeconds () {
+        return this.resolvePositiveInteger(
+            this.global_config.app_origin_canonical_cache_ttl_seconds,
+            DEFAULT_APP_ORIGIN_CANONICAL_CACHE_TTL_SECONDS,
+        );
+    }
+
+    buildAppOriginCanonicalCacheKey ({ origin, version }) {
+        const encodedOrigin = encodeURIComponent(origin);
+        return `${APP_ORIGIN_CACHE_KEY_PREFIX}:${version}:${encodedOrigin}`;
+    }
+
+    readLocalCanonicalAppUidFromCache (origin) {
+        const cachedResolution = this.appOriginCanonicalizationLocalCache.get(origin);
+        if ( ! cachedResolution ) return undefined;
+
+        if ( cachedResolution.expiresAt <= Date.now() ) {
+            this.appOriginCanonicalizationLocalCache.delete(origin);
+            return undefined;
+        }
+
+        return cachedResolution.appUid;
+    }
+
+    writeLocalCanonicalAppUidToCache (origin, appUid) {
+        const ttlSeconds = this.getAppOriginCanonicalCacheTtlSeconds();
+        this.appOriginCanonicalizationLocalCache.set(origin, {
+            appUid: appUid ?? null,
+            expiresAt: Date.now() + ttlSeconds * 1000,
+        });
+    }
+
+    async getAppOriginCacheVersion () {
+        const now = Date.now();
+        if (
+            this.appOriginCacheVersionMemo?.value
+            && this.appOriginCacheVersionMemo.expiresAt > now
+        ) {
+            return this.appOriginCacheVersionMemo.value;
+        }
+
+        let cacheVersion = '0';
+        try {
+            const redisCacheVersion = await redisClient.get(APP_ORIGIN_CACHE_VERSION_KEY);
+            if ( redisCacheVersion ) {
+                cacheVersion = `${redisCacheVersion}`;
+            }
+        } catch {
+            // Redis access is best-effort here; deterministic fallback remains safe.
+        }
+
+        this.appOriginCacheVersionMemo = {
+            value: cacheVersion,
+            expiresAt: now + APP_ORIGIN_VERSION_MEMORY_TTL_MS,
+        };
+        return cacheVersion;
+    }
+
+    async bumpAppOriginCacheVersion () {
+        try {
+            const nextVersion = await redisClient.incr(APP_ORIGIN_CACHE_VERSION_KEY);
+            this.appOriginCacheVersionMemo = {
+                value: `${nextVersion}`,
+                expiresAt: Date.now() + APP_ORIGIN_VERSION_MEMORY_TTL_MS,
+            };
+        } catch {
+            this.appOriginCacheVersionMemo = {
+                value: `${Date.now()}`,
+                expiresAt: Date.now() + APP_ORIGIN_VERSION_MEMORY_TTL_MS,
+            };
+        }
+        this.appOriginCanonicalizationLocalCache.clear();
+    }
+
+    async readCanonicalAppUidFromRedisCache (origin, version) {
+        const cacheKey = this.buildAppOriginCanonicalCacheKey({
+            origin,
+            version,
+        });
+
+        try {
+            const cachedPayload = await redisClient.get(cacheKey);
+            if ( typeof cachedPayload !== 'string' || cachedPayload === '' ) {
+                return undefined;
+            }
+
+            const parsedPayload = JSON.parse(cachedPayload);
+            if ( !parsedPayload || typeof parsedPayload !== 'object' ) {
+                return undefined;
+            }
+            if ( ! Object.prototype.hasOwnProperty.call(parsedPayload, 'appUid') ) {
+                return undefined;
+            }
+            return parsedPayload.appUid ?? null;
+        } catch {
+            return undefined;
+        }
+    }
+
+    async writeCanonicalAppUidToRedisCache (origin, version, appUid) {
+        const cacheKey = this.buildAppOriginCanonicalCacheKey({
+            origin,
+            version,
+        });
+
+        await setRedisCacheValue(
+            cacheKey,
+            JSON.stringify({ appUid: appUid ?? null }),
+            { ttlSeconds: this.getAppOriginCanonicalCacheTtlSeconds() },
+        );
+    }
+
+    async resolveCanonicalAppUidFromOrigin (origin) {
+        const normalizedOrigin = this._origin_from_url(origin);
+        if ( normalizedOrigin === null ) return null;
+
+        const canonicalOrigin = this.canonicalizeHostedAppOriginForUid(normalizedOrigin);
+        const localCachedAppUid = this.readLocalCanonicalAppUidFromCache(canonicalOrigin);
+        if ( localCachedAppUid !== undefined ) {
+            return localCachedAppUid;
+        }
+
+        const cacheVersion = await this.getAppOriginCacheVersion();
+        const redisCachedAppUid = await this.readCanonicalAppUidFromRedisCache(
+            canonicalOrigin,
+            cacheVersion,
+        );
+        if ( redisCachedAppUid !== undefined ) {
+            this.writeLocalCanonicalAppUidToCache(canonicalOrigin, redisCachedAppUid);
+            return redisCachedAppUid;
+        }
+
+        const canonicalAppUid = await this.lookupCanonicalAppUidFromOrigin(canonicalOrigin);
+        this.writeLocalCanonicalAppUidToCache(canonicalOrigin, canonicalAppUid);
+        try {
+            await this.writeCanonicalAppUidToRedisCache(canonicalOrigin, cacheVersion, canonicalAppUid);
+        } catch {
+            // Redis cache writes are best-effort.
+        }
+        return canonicalAppUid;
+    }
+
+    buildIndexUrlCandidatesFromOrigin (origin) {
+        try {
+            const parsedOrigin = new URL(origin);
+            const hostCandidates = new Set();
+            hostCandidates.add(parsedOrigin.host.toLowerCase());
+
+            const hostedSubdomain = this.extractHostedAppSubdomainFromHostname(parsedOrigin.hostname);
+            if ( hostedSubdomain ) {
+                const hostedDomainCandidates = this.getHostedAppDomainCandidatesForMatch();
+                for ( const hostedDomainCandidate of hostedDomainCandidates ) {
+                    if ( hostedDomainCandidate?.host ) {
+                        hostCandidates.add(`${hostedSubdomain}.${hostedDomainCandidate.host}`);
+                    }
+                }
+            }
+
+            const indexUrlCandidates = [];
+            for ( const hostCandidate of hostCandidates ) {
+                const baseUrl = `${parsedOrigin.protocol}//${hostCandidate}`;
+                indexUrlCandidates.push(baseUrl);
+                indexUrlCandidates.push(`${baseUrl}/`);
+                indexUrlCandidates.push(`${baseUrl}/index.html`);
+            }
+
+            return [...new Set(indexUrlCandidates)];
+        } catch {
+            return [];
+        }
+    }
+
+    async getHostedSubdomainOwnerUserId (subdomain) {
+        if ( typeof subdomain !== 'string' || !subdomain ) return null;
+        try {
+            const databaseService = this.services.get('database');
+            const dbReadSites = databaseService.get(DB_READ, 'sites');
+            const rows = await dbReadSites.read(
+                'SELECT user_id FROM subdomains WHERE subdomain = ? LIMIT 1',
+                [subdomain],
+            );
+            const ownerUserId = Number(rows?.[0]?.user_id);
+            if ( Number.isInteger(ownerUserId) && ownerUserId > 0 ) {
+                return ownerUserId;
+            }
+            return null;
+        } catch {
+            return null;
+        }
+    }
+
+    async queryOldestAppUidForIndexUrlCandidates ({
+        indexUrlCandidates,
+        ownerUserId,
+    }) {
+        if ( !Array.isArray(indexUrlCandidates) || indexUrlCandidates.length === 0 ) {
+            return null;
+        }
+
+        const placeholders = indexUrlCandidates.map(() => '?').join(', ');
+        const parameters = [];
+        let whereClause = `index_url IN (${placeholders})`;
+        parameters.push(...indexUrlCandidates);
+
+        if ( Number.isInteger(ownerUserId) && ownerUserId > 0 ) {
+            whereClause = `owner_user_id = ? AND ${whereClause}`;
+            parameters.unshift(ownerUserId);
+        }
+
+        try {
+            const dbReadApps = this.services.get('database').get(DB_READ, 'apps');
+            const rows = await dbReadApps.read(
+                `SELECT uid FROM apps WHERE ${whereClause} ORDER BY timestamp ASC, id ASC LIMIT 1`,
+                parameters,
+            );
+            const oldestAppUid = rows?.[0]?.uid;
+            if ( typeof oldestAppUid === 'string' && oldestAppUid ) {
+                return oldestAppUid;
+            }
+        } catch {
+            return null;
+        }
+
+        return null;
+    }
+
+    async lookupCanonicalAppUidFromOrigin (origin) {
+        const indexUrlCandidates = this.buildIndexUrlCandidatesFromOrigin(origin);
+        if ( indexUrlCandidates.length === 0 ) return null;
+
+        try {
+            const parsedOrigin = new URL(origin);
+            const hostedSubdomain = this.extractHostedAppSubdomainFromHostname(parsedOrigin.hostname);
+
+            if ( hostedSubdomain ) {
+                const hostedSubdomainOwnerUserId = await this.getHostedSubdomainOwnerUserId(hostedSubdomain);
+                if ( ! hostedSubdomainOwnerUserId ) {
+                    return null;
+                }
+                return await this.queryOldestAppUidForIndexUrlCandidates({
+                    ownerUserId: hostedSubdomainOwnerUserId,
+                    indexUrlCandidates,
+                });
+            }
+
+            return await this.queryOldestAppUidForIndexUrlCandidates({ indexUrlCandidates });
+        } catch {
+            return null;
+        }
     }
 
     normalizeHostedDomainCandidate (domainValue) {

--- a/src/backend/src/services/auth/AuthService.privateAssetToken.test.ts
+++ b/src/backend/src/services/auth/AuthService.privateAssetToken.test.ts
@@ -7,6 +7,7 @@ type AuthServiceForPrivateTokenTests = AuthService & {
         jwt_secret: string;
         private_app_asset_token_ttl_seconds: number;
         private_app_asset_cookie_name: string;
+        app_origin_canonical_cache_ttl_seconds?: number;
         static_hosting_domain: string;
         static_hosting_domain_alt?: string;
         private_app_hosting_domain: string;
@@ -27,10 +28,10 @@ type AuthServiceForPrivateTokenTests = AuthService & {
         decrypt: (value: string) => string;
     };
     services: {
-        get: (name: string) => {
-            emit?: (eventName: string, event: unknown) => Promise<void>;
-        };
+        get: (name: string) => unknown;
     };
+    appOriginCanonicalizationLocalCache: Map<string, { appUid: string | null; expiresAt: number }>;
+    appOriginCacheVersionMemo: { value: string | null; expiresAt: number };
 };
 
 const createAuthService = (): AuthServiceForPrivateTokenTests => {
@@ -39,6 +40,7 @@ const createAuthService = (): AuthServiceForPrivateTokenTests => {
         jwt_secret: 'private-asset-test-secret',
         private_app_asset_token_ttl_seconds: 3600,
         private_app_asset_cookie_name: 'puter.private.asset.token',
+        app_origin_canonical_cache_ttl_seconds: 300,
         static_hosting_domain: 'puter.site',
         static_hosting_domain_alt: 'puter.host',
         private_app_hosting_domain: 'app.puter.localhost',
@@ -66,6 +68,11 @@ const createAuthService = (): AuthServiceForPrivateTokenTests => {
             },
         }),
     };
+    authService.appOriginCanonicalizationLocalCache = new Map();
+    authService.appOriginCacheVersionMemo = { value: null, expiresAt: 0 };
+    authService.getAppOriginCacheVersion = vi.fn().mockResolvedValue('0');
+    authService.readCanonicalAppUidFromRedisCache = vi.fn().mockResolvedValue(undefined);
+    authService.writeCanonicalAppUidToRedisCache = vi.fn().mockResolvedValue(undefined);
     authService.get_session_ = vi.fn().mockResolvedValue(undefined);
     return authService;
 };
@@ -317,6 +324,105 @@ describe('AuthService private asset token helpers', () => {
         await expect(authService.resolvePrivateBootstrapIdentityFromToken(tampered))
             .rejects
             .toThrow();
+    });
+
+    it('prefers oldest owner-matched app for hosted subdomain origins', async () => {
+        const authService = createAuthService();
+        const readSites = vi.fn().mockResolvedValue([{ user_id: 42 }]);
+        const readApps = vi.fn().mockResolvedValue([{ uid: 'app-oldest-owner-match' }]);
+
+        authService.services = {
+            get: (name: string) => {
+                if ( name === 'database' ) {
+                    return {
+                        get: (_mode: unknown, dbName: string) => (
+                            dbName === 'sites'
+                                ? { read: readSites }
+                                : { read: readApps }
+                        ),
+                    };
+                }
+                return {
+                    emit: async () => {
+                    },
+                };
+            },
+        };
+        authService.getAppOriginCacheVersion = vi.fn().mockResolvedValue('0');
+        authService.readCanonicalAppUidFromRedisCache = vi.fn().mockResolvedValue(undefined);
+        authService.writeCanonicalAppUidToRedisCache = vi.fn().mockResolvedValue(undefined);
+
+        const appUid = await authService.app_uid_from_origin('https://beans.puter.dev');
+
+        expect(appUid).toBe('app-oldest-owner-match');
+        expect(readSites).toHaveBeenCalledWith(
+            'SELECT user_id FROM subdomains WHERE subdomain = ? LIMIT 1',
+            ['beans'],
+        );
+        expect(readApps).toHaveBeenCalled();
+    });
+
+    it('falls back to deterministic origin uid when hosted subdomain owner cannot be resolved', async () => {
+        const authService = createAuthService();
+        const readSites = vi.fn().mockResolvedValue([]);
+        const readApps = vi.fn().mockResolvedValue([]);
+
+        authService.services = {
+            get: (name: string) => {
+                if ( name === 'database' ) {
+                    return {
+                        get: (_mode: unknown, dbName: string) => (
+                            dbName === 'sites'
+                                ? { read: readSites }
+                                : { read: readApps }
+                        ),
+                    };
+                }
+                return {
+                    emit: async () => {
+                    },
+                };
+            },
+        };
+        authService.getAppOriginCacheVersion = vi.fn().mockResolvedValue('0');
+        authService.readCanonicalAppUidFromRedisCache = vi.fn().mockResolvedValue(undefined);
+        authService.writeCanonicalAppUidToRedisCache = vi.fn().mockResolvedValue(undefined);
+
+        const uidFromPrivateAlias = await authService.app_uid_from_origin('https://beans.puter.dev');
+        const uidFromStaticAlias = await authService.app_uid_from_origin('https://beans.puter.site');
+
+        expect(uidFromPrivateAlias).toBe(uidFromStaticAlias);
+        expect(uidFromPrivateAlias.startsWith('app-')).toBe(true);
+    });
+
+    it('prefers oldest app for non-hosted origins', async () => {
+        const authService = createAuthService();
+        const readApps = vi.fn().mockResolvedValue([{ uid: 'app-oldest-external' }]);
+
+        authService.services = {
+            get: (name: string) => {
+                if ( name === 'database' ) {
+                    return {
+                        get: (_mode: unknown, dbName: string) => (
+                            dbName === 'apps'
+                                ? { read: readApps }
+                                : { read: vi.fn().mockResolvedValue([]) }
+                        ),
+                    };
+                }
+                return {
+                    emit: async () => {
+                    },
+                };
+            },
+        };
+        authService.getAppOriginCacheVersion = vi.fn().mockResolvedValue('0');
+        authService.readCanonicalAppUidFromRedisCache = vi.fn().mockResolvedValue(undefined);
+        authService.writeCanonicalAppUidToRedisCache = vi.fn().mockResolvedValue(undefined);
+
+        const appUid = await authService.app_uid_from_origin('https://example.com');
+        expect(appUid).toBe('app-oldest-external');
+        expect(readApps).toHaveBeenCalled();
     });
 
     it('derives same app uid for hosted app domain aliases', async () => {

--- a/src/backend/src/services/auth/AuthService.privateAssetToken.test.ts
+++ b/src/backend/src/services/auth/AuthService.privateAssetToken.test.ts
@@ -30,7 +30,7 @@ type AuthServiceForPrivateTokenTests = AuthService & {
     services: {
         get: (name: string) => unknown;
     };
-    appOriginCanonicalizationLocalCache: Map<string, { appUid: string | null; expiresAt: number }>;
+    appOriginCanonicalizationLocalCacheNamespace?: string;
     appOriginCacheVersionMemo: { value: string | null; expiresAt: number };
 };
 
@@ -68,7 +68,7 @@ const createAuthService = (): AuthServiceForPrivateTokenTests => {
             },
         }),
     };
-    authService.appOriginCanonicalizationLocalCache = new Map();
+    authService.appOriginCanonicalizationLocalCacheNamespace = `test:${Math.random().toString(36).slice(2)}`;
     authService.appOriginCacheVersionMemo = { value: null, expiresAt: 0 };
     authService.getAppOriginCacheVersion = vi.fn().mockResolvedValue('0');
     authService.readCanonicalAppUidFromRedisCache = vi.fn().mockResolvedValue(undefined);

--- a/src/backend/src/services/auth/AuthService.privateAssetToken.test.ts
+++ b/src/backend/src/services/auth/AuthService.privateAssetToken.test.ts
@@ -31,7 +31,6 @@ type AuthServiceForPrivateTokenTests = AuthService & {
         get: (name: string) => unknown;
     };
     appOriginCanonicalizationLocalCacheNamespace?: string;
-    appOriginCacheVersionMemo: { value: string | null; expiresAt: number };
 };
 
 const createAuthService = (): AuthServiceForPrivateTokenTests => {
@@ -69,8 +68,6 @@ const createAuthService = (): AuthServiceForPrivateTokenTests => {
         }),
     };
     authService.appOriginCanonicalizationLocalCacheNamespace = `test:${Math.random().toString(36).slice(2)}`;
-    authService.appOriginCacheVersionMemo = { value: null, expiresAt: 0 };
-    authService.getAppOriginCacheVersion = vi.fn().mockResolvedValue('0');
     authService.readCanonicalAppUidFromRedisCache = vi.fn().mockResolvedValue(undefined);
     authService.writeCanonicalAppUidToRedisCache = vi.fn().mockResolvedValue(undefined);
     authService.get_session_ = vi.fn().mockResolvedValue(undefined);
@@ -348,7 +345,6 @@ describe('AuthService private asset token helpers', () => {
                 };
             },
         };
-        authService.getAppOriginCacheVersion = vi.fn().mockResolvedValue('0');
         authService.readCanonicalAppUidFromRedisCache = vi.fn().mockResolvedValue(undefined);
         authService.writeCanonicalAppUidToRedisCache = vi.fn().mockResolvedValue(undefined);
 
@@ -384,7 +380,6 @@ describe('AuthService private asset token helpers', () => {
                 };
             },
         };
-        authService.getAppOriginCacheVersion = vi.fn().mockResolvedValue('0');
         authService.readCanonicalAppUidFromRedisCache = vi.fn().mockResolvedValue(undefined);
         authService.writeCanonicalAppUidToRedisCache = vi.fn().mockResolvedValue(undefined);
 
@@ -416,13 +411,34 @@ describe('AuthService private asset token helpers', () => {
                 };
             },
         };
-        authService.getAppOriginCacheVersion = vi.fn().mockResolvedValue('0');
         authService.readCanonicalAppUidFromRedisCache = vi.fn().mockResolvedValue(undefined);
         authService.writeCanonicalAppUidToRedisCache = vi.fn().mockResolvedValue(undefined);
 
         const appUid = await authService.app_uid_from_origin('https://example.com');
         expect(appUid).toBe('app-oldest-external');
         expect(readApps).toHaveBeenCalled();
+    });
+
+    it('collects canonical cache origins from app change payloads', () => {
+        const authService = createAuthService();
+        authService.global_config.static_hosting_domain = 'puter.site';
+        authService.global_config.static_hosting_domain_alt = 'puter.host';
+        authService.global_config.private_app_hosting_domain = 'puter.app';
+        authService.global_config.private_app_hosting_domain_alt = 'puter.dev';
+
+        const canonicalOrigins = authService.collectCanonicalCacheOriginsFromAppChangeEvent({
+            app: {
+                index_url: 'https://beans.puter.dev/index.html',
+            },
+            old_app: {
+                index_url: 'https://beans.puter.site/',
+            },
+            old_index_url: 'https://example.com',
+        });
+
+        expect(canonicalOrigins).toContain('https://beans.puter.site');
+        expect(canonicalOrigins).toContain('https://example.com');
+        expect(canonicalOrigins.filter(origin => origin === 'https://beans.puter.site')).toHaveLength(1);
     });
 
     it('derives same app uid for hosted app domain aliases', async () => {


### PR DESCRIPTION
Adds cache-first canonical app uid resolution for origin-based auth flows with oldest-app selection and deterministic fallback, plus regression tests for hosted/non-hosted canonicalization behavior.