### PR TITLE
feat: phase 3 public hosted actor cookie bootstrap

### DIFF
--- a/src/backend/src/routers/hosting/puterSiteMiddleware.js
+++ b/src/backend/src/routers/hosting/puterSiteMiddleware.js
@@ -57,6 +57,7 @@ const {
 const AT_DIRECTORY_NAMESPACE = '4aa6dc52-34c1-4b8a-b63c-a62b27f727cf';
 const puterSiteConfigFilename = '.puter_site_config';
 const puterSiteConfigMaxSize = 256 * 1024;
+const defaultPublicHostedActorCookieName = 'puter.public.hosted.actor.token';
 
 function isPrivateApp (app) {
     return Number(app?.is_private ?? 0) > 0;
@@ -663,6 +664,277 @@ async function resolvePrivateIdentity ({ req, services, appUid }) {
     };
 }
 
+function getPublicHostedActorCookieName (authService) {
+    if ( typeof authService?.getPublicHostedActorCookieName === 'function' ) {
+        return authService.getPublicHostedActorCookieName();
+    }
+    return defaultPublicHostedActorCookieName;
+}
+
+function getRequestedHostedHost (req) {
+    const normalizedHost = normalizeConfiguredHostname(req.hostname);
+    return normalizedHost || undefined;
+}
+
+function buildLightweightHostedActor ({ userUid, sessionUuid }) {
+    if ( typeof userUid !== 'string' || !userUid ) {
+        return null;
+    }
+
+    return new Actor({
+        user_uid: userUid,
+        type: new UserActorType({
+            user: { uuid: userUid },
+            ...(sessionUuid ? { session: sessionUuid } : {}),
+            hasHttpOnlyCookie: false,
+        }),
+    });
+}
+
+function setHostedActorOnRequestContext ({ req, actor }) {
+    if ( ! actor ) return;
+    req.actor = actor;
+    Context.set('actor', actor);
+}
+
+async function resolvePublicHostedIdentity ({ req, services, appUid }) {
+    const authService = services.get('auth');
+    const publicHostedCookieName = getPublicHostedActorCookieName(authService);
+    const publicHostedCookieToken = req.cookies?.[publicHostedCookieName];
+    const hostedSubdomain = getSubdomainFromHostedRequest(req) || undefined;
+    const requestedHost = getRequestedHostedHost(req);
+    const hasPublicCookie = typeof publicHostedCookieToken === 'string' && !!publicHostedCookieToken;
+    let hasInvalidPublicCookie = false;
+
+    if (
+        typeof publicHostedCookieToken === 'string'
+        && publicHostedCookieToken
+        && typeof authService.verifyPublicHostedActorToken === 'function'
+    ) {
+        try {
+            const claims = authService.verifyPublicHostedActorToken(publicHostedCookieToken, {
+                ...(appUid ? { expectedAppUid: appUid } : {}),
+                expectedSubdomain: hostedSubdomain,
+                expectedHost: requestedHost,
+            });
+            return {
+                source: 'public-cookie',
+                userUid: claims.userUid,
+                sessionUuid: claims.sessionUuid,
+                tokenAppUid: claims.appUid || appUid,
+                subdomain: claims.subdomain || hostedSubdomain,
+                host: claims.host || requestedHost,
+                hasValidPublicCookie: true,
+                hasPublicCookie,
+                hasInvalidPublicCookie,
+                actor: null,
+            };
+        } catch (e) {
+            hasInvalidPublicCookie = true;
+            logPrivateAccessEvent('public_actor.identity_public_cookie_rejected', {
+                appUid: appUid ?? null,
+                requestHost: req.hostname,
+                reason: getPrivateAccessRejectionReason(e),
+            });
+        }
+    }
+
+    const sessionToken = req.cookies?.[cookieName];
+    if ( typeof sessionToken === 'string' && sessionToken ) {
+        try {
+            const actor = await authService.authenticate_from_token(sessionToken);
+            const identity = actorToPrivateIdentity(actor);
+            if ( identity ) {
+                return {
+                    source: 'session-cookie',
+                    ...identity,
+                    tokenAppUid: appUid,
+                    subdomain: hostedSubdomain,
+                    host: requestedHost,
+                    hasValidPublicCookie: false,
+                    hasPublicCookie,
+                    hasInvalidPublicCookie,
+                    actor,
+                };
+            }
+        } catch (e) {
+            logPrivateAccessEvent('public_actor.identity_session_cookie_rejected', {
+                appUid: appUid ?? null,
+                requestHost: req.hostname,
+                reason: getPrivateAccessRejectionReason(e),
+            });
+        }
+    }
+
+    const bootstrapToken = getBootstrapPrivateToken(req);
+    if ( typeof bootstrapToken === 'string' && bootstrapToken ) {
+        if ( typeof authService.resolvePrivateBootstrapIdentityFromToken === 'function' ) {
+            try {
+                const identity = await authService.resolvePrivateBootstrapIdentityFromToken(
+                    bootstrapToken,
+                    {
+                        ...(appUid ? { expectedAppUid: appUid } : {}),
+                    },
+                );
+                if ( identity?.userUid ) {
+                    return {
+                        source: 'bootstrap-token',
+                        ...identity,
+                        tokenAppUid: appUid,
+                        subdomain: hostedSubdomain,
+                        host: requestedHost,
+                        hasValidPublicCookie: false,
+                        hasPublicCookie,
+                        hasInvalidPublicCookie,
+                        actor: null,
+                    };
+                }
+            } catch (e) {
+                logPrivateAccessEvent('public_actor.identity_bootstrap_rejected', {
+                    appUid: appUid ?? null,
+                    requestHost: req.hostname,
+                    reason: getPrivateAccessRejectionReason(e),
+                });
+            }
+        } else {
+            try {
+                const actor = await authService.authenticate_from_token(bootstrapToken);
+                const identity = actorToPrivateIdentity(actor);
+                if ( identity ) {
+                    return {
+                        source: 'bootstrap-token',
+                        ...identity,
+                        tokenAppUid: appUid,
+                        subdomain: hostedSubdomain,
+                        host: requestedHost,
+                        hasValidPublicCookie: false,
+                        hasPublicCookie,
+                        hasInvalidPublicCookie,
+                        actor,
+                    };
+                }
+            } catch (e) {
+                logPrivateAccessEvent('public_actor.identity_bootstrap_rejected', {
+                    appUid: appUid ?? null,
+                    requestHost: req.hostname,
+                    reason: getPrivateAccessRejectionReason(e),
+                });
+            }
+        }
+    }
+
+    return {
+        source: 'none',
+        userUid: undefined,
+        sessionUuid: undefined,
+        tokenAppUid: appUid,
+        subdomain: hostedSubdomain,
+        host: requestedHost,
+        hasValidPublicCookie: false,
+        hasPublicCookie,
+        hasInvalidPublicCookie,
+        actor: null,
+    };
+}
+
+async function evaluatePublicHostedActorContext ({
+    req,
+    res,
+    services,
+    appUid,
+}) {
+    const existingActor = req.actor || Context.get('actor');
+    if ( existingActor ) {
+        const existingIdentity = actorToPrivateIdentity(existingActor);
+        if ( existingIdentity?.userUid ) {
+            return true;
+        }
+    }
+
+    const authService = services.get('auth');
+    const identity = await resolvePublicHostedIdentity({
+        req,
+        services,
+        appUid,
+    });
+
+    if ( identity.actor ) {
+        setHostedActorOnRequestContext({
+            req,
+            actor: identity.actor,
+        });
+    } else if ( identity.userUid ) {
+        const lightweightActor = buildLightweightHostedActor({
+            userUid: identity.userUid,
+            sessionUuid: identity.sessionUuid,
+        });
+        setHostedActorOnRequestContext({
+            req,
+            actor: lightweightActor,
+        });
+    }
+
+    if ( !identity.userUid || identity.hasValidPublicCookie ) {
+        return true;
+    }
+
+    let tokenAppUid = identity.tokenAppUid;
+    if ( !tokenAppUid && typeof authService.app_uid_from_origin === 'function' ) {
+        try {
+            const protocol = `${config.protocol ?? 'https'}`
+                .trim()
+                .replace(/:$/, '') || 'https';
+            tokenAppUid = await authService.app_uid_from_origin(`${protocol}://${req.hostname}`);
+        } catch {
+            tokenAppUid = undefined;
+        }
+    }
+    if ( !tokenAppUid || typeof authService.createPublicHostedActorToken !== 'function' ) {
+        return true;
+    }
+
+    try {
+        const publicHostedActorToken = authService.createPublicHostedActorToken({
+            appUid: tokenAppUid,
+            userUid: identity.userUid,
+            sessionUuid: identity.sessionUuid,
+            subdomain: identity.subdomain,
+            host: identity.host,
+        });
+        res.cookie(
+            getPublicHostedActorCookieName(authService),
+            publicHostedActorToken,
+            typeof authService.getPublicHostedActorCookieOptions === 'function'
+                ? authService.getPublicHostedActorCookieOptions({
+                    requestHostname: req.hostname,
+                })
+                : undefined,
+        );
+    } catch (e) {
+        logPrivateAccessEvent('public_actor.cookie_set_failed', {
+            appUid: tokenAppUid ?? null,
+            userUid: identity.userUid ?? null,
+            requestHost: req.hostname,
+            reason: getPrivateAccessRejectionReason(e),
+        });
+        return true;
+    }
+
+    const sanitizedUrl = stripBootstrapAuthTokenFromOriginalUrl(req.originalUrl);
+    if ( sanitizedUrl ) {
+        logPrivateAccessEvent('public_actor.cookie_redirect', {
+            appUid: tokenAppUid ?? null,
+            userUid: identity.userUid ?? null,
+            requestHost: req.hostname,
+            redirectUrl: sanitizedUrl,
+        });
+        res.redirect(sanitizedUrl);
+        return false;
+    }
+
+    return true;
+}
+
 function escapeHtml (value) {
     const raw = `${value ?? ''}`;
     return raw
@@ -1165,6 +1437,24 @@ async function runInternal (req, res, next) {
     }
 
     req.__puterSiteRootPath = subdomainRootPath;
+
+    if ( ! privateAppEnabled ) {
+        try {
+            const actorContextReady = await evaluatePublicHostedActorContext({
+                req,
+                res,
+                services,
+                appUid: privateApp?.uid || associatedApp?.uid,
+            });
+            if ( ! actorContextReady ) return;
+        } catch (e) {
+            logPrivateAccessEvent('public_actor.evaluate_failed', {
+                appUid: privateApp?.uid || associatedApp?.uid || null,
+                requestHost: req.hostname,
+                reason: getPrivateAccessRejectionReason(e),
+            });
+        }
+    }
 
     if ( privateAccessGateEnabled && privateAppEnabled ) {
         const accessAllowed = await evaluatePrivateAppAccess({

--- a/src/backend/src/routers/hosting/puterSiteMiddleware.test.js
+++ b/src/backend/src/routers/hosting/puterSiteMiddleware.test.js
@@ -61,6 +61,7 @@ vi.mock('../../helpers.js', () => ({
 vi.mock('../../util/context.js', () => ({
     Context: {
         get: vi.fn(),
+        set: vi.fn(),
     },
 }));
 
@@ -99,13 +100,40 @@ vi.mock('../../filesystem/ll_operations/ll_read.js', () => ({
     },
 }));
 
-vi.mock('../../services/auth/Actor.js', () => ({
-    Actor: { adapt: vi.fn(), create: vi.fn() },
-    UserActorType: class {
-    },
-    SiteActorType: class {
-    },
-}));
+vi.mock('../../services/auth/Actor.js', () => {
+    const adapt = vi.fn();
+    const create = vi.fn();
+    class UserActorType {
+        constructor ({ user, session, hasHttpOnlyCookie } = {}) {
+            this.user = user;
+            this.session = session;
+            this.hasHttpOnlyCookie = hasHttpOnlyCookie;
+        }
+    }
+    class SiteActorType {
+    }
+    class Actor {
+        constructor ({ user_uid, app_uid, type } = {}) {
+            this.user_uid = user_uid;
+            this.app_uid = app_uid;
+            this.type = type;
+        }
+
+        get_related_actor (actorType) {
+            if ( this.type instanceof actorType ) {
+                return this;
+            }
+            throw new Error('related_actor_not_found');
+        }
+    }
+    Actor.adapt = adapt;
+    Actor.create = create;
+    return {
+        Actor,
+        UserActorType,
+        SiteActorType,
+    };
+});
 
 vi.mock('../../api/APIError.js', () => ({
     default: class APIError {
@@ -136,7 +164,11 @@ describe('PuterSiteMiddleware', () => {
             config.enable_private_app_access_gate = true;
             config.private_app_hosting_domain = 'puter.dev';
             config.private_app_hosting_domain_alt = 'puter.dev';
-            Context.get = vi.fn().mockReturnValue(mockContextInstance);
+            Context.get = vi.fn().mockImplementation((key) => {
+                if ( key === 'actor' ) return undefined;
+                return mockContextInstance;
+            });
+            Context.set = vi.fn();
             getUserMockImpl = async () => null;
             getAppMockImpl = async () => null;
             capturedMiddleware = puterSiteMiddleware;
@@ -259,7 +291,11 @@ describe('PuterSiteMiddleware', () => {
         beforeEach(() => {
             vi.clearAllMocks();
             config.enable_private_app_access_gate = true;
-            Context.get = vi.fn().mockReturnValue(mockContextInstance);
+            Context.get = vi.fn().mockImplementation((key) => {
+                if ( key === 'actor' ) return undefined;
+                return mockContextInstance;
+            });
+            Context.set = vi.fn();
             getUserMockImpl = async () => null;
             getAppMockImpl = async () => null;
             capturedMiddleware = puterSiteMiddleware;
@@ -1430,6 +1466,572 @@ describe('PuterSiteMiddleware', () => {
 
             expect(mockRes.redirect).not.toHaveBeenCalled();
             expect(eventEmit).not.toHaveBeenCalled();
+            expect(mockRes.status).toHaveBeenCalledWith(404);
+            expect(mockNext).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('public hosted actor bootstrap', () => {
+        let capturedMiddleware;
+
+        const createRootAndMissingNodes = () => {
+            const rootDirectoryNode = {
+                fetchEntry: vi.fn().mockResolvedValue(undefined),
+                exists: vi.fn().mockResolvedValue(true),
+                get: vi.fn().mockImplementation(async (fieldName) => {
+                    if ( fieldName === 'type' ) return 'directory';
+                    if ( fieldName === 'path' ) return '/alice/Public';
+                    return null;
+                }),
+            };
+            const missingFileNode = {
+                fetchEntry: vi.fn().mockResolvedValue(undefined),
+                exists: vi.fn().mockResolvedValue(false),
+                get: vi.fn().mockResolvedValue(null),
+            };
+            return { rootDirectoryNode, missingFileNode };
+        };
+
+        beforeEach(() => {
+            vi.clearAllMocks();
+            config.enable_private_app_access_gate = true;
+            Context.get = vi.fn().mockImplementation((key) => {
+                if ( key === 'actor' ) return undefined;
+                return mockContextInstance;
+            });
+            Context.set = vi.fn();
+            getUserMockImpl = async () => null;
+            getAppMockImpl = async () => null;
+            capturedMiddleware = puterSiteMiddleware;
+        });
+
+        it('mints public hosted actor cookie from session identity on non-private app', async () => {
+            const { rootDirectoryNode, missingFileNode } = createRootAndMissingNodes();
+            let filesystemNodeCallCount = 0;
+            const authService = {
+                getPublicHostedActorCookieName: vi.fn().mockReturnValue('puter.public.hosted.actor.token'),
+                verifyPublicHostedActorToken: vi.fn().mockImplementation(() => {
+                    throw new Error('invalid');
+                }),
+                authenticate_from_token: vi.fn().mockResolvedValue({
+                    type: {},
+                    get_related_actor: vi.fn().mockReturnValue({
+                        type: {
+                            user: { uuid: 'user-public-111' },
+                            session: 'session-public-111',
+                        },
+                    }),
+                }),
+                createPublicHostedActorToken: vi.fn().mockReturnValue('public-hosted-token'),
+                getPublicHostedActorCookieOptions: vi.fn().mockReturnValue({ sameSite: 'none' }),
+                app_uid_from_origin: vi.fn().mockResolvedValue('app-origin-fallback-111'),
+            };
+            const mockServices = {
+                get: vi.fn().mockImplementation((serviceName) => {
+                    if ( serviceName === 'puter-site' ) {
+                        return {
+                            get_subdomain: vi.fn().mockResolvedValue({
+                                user_id: 101,
+                                associated_app_id: 202,
+                                root_dir_id: 303,
+                            }),
+                        };
+                    }
+                    if ( serviceName === 'filesystem' ) {
+                        return {
+                            node: vi.fn().mockImplementation(async () => {
+                                filesystemNodeCallCount += 1;
+                                return filesystemNodeCallCount === 1
+                                    ? rootDirectoryNode
+                                    : missingFileNode;
+                            }),
+                        };
+                    }
+                    if ( serviceName === 'acl' ) {
+                        return {
+                            check: vi.fn().mockResolvedValue(true),
+                        };
+                    }
+                    if ( serviceName === 'auth' ) return authService;
+                    return {};
+                }),
+            };
+            mockContextInstance.get.mockImplementation((key) => {
+                if ( key === 'services' ) return mockServices;
+                return null;
+            });
+            getUserMockImpl = async () => ({ id: 101, suspended: false });
+            getAppMockImpl = async () => ({
+                uid: 'app-public-11111111-1111-1111-1111-111111111111',
+                name: 'public-app',
+                is_private: 0,
+                index_url: 'https://paid.site.puter.localhost/',
+            });
+
+            const mockReq = {
+                hostname: 'paid.site.puter.localhost',
+                subdomains: ['paid'],
+                is_custom_domain: false,
+                baseUrl: '',
+                path: '/asset.js',
+                originalUrl: '/asset.js',
+                query: {},
+                cookies: {
+                    'puter.session.token': 'session-token',
+                },
+                headers: {},
+                on: vi.fn(),
+                ctx: mockContextInstance,
+            };
+            const mockRes = {
+                redirect: vi.fn(),
+                cookie: vi.fn(),
+                setHeader: vi.fn(),
+                set: vi.fn().mockReturnThis(),
+                status: vi.fn().mockReturnThis(),
+                send: vi.fn(),
+                write: vi.fn(),
+                end: vi.fn(),
+            };
+            const mockNext = vi.fn();
+
+            await capturedMiddleware(mockReq, mockRes, mockNext);
+
+            expect(authService.verifyPublicHostedActorToken).not.toHaveBeenCalled();
+            expect(authService.authenticate_from_token).toHaveBeenCalledWith('session-token');
+            expect(authService.createPublicHostedActorToken).toHaveBeenCalledWith({
+                appUid: 'app-public-11111111-1111-1111-1111-111111111111',
+                userUid: 'user-public-111',
+                sessionUuid: 'session-public-111',
+                subdomain: 'paid',
+                host: 'paid.site.puter.localhost',
+            });
+            expect(authService.app_uid_from_origin).not.toHaveBeenCalled();
+            expect(authService.getPublicHostedActorCookieOptions).toHaveBeenCalledWith({
+                requestHostname: 'paid.site.puter.localhost',
+            });
+            expect(mockRes.cookie).toHaveBeenCalledWith(
+                'puter.public.hosted.actor.token',
+                'public-hosted-token',
+                { sameSite: 'none' },
+            );
+            expect(Context.set).toHaveBeenCalledWith('actor', expect.any(Object));
+            expect(mockRes.redirect).not.toHaveBeenCalled();
+            expect(mockRes.status).toHaveBeenCalledWith(404);
+            expect(mockNext).not.toHaveBeenCalled();
+        });
+
+        it('uses valid public hosted actor cookie without re-authenticating', async () => {
+            const { rootDirectoryNode, missingFileNode } = createRootAndMissingNodes();
+            let filesystemNodeCallCount = 0;
+            const authService = {
+                getPublicHostedActorCookieName: vi.fn().mockReturnValue('puter.public.hosted.actor.token'),
+                verifyPublicHostedActorToken: vi.fn().mockReturnValue({
+                    appUid: 'app-public-22222222-2222-2222-2222-222222222222',
+                    userUid: 'user-public-222',
+                    sessionUuid: 'session-public-222',
+                    subdomain: 'paid',
+                    host: 'paid.site.puter.localhost',
+                }),
+                authenticate_from_token: vi.fn(),
+                createPublicHostedActorToken: vi.fn(),
+                getPublicHostedActorCookieOptions: vi.fn(),
+                app_uid_from_origin: vi.fn(),
+            };
+            const mockServices = {
+                get: vi.fn().mockImplementation((serviceName) => {
+                    if ( serviceName === 'puter-site' ) {
+                        return {
+                            get_subdomain: vi.fn().mockResolvedValue({
+                                user_id: 101,
+                                associated_app_id: 202,
+                                root_dir_id: 303,
+                            }),
+                        };
+                    }
+                    if ( serviceName === 'filesystem' ) {
+                        return {
+                            node: vi.fn().mockImplementation(async () => {
+                                filesystemNodeCallCount += 1;
+                                return filesystemNodeCallCount === 1
+                                    ? rootDirectoryNode
+                                    : missingFileNode;
+                            }),
+                        };
+                    }
+                    if ( serviceName === 'acl' ) {
+                        return {
+                            check: vi.fn().mockResolvedValue(true),
+                        };
+                    }
+                    if ( serviceName === 'auth' ) return authService;
+                    return {};
+                }),
+            };
+            mockContextInstance.get.mockImplementation((key) => {
+                if ( key === 'services' ) return mockServices;
+                return null;
+            });
+            getUserMockImpl = async () => ({ id: 101, suspended: false });
+            getAppMockImpl = async () => ({
+                uid: 'app-public-22222222-2222-2222-2222-222222222222',
+                name: 'public-app',
+                is_private: 0,
+                index_url: 'https://paid.site.puter.localhost/',
+            });
+
+            const mockReq = {
+                hostname: 'paid.site.puter.localhost',
+                subdomains: ['paid'],
+                is_custom_domain: false,
+                baseUrl: '',
+                path: '/asset.js',
+                originalUrl: '/asset.js',
+                query: {},
+                cookies: {
+                    'puter.public.hosted.actor.token': 'public-cookie-token',
+                },
+                headers: {},
+                on: vi.fn(),
+                ctx: mockContextInstance,
+            };
+            const mockRes = {
+                redirect: vi.fn(),
+                cookie: vi.fn(),
+                setHeader: vi.fn(),
+                set: vi.fn().mockReturnThis(),
+                status: vi.fn().mockReturnThis(),
+                send: vi.fn(),
+                write: vi.fn(),
+                end: vi.fn(),
+            };
+            const mockNext = vi.fn();
+
+            await capturedMiddleware(mockReq, mockRes, mockNext);
+
+            expect(authService.verifyPublicHostedActorToken).toHaveBeenCalledWith(
+                'public-cookie-token',
+                {
+                    expectedAppUid: 'app-public-22222222-2222-2222-2222-222222222222',
+                    expectedSubdomain: 'paid',
+                    expectedHost: 'paid.site.puter.localhost',
+                },
+            );
+            expect(authService.authenticate_from_token).not.toHaveBeenCalled();
+            expect(authService.createPublicHostedActorToken).not.toHaveBeenCalled();
+            expect(authService.app_uid_from_origin).not.toHaveBeenCalled();
+            expect(mockRes.cookie).not.toHaveBeenCalled();
+            expect(Context.set).toHaveBeenCalledWith('actor', expect.any(Object));
+            const [, actor] = Context.set.mock.calls[0];
+            expect(actor?.type?.user?.uuid).toBe('user-public-222');
+            expect(mockRes.redirect).not.toHaveBeenCalled();
+            expect(mockRes.status).toHaveBeenCalledWith(404);
+            expect(mockNext).not.toHaveBeenCalled();
+        });
+
+        it('sets public hosted cookie and redirects to sanitized url for bootstrap tokens', async () => {
+            const { rootDirectoryNode, missingFileNode } = createRootAndMissingNodes();
+            let filesystemNodeCallCount = 0;
+            const authService = {
+                getPublicHostedActorCookieName: vi.fn().mockReturnValue('puter.public.hosted.actor.token'),
+                verifyPublicHostedActorToken: vi.fn().mockImplementation(() => {
+                    throw new Error('invalid');
+                }),
+                authenticate_from_token: vi.fn().mockResolvedValue({
+                    type: {},
+                    get_related_actor: vi.fn().mockReturnValue({
+                        type: {
+                            user: { uuid: 'user-public-333' },
+                            session: 'session-public-333',
+                        },
+                    }),
+                }),
+                createPublicHostedActorToken: vi.fn().mockReturnValue('public-hosted-token-333'),
+                getPublicHostedActorCookieOptions: vi.fn().mockReturnValue({ sameSite: 'none' }),
+                app_uid_from_origin: vi.fn(),
+            };
+            const mockServices = {
+                get: vi.fn().mockImplementation((serviceName) => {
+                    if ( serviceName === 'puter-site' ) {
+                        return {
+                            get_subdomain: vi.fn().mockResolvedValue({
+                                user_id: 101,
+                                associated_app_id: 202,
+                                root_dir_id: 303,
+                            }),
+                        };
+                    }
+                    if ( serviceName === 'filesystem' ) {
+                        return {
+                            node: vi.fn().mockImplementation(async () => {
+                                filesystemNodeCallCount += 1;
+                                return filesystemNodeCallCount === 1
+                                    ? rootDirectoryNode
+                                    : missingFileNode;
+                            }),
+                        };
+                    }
+                    if ( serviceName === 'acl' ) {
+                        return {
+                            check: vi.fn().mockResolvedValue(true),
+                        };
+                    }
+                    if ( serviceName === 'auth' ) return authService;
+                    return {};
+                }),
+            };
+            mockContextInstance.get.mockImplementation((key) => {
+                if ( key === 'services' ) return mockServices;
+                return null;
+            });
+            getUserMockImpl = async () => ({ id: 101, suspended: false });
+            getAppMockImpl = async () => ({
+                uid: 'app-public-33333333-3333-3333-3333-333333333333',
+                name: 'public-app',
+                is_private: 0,
+                index_url: 'https://paid.site.puter.localhost/',
+            });
+
+            const mockReq = {
+                hostname: 'paid.site.puter.localhost',
+                subdomains: ['paid'],
+                is_custom_domain: false,
+                baseUrl: '',
+                path: '/asset.js',
+                originalUrl: '/asset.js?puter.auth.token=bootstrap-token&foo=bar',
+                query: {
+                    'puter.auth.token': 'bootstrap-token',
+                    foo: 'bar',
+                },
+                cookies: {},
+                headers: {},
+                on: vi.fn(),
+                ctx: mockContextInstance,
+            };
+            const mockRes = {
+                redirect: vi.fn(),
+                cookie: vi.fn(),
+                setHeader: vi.fn(),
+                set: vi.fn().mockReturnThis(),
+                status: vi.fn().mockReturnThis(),
+                send: vi.fn(),
+                write: vi.fn(),
+                end: vi.fn(),
+            };
+            const mockNext = vi.fn();
+
+            await capturedMiddleware(mockReq, mockRes, mockNext);
+
+            expect(authService.authenticate_from_token).toHaveBeenCalledWith('bootstrap-token');
+            expect(authService.createPublicHostedActorToken).toHaveBeenCalledWith({
+                appUid: 'app-public-33333333-3333-3333-3333-333333333333',
+                userUid: 'user-public-333',
+                sessionUuid: 'session-public-333',
+                subdomain: 'paid',
+                host: 'paid.site.puter.localhost',
+            });
+            expect(mockRes.cookie).toHaveBeenCalledWith(
+                'puter.public.hosted.actor.token',
+                'public-hosted-token-333',
+                { sameSite: 'none' },
+            );
+            expect(mockRes.redirect).toHaveBeenCalledWith('/asset.js?foo=bar');
+            expect(mockNext).not.toHaveBeenCalled();
+        });
+
+        it('uses strict bootstrap identity verification when available', async () => {
+            const { rootDirectoryNode, missingFileNode } = createRootAndMissingNodes();
+            let filesystemNodeCallCount = 0;
+            const authService = {
+                getPublicHostedActorCookieName: vi.fn().mockReturnValue('puter.public.hosted.actor.token'),
+                verifyPublicHostedActorToken: vi.fn().mockImplementation(() => {
+                    throw new Error('invalid');
+                }),
+                resolvePrivateBootstrapIdentityFromToken: vi.fn().mockResolvedValue({
+                    userUid: 'user-public-555',
+                    sessionUuid: 'session-public-555',
+                }),
+                authenticate_from_token: vi.fn(),
+                createPublicHostedActorToken: vi.fn().mockReturnValue('public-hosted-token-555'),
+                getPublicHostedActorCookieOptions: vi.fn().mockReturnValue({ sameSite: 'none' }),
+                app_uid_from_origin: vi.fn(),
+            };
+            const mockServices = {
+                get: vi.fn().mockImplementation((serviceName) => {
+                    if ( serviceName === 'puter-site' ) {
+                        return {
+                            get_subdomain: vi.fn().mockResolvedValue({
+                                user_id: 101,
+                                associated_app_id: 202,
+                                root_dir_id: 303,
+                            }),
+                        };
+                    }
+                    if ( serviceName === 'filesystem' ) {
+                        return {
+                            node: vi.fn().mockImplementation(async () => {
+                                filesystemNodeCallCount += 1;
+                                return filesystemNodeCallCount === 1
+                                    ? rootDirectoryNode
+                                    : missingFileNode;
+                            }),
+                        };
+                    }
+                    if ( serviceName === 'acl' ) {
+                        return {
+                            check: vi.fn().mockResolvedValue(true),
+                        };
+                    }
+                    if ( serviceName === 'auth' ) return authService;
+                    return {};
+                }),
+            };
+            mockContextInstance.get.mockImplementation((key) => {
+                if ( key === 'services' ) return mockServices;
+                return null;
+            });
+            getUserMockImpl = async () => ({ id: 101, suspended: false });
+            getAppMockImpl = async () => ({
+                uid: 'app-public-55555555-5555-5555-5555-555555555555',
+                name: 'public-app',
+                is_private: 0,
+                index_url: 'https://paid.site.puter.localhost/',
+            });
+
+            const mockReq = {
+                hostname: 'paid.site.puter.localhost',
+                subdomains: ['paid'],
+                is_custom_domain: false,
+                baseUrl: '',
+                path: '/asset.js',
+                originalUrl: '/asset.js?puter.auth.token=bootstrap-token&foo=bar',
+                query: {
+                    'puter.auth.token': 'bootstrap-token',
+                    foo: 'bar',
+                },
+                cookies: {},
+                headers: {},
+                on: vi.fn(),
+                ctx: mockContextInstance,
+            };
+            const mockRes = {
+                redirect: vi.fn(),
+                cookie: vi.fn(),
+                setHeader: vi.fn(),
+                set: vi.fn().mockReturnThis(),
+                status: vi.fn().mockReturnThis(),
+                send: vi.fn(),
+                write: vi.fn(),
+                end: vi.fn(),
+            };
+            const mockNext = vi.fn();
+
+            await capturedMiddleware(mockReq, mockRes, mockNext);
+
+            expect(authService.resolvePrivateBootstrapIdentityFromToken).toHaveBeenCalledWith(
+                'bootstrap-token',
+                {
+                    expectedAppUid: 'app-public-55555555-5555-5555-5555-555555555555',
+                },
+            );
+            expect(authService.authenticate_from_token).not.toHaveBeenCalled();
+            expect(authService.createPublicHostedActorToken).toHaveBeenCalledWith({
+                appUid: 'app-public-55555555-5555-5555-5555-555555555555',
+                userUid: 'user-public-555',
+                sessionUuid: 'session-public-555',
+                subdomain: 'paid',
+                host: 'paid.site.puter.localhost',
+            });
+            expect(mockRes.redirect).toHaveBeenCalledWith('/asset.js?foo=bar');
+            expect(mockNext).not.toHaveBeenCalled();
+        });
+
+        it('short-circuits without auth calls when no identity tokens exist', async () => {
+            const { rootDirectoryNode, missingFileNode } = createRootAndMissingNodes();
+            let filesystemNodeCallCount = 0;
+            const authService = {
+                getPublicHostedActorCookieName: vi.fn().mockReturnValue('puter.public.hosted.actor.token'),
+                verifyPublicHostedActorToken: vi.fn(),
+                authenticate_from_token: vi.fn(),
+                createPublicHostedActorToken: vi.fn(),
+                getPublicHostedActorCookieOptions: vi.fn(),
+                app_uid_from_origin: vi.fn(),
+            };
+            const mockServices = {
+                get: vi.fn().mockImplementation((serviceName) => {
+                    if ( serviceName === 'puter-site' ) {
+                        return {
+                            get_subdomain: vi.fn().mockResolvedValue({
+                                user_id: 101,
+                                associated_app_id: 202,
+                                root_dir_id: 303,
+                            }),
+                        };
+                    }
+                    if ( serviceName === 'filesystem' ) {
+                        return {
+                            node: vi.fn().mockImplementation(async () => {
+                                filesystemNodeCallCount += 1;
+                                return filesystemNodeCallCount === 1
+                                    ? rootDirectoryNode
+                                    : missingFileNode;
+                            }),
+                        };
+                    }
+                    if ( serviceName === 'acl' ) {
+                        return {
+                            check: vi.fn().mockResolvedValue(true),
+                        };
+                    }
+                    if ( serviceName === 'auth' ) return authService;
+                    return {};
+                }),
+            };
+            mockContextInstance.get.mockImplementation((key) => {
+                if ( key === 'services' ) return mockServices;
+                return null;
+            });
+            getUserMockImpl = async () => ({ id: 101, suspended: false });
+            getAppMockImpl = async () => ({
+                uid: 'app-public-44444444-4444-4444-4444-444444444444',
+                name: 'public-app',
+                is_private: 0,
+                index_url: 'https://paid.site.puter.localhost/',
+            });
+
+            const mockReq = {
+                hostname: 'paid.site.puter.localhost',
+                subdomains: ['paid'],
+                is_custom_domain: false,
+                baseUrl: '',
+                path: '/asset.js',
+                originalUrl: '/asset.js',
+                query: {},
+                cookies: {},
+                headers: {},
+                on: vi.fn(),
+                ctx: mockContextInstance,
+            };
+            const mockRes = {
+                redirect: vi.fn(),
+                cookie: vi.fn(),
+                setHeader: vi.fn(),
+                set: vi.fn().mockReturnThis(),
+                status: vi.fn().mockReturnThis(),
+                send: vi.fn(),
+                write: vi.fn(),
+                end: vi.fn(),
+            };
+            const mockNext = vi.fn();
+
+            await capturedMiddleware(mockReq, mockRes, mockNext);
+
+            expect(authService.verifyPublicHostedActorToken).not.toHaveBeenCalled();
+            expect(authService.authenticate_from_token).not.toHaveBeenCalled();
+            expect(authService.createPublicHostedActorToken).not.toHaveBeenCalled();
+            expect(authService.app_uid_from_origin).not.toHaveBeenCalled();
+            expect(mockRes.cookie).not.toHaveBeenCalled();
+            expect(mockRes.redirect).not.toHaveBeenCalled();
             expect(mockRes.status).toHaveBeenCalledWith(404);
             expect(mockNext).not.toHaveBeenCalled();
         });

--- a/src/backend/src/services/auth/AuthService.js
+++ b/src/backend/src/services/auth/AuthService.js
@@ -36,6 +36,8 @@ const APP_ORIGIN_LOCAL_CACHE_KEY_PREFIX = 'auth:appOriginCanonicalization:local'
 const DEFAULT_APP_ORIGIN_CANONICAL_CACHE_TTL_SECONDS = 300;
 const DEFAULT_PRIVATE_APP_ASSET_TOKEN_TTL_SECONDS = 60 * 60;
 const DEFAULT_PRIVATE_APP_ASSET_COOKIE_NAME = 'puter.private.asset.token';
+const DEFAULT_PUBLIC_HOSTED_ACTOR_TOKEN_TTL_SECONDS = 15 * 60;
+const DEFAULT_PUBLIC_HOSTED_ACTOR_COOKIE_NAME = 'puter.public.hosted.actor.token';
 
 const LegacyTokenError = class extends Error {
 };
@@ -292,6 +294,21 @@ class AuthService extends BaseService {
         return DEFAULT_PRIVATE_APP_ASSET_COOKIE_NAME;
     }
 
+    getPublicHostedActorTokenTtlSeconds () {
+        return this.resolvePositiveInteger(
+            this.global_config.public_hosted_actor_token_ttl_seconds,
+            DEFAULT_PUBLIC_HOSTED_ACTOR_TOKEN_TTL_SECONDS,
+        );
+    }
+
+    getPublicHostedActorCookieName () {
+        const configuredCookieName = this.global_config.public_hosted_actor_cookie_name;
+        if ( typeof configuredCookieName === 'string' && configuredCookieName.trim() ) {
+            return configuredCookieName.trim();
+        }
+        return DEFAULT_PUBLIC_HOSTED_ACTOR_COOKIE_NAME;
+    }
+
     normalizeHostnameForCookieDomain (hostnameValue) {
         if ( typeof hostnameValue !== 'string' ) return null;
         const trimmedHostname = hostnameValue.trim().toLowerCase().replace(/^\./, '');
@@ -315,6 +332,22 @@ class AuthService extends BaseService {
     getConfiguredPrivateCookieDomains () {
         const configuredDomains = [];
         for ( const configuredDomainCandidate of [
+            this.global_config.private_app_hosting_domain,
+            this.global_config.private_app_hosting_domain_alt,
+        ] ) {
+            const normalizedDomain = this.normalizeHostnameForCookieDomain(configuredDomainCandidate);
+            if ( normalizedDomain ) {
+                configuredDomains.push(normalizedDomain);
+            }
+        }
+        return [...new Set(configuredDomains)];
+    }
+
+    getConfiguredHostedCookieDomains () {
+        const configuredDomains = [];
+        for ( const configuredDomainCandidate of [
+            this.global_config.static_hosting_domain,
+            this.global_config.static_hosting_domain_alt,
             this.global_config.private_app_hosting_domain,
             this.global_config.private_app_hosting_domain_alt,
         ] ) {
@@ -373,6 +406,53 @@ class AuthService extends BaseService {
         return cookieOptions;
     }
 
+    resolvePublicHostedActorCookieDomain ({ requestHostname } = {}) {
+        const configuredDomains = this.getConfiguredHostedCookieDomains();
+        const normalizedRequestHost = this.normalizeHostnameForCookieDomain(requestHostname);
+
+        if ( normalizedRequestHost ) {
+            const matchedConfiguredDomain = configuredDomains
+                .sort((domainA, domainB) => domainB.length - domainA.length)
+                .find(configuredDomain =>
+                    normalizedRequestHost === configuredDomain ||
+                    normalizedRequestHost.endsWith(`.${configuredDomain}`));
+            if ( this.isCookieDomainHostEligible(matchedConfiguredDomain) ) {
+                return `.${matchedConfiguredDomain}`;
+            }
+            return undefined;
+        }
+
+        const [firstConfiguredDomain] = configuredDomains;
+        if ( this.isCookieDomainHostEligible(firstConfiguredDomain) ) {
+            return `.${firstConfiguredDomain}`;
+        }
+        return undefined;
+    }
+
+    getPublicHostedActorCookieOptions ({ ttlSeconds, requestHostname } = {}) {
+        const effectiveTtlSeconds = this.resolvePositiveInteger(
+            ttlSeconds,
+            this.getPublicHostedActorTokenTtlSeconds(),
+        );
+
+        const cookieOptions = {
+            sameSite: 'none',
+            secure: true,
+            httpOnly: true,
+            path: '/',
+            maxAge: effectiveTtlSeconds * 1000,
+        };
+
+        const cookieDomain = this.resolvePublicHostedActorCookieDomain({
+            requestHostname,
+        });
+        if ( cookieDomain ) {
+            cookieOptions.domain = cookieDomain;
+        }
+
+        return cookieOptions;
+    }
+
     normalizePrivateAssetSubdomain (subdomain) {
         if ( typeof subdomain !== 'string' ) return undefined;
         const normalizedSubdomain = subdomain.trim().toLowerCase();
@@ -418,6 +498,45 @@ class AuthService extends BaseService {
             ...(sessionUuid ? { session: this.uuid_fpe.encrypt(sessionUuid) } : {}),
             ...(normalizedSubdomain ? { subdomain: normalizedSubdomain } : {}),
             ...(normalizedPrivateHost ? { private_host: normalizedPrivateHost } : {}),
+        };
+
+        return this.tokenService.sign('auth', payload, {
+            expiresIn: effectiveTtlSeconds,
+        });
+    }
+
+    createPublicHostedActorToken ({ appUid, userUid, sessionUuid, subdomain, host, ttlSeconds } = {}) {
+        if ( typeof appUid !== 'string' || !appUid.trim() ) {
+            throw new Error('appUid is required to create public hosted actor token.');
+        }
+        if ( typeof userUid !== 'string' || !userUid.trim() ) {
+            throw new Error('userUid is required to create public hosted actor token.');
+        }
+        if ( sessionUuid !== undefined && (typeof sessionUuid !== 'string' || !sessionUuid.trim()) ) {
+            throw new Error('sessionUuid must be a non-empty string when provided.');
+        }
+        const normalizedSubdomain = this.normalizePrivateAssetSubdomain(subdomain);
+        if ( subdomain !== undefined && !normalizedSubdomain ) {
+            throw new Error('subdomain must be a non-empty string when provided.');
+        }
+        const normalizedHost = this.normalizePrivateAssetHost(host);
+        if ( host !== undefined && !normalizedHost ) {
+            throw new Error('host must be a non-empty string when provided.');
+        }
+
+        const effectiveTtlSeconds = this.resolvePositiveInteger(
+            ttlSeconds,
+            this.getPublicHostedActorTokenTtlSeconds(),
+        );
+
+        const payload = {
+            type: 'app-public-hosted-actor',
+            version: '0.0.0',
+            app_uid: appUid.trim(),
+            user_uid: userUid.trim(),
+            ...(sessionUuid ? { session: this.uuid_fpe.encrypt(sessionUuid) } : {}),
+            ...(normalizedSubdomain ? { subdomain: normalizedSubdomain } : {}),
+            ...(normalizedHost ? { host: normalizedHost } : {}),
         };
 
         return this.tokenService.sign('auth', payload, {
@@ -510,6 +629,99 @@ class AuthService extends BaseService {
             sessionUuid,
             subdomain,
             privateHost,
+            exp: decoded.exp,
+            iat: decoded.iat,
+        };
+    }
+
+    verifyPublicHostedActorToken (
+        token,
+        { expectedAppUid, expectedUserUid, expectedSessionUuid, expectedSubdomain, expectedHost } = {},
+    ) {
+        let decoded;
+        try {
+            decoded = this.tokenService.verify('auth', token);
+        } catch (e) {
+            throw APIError.create('token_auth_failed');
+        }
+
+        if (
+            !decoded ||
+            decoded.type !== 'app-public-hosted-actor' ||
+            typeof decoded.app_uid !== 'string' ||
+            !decoded.app_uid ||
+            typeof decoded.user_uid !== 'string' ||
+            !decoded.user_uid
+        ) {
+            throw APIError.create('token_auth_failed');
+        }
+
+        let sessionUuid;
+        if ( decoded.session !== undefined ) {
+            if ( typeof decoded.session !== 'string' || !decoded.session ) {
+                throw APIError.create('token_auth_failed');
+            }
+            try {
+                sessionUuid = this.uuid_fpe.decrypt(decoded.session);
+            } catch (e) {
+                throw APIError.create('token_auth_failed');
+            }
+        }
+
+        let subdomain;
+        if ( decoded.subdomain !== undefined ) {
+            if ( typeof decoded.subdomain !== 'string' || !decoded.subdomain.trim() ) {
+                throw APIError.create('token_auth_failed');
+            }
+            subdomain = decoded.subdomain.trim().toLowerCase();
+        }
+
+        let host;
+        if ( decoded.host !== undefined ) {
+            if ( typeof decoded.host !== 'string' || !decoded.host.trim() ) {
+                throw APIError.create('token_auth_failed');
+            }
+            host = decoded.host.trim().toLowerCase();
+        }
+
+        if ( expectedAppUid && decoded.app_uid !== expectedAppUid ) {
+            throw APIError.create('token_auth_failed');
+        }
+        if ( expectedUserUid && decoded.user_uid !== expectedUserUid ) {
+            throw APIError.create('token_auth_failed');
+        }
+        if ( expectedSessionUuid ) {
+            if ( !sessionUuid || sessionUuid !== expectedSessionUuid ) {
+                throw APIError.create('token_auth_failed');
+            }
+        }
+
+        const normalizedExpectedSubdomain = this.normalizePrivateAssetSubdomain(expectedSubdomain);
+        if ( expectedSubdomain !== undefined && !normalizedExpectedSubdomain ) {
+            throw APIError.create('token_auth_failed');
+        }
+        if ( normalizedExpectedSubdomain ) {
+            if ( !subdomain || subdomain !== normalizedExpectedSubdomain ) {
+                throw APIError.create('token_auth_failed');
+            }
+        }
+
+        const normalizedExpectedHost = this.normalizePrivateAssetHost(expectedHost);
+        if ( expectedHost !== undefined && !normalizedExpectedHost ) {
+            throw APIError.create('token_auth_failed');
+        }
+        if ( normalizedExpectedHost ) {
+            if ( !host || host !== normalizedExpectedHost ) {
+                throw APIError.create('token_auth_failed');
+            }
+        }
+
+        return {
+            appUid: decoded.app_uid,
+            userUid: decoded.user_uid,
+            sessionUuid,
+            subdomain,
+            host,
             exp: decoded.exp,
             iat: decoded.iat,
         };

--- a/src/backend/src/services/auth/AuthService.privateAssetToken.test.ts
+++ b/src/backend/src/services/auth/AuthService.privateAssetToken.test.ts
@@ -8,6 +8,8 @@ type AuthServiceForPrivateTokenTests = AuthService & {
         private_app_asset_token_ttl_seconds: number;
         private_app_asset_cookie_name: string;
         app_origin_canonical_cache_ttl_seconds?: number;
+        public_hosted_actor_token_ttl_seconds?: number;
+        public_hosted_actor_cookie_name?: string;
         static_hosting_domain: string;
         static_hosting_domain_alt?: string;
         private_app_hosting_domain: string;
@@ -40,6 +42,8 @@ const createAuthService = (): AuthServiceForPrivateTokenTests => {
         private_app_asset_token_ttl_seconds: 3600,
         private_app_asset_cookie_name: 'puter.private.asset.token',
         app_origin_canonical_cache_ttl_seconds: 300,
+        public_hosted_actor_token_ttl_seconds: 900,
+        public_hosted_actor_cookie_name: 'puter.public.hosted.actor.token',
         static_hosting_domain: 'puter.site',
         static_hosting_domain_alt: 'puter.host',
         private_app_hosting_domain: 'app.puter.localhost',
@@ -181,6 +185,61 @@ describe('AuthService private asset token helpers', () => {
         expect(options.path).toBe('/');
         expect(options.maxAge).toBe(3_600_000);
         expect(options.domain).toBe('.app.puter.localhost');
+    });
+
+    it('creates and verifies public hosted actor tokens with expected claims', () => {
+        const authService = createAuthService();
+        const appUid = 'app-d18f4a26-1e9a-4e9d-89dd-d3476f9efab4';
+        const userUid = '1a8600ea-25a7-4ac6-95be-3a9f84e95f17';
+        const sessionUuid = 'f6bb30b0-f9d8-4bd6-94ea-0bfcf48e1ba8';
+        const subdomain = 'beans';
+        const host = 'beans.puter.dev';
+
+        const token = authService.createPublicHostedActorToken({
+            appUid,
+            userUid,
+            sessionUuid,
+            subdomain,
+            host,
+            ttlSeconds: 180,
+        });
+
+        const claims = authService.verifyPublicHostedActorToken(token, {
+            expectedAppUid: appUid,
+            expectedUserUid: userUid,
+            expectedSessionUuid: sessionUuid,
+            expectedSubdomain: subdomain,
+            expectedHost: host,
+        });
+
+        expect(claims.appUid).toBe(appUid);
+        expect(claims.userUid).toBe(userUid);
+        expect(claims.sessionUuid).toBe(sessionUuid);
+        expect(claims.subdomain).toBe(subdomain);
+        expect(claims.host).toBe(host);
+        expect(typeof claims.exp).toBe('number');
+    });
+
+    it('returns public hosted actor cookie options with matched hosted domain', () => {
+        const authService = createAuthService();
+        authService.global_config.static_hosting_domain = 'site.puter.localhost';
+        authService.global_config.static_hosting_domain_alt = 'site.puter.dev';
+        authService.global_config.private_app_hosting_domain = 'app.puter.localhost';
+        authService.global_config.private_app_hosting_domain_alt = 'puter.dev';
+        authService.global_config.public_hosted_actor_token_ttl_seconds = 1200;
+        authService.global_config.public_hosted_actor_cookie_name = 'puter.public.hosted.actor';
+
+        const options = authService.getPublicHostedActorCookieOptions({
+            requestHostname: 'beans.puter.dev',
+        });
+
+        expect(authService.getPublicHostedActorCookieName()).toBe('puter.public.hosted.actor');
+        expect(options.sameSite).toBe('none');
+        expect(options.secure).toBe(true);
+        expect(options.httpOnly).toBe(true);
+        expect(options.path).toBe('/');
+        expect(options.maxAge).toBe(1_200_000);
+        expect(options.domain).toBe('.puter.dev');
     });
 
     it('uses the matched request host private domain when provided', () => {


### PR DESCRIPTION
Adds non-blocking public hosted actor cookie mint/verify flow for non-private apps, sets actor context when available, and includes focused middleware/auth tests for security and performance-sensitive paths.