### PR TITLE
perf(core): LRU cache PuterHomepageService

### DIFF
--- a/src/backend/src/services/PuterHomepageService.js
+++ b/src/backend/src/services/PuterHomepageService.js
@@ -22,15 +22,22 @@ import { Endpoint } from '../util/expressutil.js';
 import { PathBuilder } from '../util/pathutil.js';
 import BaseService from './BaseService.js';
 import fs from 'node:fs';
+import { LRUCache } from 'lru-cache';
 /**
  * PuterHomepageService serves the initial HTML page that loads the Puter GUI
  * and all of its assets.
  */
 export class PuterHomepageService extends BaseService {
 
+    #outputCache = null;
+
     _construct () {
         this.service_scripts = [];
         this.gui_params = {};
+
+        this.#outputCache = new LRUCache({
+            max: 200,
+        });
     }
 
     /**
@@ -42,11 +49,13 @@ export class PuterHomepageService extends BaseService {
     async _init () {
         // Load manifest
         const config = this.global_config;
-        const manifest_raw = fs.readFileSync(PathBuilder
-            .add(config.assets.gui, { allow_traversal: true })
-            .add('puter-gui.json')
-            .build(),
-        'utf8');
+        const manifest_raw = fs.readFileSync(
+            PathBuilder
+                .add(config.assets.gui, { allow_traversal: true })
+                .add('puter-gui.json')
+                .build(),
+            'utf8',
+        );
         const manifest_data = JSON.parse(manifest_raw);
         this.manifest = manifest_data[config.assets.gui_profile];
     }
@@ -119,7 +128,29 @@ export class PuterHomepageService extends BaseService {
         // cloudflare turnstile site key
         const turnstileSiteKey = config.services?.['cloudflare-turnstile']?.enabled ? config.services?.['cloudflare-turnstile']?.site_key : null;
 
-        return res.send(await this.generate_puter_page_html({
+        const cacheKey = (() => {
+            const cacheKeyObject = {
+                ...(meta ? {
+                    title: meta.title,
+                    app_name: meta?.app?.name,
+                } : {}),
+            };
+            return JSON.stringify(
+                cacheKeyObject,
+                Object.keys(cacheKeyObject).sort(),
+            );
+        })();
+
+        // Possibly send cached output
+        {
+            const maybeCachedOutputHTML = this.#outputCache.get(cacheKey);
+            if ( maybeCachedOutputHTML ) {
+                res.send(maybeCachedOutputHTML);
+                return;
+            }
+        }
+
+        const outputHTML = await this.generate_puter_page_html({
             env: config.env,
 
             app_origin: config.origin,
@@ -161,7 +192,11 @@ export class PuterHomepageService extends BaseService {
                 captchaRequired: captchaRequired,
                 turnstileSiteKey: turnstileSiteKey,
             },
-        }));
+        });
+
+        this.#outputCache.set(cacheKey, outputHTML);
+
+        res.send(outputHTML);
     }
 
     async generate_puter_page_html ({
@@ -327,8 +362,8 @@ export class PuterHomepageService extends BaseService {
 
         <!-- Files from JSON (may be empty) -->
         ${((!bundled && manifest?.css_paths)
-            ? manifest.css_paths.map(path => `<link rel="stylesheet" href="${path}">\n`)
-            : []).join('')
+                ? manifest.css_paths.map(path => `<link rel="stylesheet" href="${path}">\n`)
+                : []).join('')
         }
         <!-- END Files from JSON -->
 


### PR DESCRIPTION
LRU cache the output of PuterHomepageService with a cache key based on metadata that affects the output of the homepage (if an app was specified, and if so what app was specified).

With this change in place we can afford more time processing this output, for example to minify the output and reduce outbound bandwidth.