### PR TITLE
devex(core): avoid email verification on dev

### DIFF
--- a/src/backend/src/services/CleanEmailService.js
+++ b/src/backend/src/services/CleanEmailService.js
@@ -152,6 +152,8 @@ class CleanEmailService extends BaseService {
     * set event.allow=false to reject the email.
     */
     async validate (email) {
+        if ( this?.global_config?.env === 'dev' ) return true;
+
         email = this.clean(email);
         const config = this.global_config;
 


### PR DESCRIPTION
Add guards to check if `env` in the backend configuration is set to `'dev'`. When it is set to `'dev'`, do not invoke email verification extensions.