### PR TITLE
feat(puter-js): add Batch builder class

### DIFF
--- a/src/puter-js/src/modules/FileSystem/Batch.js
+++ b/src/puter-js/src/modules/FileSystem/Batch.js
@@ -1,0 +1,51 @@
+export default puter => class Batch {
+    constructor () {
+        this.form = new FormData();
+        this.operations = [];
+    }
+
+    move (source, destination, new_name) {
+        this.operations.push({
+            op: 'move',
+            source,
+            destination,
+            new_name,
+        });
+        return this; // for chaining
+    }
+
+    // alias for `delete`
+    rm (...a) {
+        return this.delete(...a);
+    }
+
+    delete (...paths) {
+        for ( const path of paths ) {
+            this.operations.push({
+                op: 'delete',
+                path,
+            });
+        }
+    }
+
+    async send () {
+        // Prepare Form
+        for ( const operation of this.operations ) {
+            this.form.append('operation', JSON.stringify(operation));
+        }
+
+        // Send Request
+        const res = await fetch(`${puter.APIOrigin}/batch`, {
+            headers: {
+                Authorization: `Bearer ${puter.authToken}`,
+                ...(['web', 'app'].includes(puter.env) ? {
+                    Origin: 'https://puter.work',
+                } : {}),
+            },
+            method: 'POST',
+            body: this.form,
+        });
+
+        return (await res.json())?.results;
+    }
+};

--- a/src/puter-js/src/modules/FileSystem/index.js
+++ b/src/puter-js/src/modules/FileSystem/index.js
@@ -9,6 +9,7 @@ const LAST_VALID_TS = 'last_valid_ts';
 
 // Operations
 import FSItem from '../FSItem.js';
+import Batch from './Batch.js';
 import copy from './operations/copy.js';
 import deleteFSEntry from './operations/deleteFSEntry.js';
 import getReadURL from './operations/getReadUrl.js';
@@ -60,6 +61,7 @@ export class PuterJSFileSystemModule {
      */
     constructor (puter) {
         this.puter = puter;
+        this.Batch = Batch(puter);
         this.authToken = puter.authToken;
         this.APIOrigin = puter.APIOrigin;
         this.appID = puter.appID;


### PR DESCRIPTION
Usage example:

```javascript
  const b = new puter.fs.Batch();
  b.move('file_1.txt', '~/Trash');
  b.move('file_2.txt', '~/Trash');
  await b.end();
```

Chaining is also supported:
```javascript
  await new puter.fs.Batch()
    .move('file_1.txt', '~/Trash')
    .move('file_2.txt', '~/Trash')
    .end();
```

This commit provides `move` and `delete` methods for Batch.