### PR TITLE
fix coercion service not selecting correct rule

### DIFF
--- a/src/backend/src/services/drivers/CoercionService.js
+++ b/src/backend/src/services/drivers/CoercionService.js
@@ -66,11 +66,13 @@ class CoercionService extends BaseService {
             coerce: async typed_value => {
                 console.debug('coercion is running!');
 
-                const response = await secureAxiosRequest(CoercionService.MODULES.axios,
-                                typed_value.value,
-                                {
-                                    responseType: 'stream',
-                                });
+                const response = await secureAxiosRequest(
+                    CoercionService.MODULES.axios,
+                    typed_value.value,
+                    {
+                        responseType: 'stream',
+                    },
+                );
 
                 return new TypedValue({
                     $: 'stream',
@@ -89,11 +91,13 @@ class CoercionService extends BaseService {
                 content_type: 'video',
             },
             coerce: async typed_value => {
-                const response = await secureAxiosRequest(CoercionService.MODULES.axios,
-                                typed_value.value,
-                                {
-                                    responseType: 'stream',
-                                });
+                const response = await secureAxiosRequest(
+                    CoercionService.MODULES.axios,
+                    typed_value.value,
+                    {
+                        responseType: 'stream',
+                    },
+                );
 
                 return new TypedValue({
                     $: 'stream',
@@ -172,7 +176,7 @@ class CoercionService extends BaseService {
             return coerced;
         }
 
-        return typed_value;
+        return undefined;
     }
 }
 

--- a/src/backend/src/services/drivers/DriverService.js
+++ b/src/backend/src/services/drivers/DriverService.js
@@ -182,11 +182,15 @@ class DriverService extends BaseService {
                 col_types.set(k, types[k]);
             }
         }
-        await services.emit('driver.register.interfaces',
-                        { col_interfaces });
+        await services.emit(
+            'driver.register.interfaces',
+            { col_interfaces },
+        );
 
-        await services.emit('driver.register.drivers',
-                        { col_drivers });
+        await services.emit(
+            'driver.register.drivers',
+            { col_drivers },
+        );
     }
 
     // This is a bit meta: we register the "driver" driver interface.
@@ -421,8 +425,10 @@ class DriverService extends BaseService {
         }
 
         const svc_permission = this.services.get('permission');
-        const reading = await svc_permission.scan(actor,
-                        PermissionUtil.join('service', service_name, 'ii', iface));
+        const reading = await svc_permission.scan(
+            actor,
+            PermissionUtil.join('service', service_name, 'ii', iface),
+        );
         const options = PermissionUtil.reading_to_options(reading);
         if ( options.length <= 0 ) {
             throw APIError.create('forbidden');
@@ -480,9 +486,11 @@ class DriverService extends BaseService {
                         const svc_rateLimit = this.services.get('rate-limit');
 
                         await svc_su.sudo(policy_holder, async () => {
-                            await svc_rateLimit.check_and_increment(`V1:${service_name}:${iface}:${method}`,
-                                            effective_policy['rate-limit'].max,
-                                            effective_policy['rate-limit'].period);
+                            await svc_rateLimit.check_and_increment(
+                                `V1:${service_name}:${iface}:${method}`,
+                                effective_policy['rate-limit'].max,
+                                effective_policy['rate-limit'].period,
+                            );
                         });
                         return args;
                     },
@@ -519,7 +527,10 @@ class DriverService extends BaseService {
                                     : method_spec.result.type
                                     ;
                             const svc_coercion = this.services.get('coercion');
-                            result = await svc_coercion.coerce(desired_type, result);
+                            const coerced = await svc_coercion.coerce(desired_type, result);
+                            if ( coerced ) {
+                                result = coerced;
+                            }
                         }
                         return result;
                     },


### PR DESCRIPTION
currently coerce method always returns a value even when no coercion is found. this causes a "string:url:data" type result to run through a "string:url:web -> stream" coercion instead of the intended "string:url:data -> stream", resulting in issues such as undefined content_type and passing a base64 data url into the web url processing logic. 
changed the method to return undefined in case no valid coercion was found and to allow it to try others.

side note: TypeSpec.equals() only checks the base value ($) ignoring content_type. this means a content_type: video result can get routed through a content_type: image rule. this doesn't break anything right now as they're almost the same, but something to keep in mind.
https://github.com/HeyPuter/puter/blob/87672802fe3b0bc7b4052b9c1b892798556458b6/src/backend/src/services/drivers/meta/Construct.js#L156-L168