### PR TITLE
fix flash image quality level

### DIFF
--- a/src/backend/src/services/ai/image/providers/GeminiImageGenerationProvider/models.ts
+++ b/src/backend/src/services/ai/image/providers/GeminiImageGenerationProvider/models.ts
@@ -31,7 +31,7 @@ export const GEMINI_ESTIMATED_IMAGE_TOKENS: Record<string, number> = {
     'gemini-3-pro-image-preview:2K': 1120,
     'gemini-3-pro-image-preview:4K': 2000,
 
-    'gemini-3.1-flash-image-preview:0.5K': 747,
+    'gemini-3.1-flash-image-preview:512': 747,
     'gemini-3.1-flash-image-preview:1K': 1120,
     'gemini-3.1-flash-image-preview:2K': 1680,
     'gemini-3.1-flash-image-preview:4K': 2520,
@@ -124,7 +124,7 @@ export const GEMINI_IMAGE_GENERATION_MODELS: IImageModel[] = [
             'google/gemini-3.1-flash-image',
             'google:google/gemini-3.1-flash-image-preview',
         ],
-        allowedQualityLevels: ['0.5K', '1K', '2K', '4K'],
+        allowedQualityLevels: ['512', '1K', '2K', '4K'],
         allowedRatios: [
             { w: 1, h: 1 },
             { w: 1, h: 4 },


### PR DESCRIPTION
missed this in my last pr
turns out it's 512 not 0.5K for flash image 3.1 quality level
https://ai.google.dev/gemini-api/docs/image-generation#use-14-images -> click "Python"
currently causes "Request contains an invalid argument" when requesting 0.5K (default)
```js
puter.ai.txt2img('generate an image', options= {
    model: "google:google/gemini-3.1-flash-image-preview",
})
```
other quality levels are unaffected and work as intended
not able to verify this locally as i don't have a gemini key but i assume we can trust gemini docs