### PR TITLE
fix: remove double slash in docs canonical link

### DIFF
--- a/src/docs/build.js
+++ b/src/docs/build.js
@@ -273,7 +273,7 @@ function generateDocsHTML (filePath, rootDir, page, isIndex = false) {
         html += `<meta name="title" content="${removeTags(page.title_tag ?? page.title)}" />`;
     }
     // Self referencing canonical
-    html += `<link rel="canonical" href="${new URL(page.path, site).href}/">`;
+    html += `<link rel="canonical" href="${new URL(page.path, site).href.replace(/\/$/, '')}/">`;
     // Viewport
     html += '<meta name="viewport" content="width=device-width, initial-scale=1.0">';
     // Description


### PR DESCRIPTION
## Problem

The canonical link tag in generated docs pages produces a double slash for the index page:

```
https://docs.puter.com//
```

This happens because `new URL(page.path, site).href` already returns `https://docs.puter.com/` (with trailing slash) when `page.path` is `/`, and then another `/` is appended.

## Fix

Strip any trailing slash from `.href` before appending the normalized trailing slash, so every URL gets exactly one.

Fixes #2672