### PR TITLE
Fix double slash in canonical URL #2672

### DIFF
--- a/src/docs/build.js
+++ b/src/docs/build.js
@@ -273,7 +273,11 @@ function generateDocsHTML (filePath, rootDir, page, isIndex = false) {
         html += `<meta name="title" content="${removeTags(page.title_tag ?? page.title)}" />`;
     }
     // Self referencing canonical
-    html += `<link rel="canonical" href="${new URL(page.path, site).href}/">`;
+    let canonicalUrl = new URL(page.path, site).href;
+    if (!canonicalUrl.endsWith('/')) {
+        canonicalUrl += '/';
+    }
+    html += `<link rel="canonical" href="${canonicalUrl}">`;
     // Viewport
     html += '<meta name="viewport" content="width=device-width, initial-scale=1.0">';
     // Description


### PR DESCRIPTION
Fixes #2672 

### Description
This pull request fixes a minor structural issue in the Puter.js documentation where the `<link rel="canonical">` tag was generating a double slash `//` at the end of the root URL (`https://docs.puter.com//`).

###solution
The metadata builder (`src/docs/build.js`) previously made an assumption that the underlying URL would not have a trailing slash and blindly appended one via string concatenation (`/">`). Because Node.js's `URL` constructor evaluates the root index automatically with a trailing slash resulting in `https://docs.puter.com/`, the manual string concatenation triggered the double slash. 

This commit updates the canonical tag string interpolation to dynamically check if the URL already resolves ending with `/`, ensuring exactly one trailing slash across both root and sub-pages.
