### PR TITLE
docs: fix 404 in CreateAppResult documentation due to case sensitivity

### DIFF
--- a/src/docs/src/Objects/createappresult.md
+++ b/src/docs/src/Objects/createappresult.md
@@ -3,7 +3,7 @@ title: CreateAppResult
 description: The CreateAppResult object containing puter.apps.create() result.
 ---
 
-The `CreateAppResult` object containing [`puter.apps.create()`](/apps/create/) result.
+The `CreateAppResult` object containing [`puter.apps.create()`](/Apps/create/) result.
 
 ## Attributes
 


### PR DESCRIPTION
### Summary
This PR fixes a 404 error in the documentation reported at `https://docs.puter.com/Objects/createappresult/`. The error was caused by a case-sensitivity mismatch where a link pointed to `/apps/create/` (lowercase), but the canonical path defined in the sidebar is `/Apps/create/` (Uppercase 'A').

### Changes
*   Modified [src/docs/src/Objects/createappresult.md](cci:7://file:///home/huseynvovvusal/Documents/Open%20Source/puter/src/docs/src/Objects/createappresult.md:0:0-0:0) to update the link for `puter.apps.create()` to use the correct casing (`/Apps/create/`).

### Verification
*   Performed a search across documentation files to ensure other top-level category links (e.g., `/FS/`, `/Auth/`, `/AI/`) are correctly cased.
*   Verified the fix manually by confirming the correct link path in the source file.

_Closes #2692_
