### PR TITLE
docs: add ai-voice-changer playground example

### DIFF
--- a/src/docs/src/examples.js
+++ b/src/docs/src/examples.js
@@ -170,6 +170,12 @@ const examples = [
                 source: '/playground/examples/ai-txt2speech-elevenlabs.html',
             },
             {
+                title: 'Voice Changer',
+                description: 'Swap a sample clip into a new voice using Puter.js AI speech-to-speech helpers.',
+                slug: 'ai-voice-changer',
+                source: '/playground/examples/ai-voice-changer.html',
+            },
+            {
                 title: 'ElevenLabs Voice changer with a sample clip',
                 description: 'Transform an audio clip into a new voice using Puter.js speech-to-speech helper.',
                 slug: 'ai-speech2speech-url',

--- a/src/docs/src/playground/examples/ai-voice-changer.html
+++ b/src/docs/src/playground/examples/ai-voice-changer.html
@@ -1,0 +1,19 @@
+<html>
+<body>
+    <script src="https://js.puter.com/v2/"></script>
+    <button id="swap">Convert voice</button>
+    <script>
+        document.getElementById('swap').addEventListener('click', async ()=>{
+            const audio = await puter.ai.speech2speech(
+                'https://puter-sample-data.puter.site/tts_example.mp3',
+                {
+                    voice: '21m00Tcm4TlvDq8ikWAM',
+                    model: 'eleven_multilingual_sts_v2',
+                    output_format: 'mp3_44100_128'
+                }
+            );
+            audio.play();
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
This fixes the missing `ai-voice-changer` playground route referenced from the AI docs.

## Root cause
`AI.md` referenced the `ai-voice-changer` playground slug, but the docs playground registry had no matching entry, so the Run button resolved to a 404.

## Changes
- add `ai-voice-changer` example source
- register `ai-voice-changer` in docs playground examples

## Verification
- `npm ci`
- `npm --prefix src/docs run build`
- local HTTP check for `/AI/`
- local HTTP check for `/playground/ai-voice-changer/`
- local HTTP check for `/playground/ai-speech2speech-url/`
- local HTTP check for `/playground/ai-speech2speech-file/`

Closes #2693