### PR TITLE
fix case sensitive together video model ids

### DIFF
--- a/src/backend/src/services/ai/video/providers/TogetherVideoGenerationProvider/TogetherVideoGenerationProvider.ts
+++ b/src/backend/src/services/ai/video/providers/TogetherVideoGenerationProvider/TogetherVideoGenerationProvider.ts
@@ -90,8 +90,8 @@ export class TogetherVideoGenerationProvider implements IVideoProvider {
             });
         }
 
-        const model = this.#stripTogetherPrefix(requestedModel ?? DEFAULT_MODEL);
         const selectedModel = await this.#getModel(requestedModel);
+        const model = selectedModel?.model ?? this.#stripTogetherPrefix(requestedModel ?? DEFAULT_MODEL);
 
         if ( testMode ) {
             return new TypedValue({


### PR DESCRIPTION
together video errors on lowercase model ids, changed to keep the same case as in models.ts
tested on a real key returning 400 before this and 402 (valid model but no balance on my key) after
closes #2724 
