### PR TITLE
Display logged-in banner on homepage

### DIFF
--- a/src/backend/src/routers/_default.js
+++ b/src/backend/src/routers/_default.js
@@ -25,8 +25,7 @@ const _fs = require('fs');
 const { Context } = require('../util/context');
 const { DB_READ } = require('../services/database/consts');
 const { PathBuilder } = require('../util/pathutil.js');
-
-let auth_user;
+const { jwt_auth, get_app, invalidate_cached_user } = require('../helpers');
 
 // Helper function to safely handle metadata parsing
 const parseMetadata = (metadata) => {
@@ -59,8 +58,18 @@ const parseMetadata = (metadata) => {
 // All other requests
 // -----------------------------------------------------------------------//
 router.all('*', async function (req, res, next) {
+    const authService = Context.get('services').get('auth');
+
     const subdomain = req.hostname.slice(0, -1 * (config.domain.length + 1));
     let path = req.params[0] ? req.params[0] : 'index.html';
+    let auth_user;
+    // TODO DS: we should just do this as a middleware for every request, and check all possible types of auth
+    try {
+        auth_user = (await jwt_auth(req, authService))?.user;
+    }
+    catch (e) {
+        // no-op
+    }
 
     // --------------------------------------
     // API
@@ -113,7 +122,6 @@ router.all('*', async function (req, res, next) {
     }
 
     const db = Context.get('services').get('database').get(DB_READ, 'default');
-    const authService = Context.get('services').get('auth');
 
     // --------------------------------------
     // POST to login/signup/logout
@@ -133,21 +141,6 @@ router.all('*', async function (req, res, next) {
     // No subdomain: either GUI or landing pages
     // --------------------------------------
     else if ( subdomain === '' ) {
-        // auth
-        const { jwt_auth, get_app, invalidate_cached_user } = require('../helpers');
-        let authed = false;
-        try {
-            try {
-                auth_user = await jwt_auth(req, authService);
-                auth_user = auth_user.user;
-                authed = true;
-            } catch (e) {
-                authed = false;
-            }
-        }
-        catch (e) {
-            authed = false;
-        }
 
         if ( path === '/robots.txt' ) {
             res.set('Content-Type', 'text/plain');

--- a/src/backend/src/routers/_default.js
+++ b/src/backend/src/routers/_default.js
@@ -391,7 +391,7 @@ router.all('*', async function (req, res, next) {
             // index.js
             if ( path === '/' ) {
                 const svc_puterHomepage = Context.get('services').get('puter-homepage');
-                return svc_puterHomepage.send({ req, res }, {
+                return svc_puterHomepage.send({ req, res, auth_user }, {
                     title: app_title,
                     description: app_description || config.short_description,
                     short_description: app_description || config.short_description,

--- a/src/backend/src/services/PuterHomepageService.js
+++ b/src/backend/src/services/PuterHomepageService.js
@@ -154,6 +154,8 @@ export class PuterHomepageService extends BaseService {
         const logged_in_user = auth_user || null;
 
         const outputHTML = await this.generate_puter_page_html({
+            path: req.path,
+
             env: config.env,
 
             app_origin: config.origin,
@@ -213,6 +215,7 @@ export class PuterHomepageService extends BaseService {
     }
 
     async generate_puter_page_html ({
+        path,
         env,
         manifest,
         gui_path: _gui_path,
@@ -283,32 +286,15 @@ export class PuterHomepageService extends BaseService {
 
         // emit extension event
         const event = {
+            path: path,
             bodyContent: '',
             headContent: '',
+            logged_in_user: logged_in_user,
             guiParams: {
                 ...gui_params,
             },
         };
         await eventService.emit('puter.gui.addons', event);
-        const logged_in_banner = logged_in_user ? `
-        <div id="logged-in-banner" style="
-            position: fixed;
-            top: 0;
-            left: 0;
-            width: 100%;
-            z-index: 999999;
-            background: linear-gradient(135deg, #2f70ab, #4a90d9);
-            color: white;
-            text-align: center;
-            padding: 16px 20px;
-            font-family: 'Inter', 'Helvetica Neue', HelveticaNeue, Helvetica, Arial, sans-serif;
-            font-size: 18px;
-            font-weight: 600;
-            box-shadow: 0 2px 10px rgba(0,0,0,0.2);
-            letter-spacing: 0.3px;
-        ">
-            Logged in as ${encode(logged_in_user.username)}
-        </div>` : '';
 
         return `<!DOCTYPE html>
     <html lang="en">
@@ -415,8 +401,6 @@ export class PuterHomepageService extends BaseService {
     </head>
 
     <body>
-
-        ${logged_in_banner}
 
         <!-- Custom body content to be added to the homepage by extensions -->
         ${event.bodyContent || ''}

--- a/src/backend/src/services/PuterHomepageService.js
+++ b/src/backend/src/services/PuterHomepageService.js
@@ -97,7 +97,7 @@ export class PuterHomepageService extends BaseService {
     /**
     * This method sends the initial HTML page that loads the Puter GUI and its assets.
     */
-    async send ({ req, res }, meta, launch_options) {
+    async send ({ req, res, auth_user }, meta, launch_options) {
         const config = this.global_config;
 
         if (
@@ -150,6 +150,9 @@ export class PuterHomepageService extends BaseService {
             }
         }
 
+        // Check if user is logged in
+        const logged_in_user = auth_user || null;
+
         const outputHTML = await this.generate_puter_page_html({
             env: config.env,
 
@@ -165,6 +168,9 @@ export class PuterHomepageService extends BaseService {
 
             // launch options
             launch_options,
+
+            // logged-in user info
+            logged_in_user,
 
             // gui parameters
             gui_params: {
@@ -215,6 +221,7 @@ export class PuterHomepageService extends BaseService {
         api_origin,
         meta,
         launch_options,
+        logged_in_user,
         gui_params,
     }) {
 
@@ -283,6 +290,26 @@ export class PuterHomepageService extends BaseService {
             },
         };
         await eventService.emit('puter.gui.addons', event);
+        const logged_in_banner = logged_in_user ? `
+        <div id="logged-in-banner" style="
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            z-index: 999999;
+            background: linear-gradient(135deg, #2f70ab, #4a90d9);
+            color: white;
+            text-align: center;
+            padding: 16px 20px;
+            font-family: 'Inter', 'Helvetica Neue', HelveticaNeue, Helvetica, Arial, sans-serif;
+            font-size: 18px;
+            font-weight: 600;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.2);
+            letter-spacing: 0.3px;
+        ">
+            Logged in as ${encode(logged_in_user.username)}
+        </div>` : '';
+
         return `<!DOCTYPE html>
     <html lang="en">
 
@@ -388,7 +415,9 @@ export class PuterHomepageService extends BaseService {
     </head>
 
     <body>
-    
+
+        ${logged_in_banner}
+
         <!-- Custom body content to be added to the homepage by extensions -->
         ${event.bodyContent || ''}
         <!-- END Custom body content -->


### PR DESCRIPTION
Pass auth_user from the router into PuterHomepageService and show a logged-in banner when a user is present. _default.js now includes auth_user in the svc_puterHomepage.send call. PuterHomepageService.send signature was updated to accept auth_user; the service stores logged_in_user, forwards it to generate_puter_page_html, and injects a styled "Logged in as <username>" banner into the top of the page when available. This surfaces the current user on the GUI and exposes logged_in_user to page generation and addons.