### PR TITLE
Feature/group by kind

### DIFF
--- a/docker-compose.yml.1
+++ b/docker-compose.yml.1
@@ -1,0 +1,25 @@
+---
+version: "3.8"
+services:
+  puter:
+    container_name: puter
+    image: ghcr.io/heyputer/puter:latest
+    pull_policy: always
+    # build: ./
+    restart: unless-stopped
+    ports:
+      - '4100:4100'
+    environment:
+      # TZ: Europe/Paris
+      # CONFIG_PATH: /etc/puter
+      PUID: 1000
+      PGID: 1000
+    volumes:
+      - ./puter/config:/etc/puter
+      - ./puter/data:/var/puter
+    healthcheck:
+      test: wget --no-verbose --tries=1 --spider http://puter.localhost:4100/test || exit 1
+      interval: 30s
+      timeout: 3s
+      retries: 3
+      start_period: 30s

--- a/src/backend/src/helpers.js
+++ b/src/backend/src/helpers.js
@@ -855,6 +855,7 @@ export async function uuid2fsentry (uuid, return_thumbnail) {
             is_shortcut,
             shortcut_to,
             sort_by,
+            group_by_kind,
             ${return_thumbnail ? 'thumbnail,' : ''}
             immutable,
             name,
@@ -903,6 +904,7 @@ export async function id2fsentry (id, return_thumbnail) {
             is_shortcut,
             shortcut_to,
             sort_by,
+            group_by_kind,
             ${return_thumbnail ? 'thumbnail,' : ''}
             immutable,
             name,
@@ -1286,6 +1288,7 @@ async function getDescendantsHelper (path, user, depth, return_thumbnail = false
             accessed: children[i].accessed,
             size: children[i].size,
             sort_by: children[i].sort_by,
+            group_by_kind: children[i].group_by_kind,
             thumbnail: children[i].thumbnail,
             associated_app_id: children[i].associated_app_id,
             type: contentType ? contentType : null,

--- a/src/backend/src/routers/set_group_by_kind.js
+++ b/src/backend/src/routers/set_group_by_kind.js
@@ -1,0 +1,64 @@
+'use strict';
+const express = require('express');
+const router = express.Router();
+const auth = require('../middleware/auth.js');
+const config = require('../config');
+const { DB_WRITE } = require('../services/database/consts.js');
+
+// -----------------------------------------------------------------------//
+// POST /set_group_by_kind
+// -----------------------------------------------------------------------//
+router.post('/set_group_by_kind', auth, express.json(), async (req, res, next) => {
+    // check subdomain
+    if ( require('../helpers').subdomain(req) !== 'api' ) {
+        next();
+    }
+
+    // check if user is verified
+    if ( (config.strict_email_verification_required || req.user.requires_email_confirmation) && !req.user.email_confirmed ) {
+        return res.status(400).send({ code: 'account_is_not_verified', message: 'Account is not verified' });
+    }
+
+    // validation
+    if ( req.body.item_uid === undefined ) {
+        return res.status(400).send('`item_uid` is required');
+    }
+    if ( req.body.group_by_kind === undefined ) {
+        return res.status(400).send('`group_by_kind` is required');
+    }
+    if ( req.body.group_by_kind !== true && req.body.group_by_kind !== false ) {
+        return res.status(400).send('`group_by_kind` must be a boolean');
+    }
+
+    // modules
+    const db = req.services.get('database').get(DB_WRITE, 'ui');
+    const { uuid2fsentry, chkperm } = require('../helpers');
+
+    // get dir
+    const item = await uuid2fsentry(req.body.item_uid);
+
+    // item not found
+    if ( item === false ) {
+        return res.status(400).send({ error: { message: 'No entry found with this uid' } });
+    }
+
+    // must be dir
+    if ( ! item.is_dir ) {
+        return res.status(400).send('must be a directory');
+    }
+
+    // check permission
+    if ( ! await chkperm(item, req.user.id, 'write') ) {
+        return res.status(403).send({ code: 'forbidden', message: 'permission denied.' });
+    }
+
+    // save group_by_kind
+    await db.write(
+        'UPDATE fsentries SET group_by_kind = ? WHERE id = ?',
+        [req.body.group_by_kind ? 1 : 0, item.id],
+    );
+
+    return res.send({});
+});
+
+module.exports = router;

--- a/src/backend/src/routers/set_sort_by.js
+++ b/src/backend/src/routers/set_sort_by.js
@@ -48,7 +48,7 @@ router.post('/set_sort_by', auth, express.json(), async (req, res, next) => {
     {
         return res.status(400).send('`sort_by` is required');
     }
-    else if ( req.body.sort_by !== 'name' && req.body.sort_by !== 'size' && req.body.sort_by !== 'modified' && req.body.sort_by !== 'type' )
+    else if ( req.body.sort_by !== 'name' && req.body.sort_by !== 'size' && req.body.sort_by !== 'modified' && req.body.sort_by !== 'type' && req.body.sort_by !== 'kind' )
     {
         return res.status(400).send('invalid `sort_by`');
     }
@@ -94,12 +94,16 @@ router.post('/set_sort_by', auth, express.json(), async (req, res, next) => {
     }
 
     // set sort_by
-    await db.write('UPDATE fsentries SET sort_by = ? WHERE id = ?',
-                    [req.body.sort_by, item.id]);
+    await db.write(
+        'UPDATE fsentries SET sort_by = ? WHERE id = ?',
+        [req.body.sort_by, item.id],
+    );
 
     // set sort_order
-    await db.write('UPDATE fsentries SET sort_order = ? WHERE id = ?',
-                    [req.body.sort_order, item.id]);
+    await db.write(
+        'UPDATE fsentries SET sort_order = ? WHERE id = ?',
+        [req.body.sort_order, item.id],
+    );
 
     // send results to client
     return res.send({});

--- a/src/backend/src/services/PuterAPIService.js
+++ b/src/backend/src/services/PuterAPIService.js
@@ -56,6 +56,7 @@ import setDesktopBackgroundRouter from '../routers/set-desktop-bg.js';
 import setPassUsingTokenRouter from '../routers/set-pass-using-token.js';
 import setLayoutRouter from '../routers/set_layout.js';
 import setSortByRouter from '../routers/set_sort_by.js';
+import setGroupByKindRouter from '../routers/set_group_by_kind.js';
 import signRouter from '../routers/sign.js';
 import signupRouter from '../routers/signup.js';
 import suggestAppsRouter from '../routers/suggest_apps.js';
@@ -125,6 +126,7 @@ export class PuterAPIService extends BaseService {
         app.use(setPassUsingTokenRouter);
         app.use(setLayoutRouter);
         app.use(setSortByRouter);
+        app.use(setGroupByKindRouter);
         app.use(signRouter);
         app.use(signupRouter);
         app.use(suggestAppsRouter);

--- a/src/backend/src/services/database/sqlite_setup/0047_add_group_by_kind.sql
+++ b/src/backend/src/services/database/sqlite_setup/0047_add_group_by_kind.sql
@@ -1,0 +1,1 @@
+ALTER TABLE fsentries ADD COLUMN `group_by_kind` INTEGER DEFAULT 0;

--- a/src/gui/src/IPC.js
+++ b/src/gui/src/IPC.js
@@ -1506,6 +1506,17 @@ const ipc_listener = async (event, handled) => {
             $(`.item-container[data-path="${html_encode(path.dirname(target_path))}" i]`).each(function () {
                 window.sort_items(this, $(this).attr('data-sort_by'), $(this).attr('data-sort_order'));
             });
+            // re-apply group by kind if active
+            $(`.item-container[data-path="${html_encode(path.dirname(target_path))}" i]`).each(function () {
+                if ( $(this).attr('data-sort_by') === 'kind' ) {
+                    window.group_items_by_kind(this);
+                }
+            });
+
+            // sort or group each window
+            $(`.item-container[data-path="${html_encode(path.dirname(target_path))}" i]`).each(function () {
+                window.sort_or_group_items(this);
+            });
             $(el_filedialog_window).close();
             window.show_save_account_notice_if_needed();
         };

--- a/src/gui/src/UI/UIWindow.js
+++ b/src/gui/src/UI/UIWindow.js
@@ -2510,6 +2510,8 @@ async function UIWindow (options) {
                             html: i18n('name'),
                             icon: $(el_window).attr('data-sort_by') === 'name' ? '✓' : '',
                             onClick: async function () {
+                                $(el_window).attr('data-group_by_kind', 'false');
+                                $(el_window_body).find('.group-by-kind-header').remove();
                                 window.sort_items(el_window_body, 'name', $(el_window).attr('data-sort_order'));
                                 window.set_sort_by($(el_window).attr('data-uid'), 'name', $(el_window).attr('data-sort_order'));
                             },
@@ -2518,6 +2520,8 @@ async function UIWindow (options) {
                             html: i18n('date_modified'),
                             icon: $(el_window).attr('data-sort_by') === 'modified' ? '✓' : '',
                             onClick: async function () {
+                                $(el_window).attr('data-group_by_kind', 'false');
+                                $(el_window_body).find('.group-by-kind-header').remove();
                                 window.sort_items(el_window_body, 'modified', $(el_window).attr('data-sort_order'));
                                 window.set_sort_by($(el_window).attr('data-uid'), 'modified', $(el_window).attr('data-sort_order'));
                             },
@@ -2526,6 +2530,8 @@ async function UIWindow (options) {
                             html: i18n('type'),
                             icon: $(el_window).attr('data-sort_by') === 'type' ? '✓' : '',
                             onClick: async function () {
+                                $(el_window).attr('data-group_by_kind', 'false');
+                                $(el_window_body).find('.group-by-kind-header').remove();
                                 window.sort_items(el_window_body, 'type', $(el_window).attr('data-sort_order'));
                                 window.set_sort_by($(el_window).attr('data-uid'), 'type', $(el_window).attr('data-sort_order'));
                             },
@@ -2534,8 +2540,29 @@ async function UIWindow (options) {
                             html: i18n('size'),
                             icon: $(el_window).attr('data-sort_by') === 'size' ? '✓' : '',
                             onClick: async function () {
+                                $(el_window).attr('data-group_by_kind', 'false');
+                                $(el_window_body).find('.group-by-kind-header').remove();
                                 window.sort_items(el_window_body, 'size', $(el_window).attr('data-sort_order'));
                                 window.set_sort_by($(el_window).attr('data-uid'), 'size', $(el_window).attr('data-sort_order'));
+                            },
+                        },
+                        {
+                            html: 'Group by Kind',
+                            icon: $(el_window).attr('data-group_by_kind') === 'true' ? '✓' : '',
+                            onClick: async function () {
+                                const item_uid = $(el_window).attr('data-uid');
+                                const is_grouped = $(el_window).attr('data-group_by_kind') === 'true';
+                                if ( is_grouped ) {
+                                    $(el_window).attr('data-group_by_kind', 'false');
+                                    $(el_window_body).find('.group-by-kind-header').remove();
+                                    window.sort_items(el_window_body, 'name', $(el_window).attr('data-sort_order'));
+                                    if ( item_uid ) window.set_sort_by(item_uid, 'name', $(el_window).attr('data-sort_order'));
+                                } else {
+                                    $(el_window).attr('data-group_by_kind', 'true');
+                                    $(el_window).attr('data-sort_by', 'kind');
+                                    window.group_items_by_kind(el_window_body);
+                                    if ( item_uid ) window.set_sort_by(item_uid, 'kind', $(el_window).attr('data-sort_order'));
+                                }
                             },
                         },
                         // -------------------------------------------
@@ -3886,9 +3913,8 @@ window.set_sort_by = function (item_uid, sort_by, sort_order) {
                 window.logout();
             },
         },
-        success: function () {
-        },
     });
+
     // update the sort_by & sort_order attr of every matching element
     $(`[data-uid="${item_uid}"]`).attr({
         'data-sort_by': sort_by,

--- a/src/gui/src/css/style.css
+++ b/src/gui/src/css/style.css
@@ -5783,3 +5783,16 @@ html.dark-mode .usage-table-show-less:hover {
     height: 100%;
     width: 100%;
 }
+/* Group by Kind headers */
+.group-by-kind-header {
+     width: 100%;
+    padding: 8px 12px 4px 12px;
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--primary-color, #666);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    border-bottom: 1px solid var(--separator-color, #eee);
+    margin-bottom: 6px;
+    clear: both;
+}

--- a/src/gui/src/helpers.js
+++ b/src/gui/src/helpers.js
@@ -374,18 +374,20 @@ window.check_fsentry_against_allowed_file_types_string = function (fsentry, allo
         $elem.data('taphold_cancelled', false); // If event has been cancelled.
 
         // Set the timer for the hold event.
-        $elem.data('taphold_timer',
-                        setTimeout(function ()
-                        {
-                            // If event hasn't been cancelled/clicked already, then go ahead and trigger the hold.
-                            if ( !$elem.data('taphold_cancelled')
-                                && !$elem.data('taphold_clicked') )
-                            {
-                                // Trigger the hold event, and set the flag to say it's been triggered.
-                                $elem.trigger(jQuery.extend(event, jQuery.Event('taphold')));
-                                $elem.data('taphold_triggered', true);
-                            }
-                        }, settings.duration));
+        $elem.data(
+            'taphold_timer',
+            setTimeout(function ()
+            {
+                // If event hasn't been cancelled/clicked already, then go ahead and trigger the hold.
+                if ( !$elem.data('taphold_cancelled')
+                    && !$elem.data('taphold_clicked') )
+                {
+                    // Trigger the hold event, and set the flag to say it's been triggered.
+                    $elem.trigger(jQuery.extend(event, jQuery.Event('taphold')));
+                    $elem.data('taphold_triggered', true);
+                }
+            }, settings.duration),
+        );
     }
 
     // When user ends a tap or click, decide what we should do.
@@ -724,8 +726,10 @@ window.get_apps = async (app_names, callback) => {
         })();
 
         for ( const name of uniqueMissing ) {
-            getAppsInflight.set(name,
-                            fetchPromise.then((appMap) => appMap.get(name) ?? null));
+            getAppsInflight.set(
+                name,
+                fetchPromise.then((appMap) => appMap.get(name) ?? null),
+            );
         }
 
         pendingPromises.push(fetchPromise.then((appMap) => {
@@ -880,6 +884,60 @@ window.onpopstate = (event) => {
     }
 };
 
+window.get_item_kind = (item) => {
+
+    if ( item.dataset.is_dir === '1' ) return '0_folders';
+    const ext = path.extname(item.dataset.name.toLowerCase());
+    const images = ['.jpg', '.jpeg', '.png', '.gif', '.webp', '.svg', '.bmp', '.ico'];
+    const videos = ['.mp4', '.mkv', '.avi', '.mov', '.webm'];
+    const audio  = ['.mp3', '.wav', '.ogg', '.flac', '.aac'];
+    const docs   = ['.pdf', '.doc', '.docx', '.odt'];
+    const code   = ['.js', '.ts', '.py', '.html', '.css', '.json', '.sh'];
+    if ( images.includes(ext) ) return '1_images';
+    if ( videos.includes(ext) ) return '2_videos';
+    if ( audio.includes(ext) ) return '3_audio';
+    if ( docs.includes(ext) ) return '4_documents';
+    if ( code.includes(ext) ) return '5_code';
+    return '6_other';
+};
+
+window.get_kind_label = (kind) => {
+    const labels = {
+        '0_folders': 'Folders',
+        '1_images': 'Images',
+        '2_videos': 'Videos',
+        '3_audio': 'Audio',
+        '4_documents': 'Documents',
+        '5_code': 'Code',
+        '6_other': 'Other',
+    };
+    return labels[kind] || 'Other';
+};
+
+window.group_items_by_kind = (item_container) => {
+
+    if ( $(item_container).hasClass('desktop') ) return;
+    // remove existing group headers
+    $(item_container).find('.group-by-kind-header').remove();
+
+    const items = $(item_container).find('.item[data-sortable="true"]').detach();
+
+    // group items by kind
+    const groups = {};
+    items.each(function () {
+        const kind = window.get_item_kind(this);
+        if ( ! groups[kind] ) groups[kind] = [];
+        groups[kind].push(this);
+    });
+
+    // sort groups and append with headers
+    Object.keys(groups).sort().forEach(kind => {
+        const label = window.get_kind_label(kind);
+        $(item_container).append(`<div class="group-by-kind-header">${label}</div>`);
+        groups[kind].forEach(item => $(item_container).append(item));
+    });
+};
+
 window.sort_items = (item_container, sort_by, sort_order) => {
     if ( sort_order !== 'asc' && sort_order !== 'desc' )
     {
@@ -931,6 +989,24 @@ window.sort_items = (item_container, sort_by, sort_order) => {
     }).appendTo(item_container);
 };
 
+window.sort_or_group_items = (item_container) => {
+    const sort_by = $(item_container).attr('data-sort_by');
+    const sort_order = $(item_container).attr('data-sort_order');
+    // don't group desktop items
+    if ( $(item_container).hasClass('desktop') ) {
+        window.sort_items(item_container, sort_by, sort_order);
+        return;
+    }
+    // check group_by_kind on either the container or its parent window
+    const el_window = $(item_container).closest('.window');
+    const is_grouped = sort_by === 'kind' || $(el_window).attr('data-group_by_kind') === 'true' || $(item_container).attr('data-group_by_kind') === 'true';
+    if ( is_grouped ) {
+        window.group_items_by_kind(item_container);
+    } else {
+        window.sort_items(item_container, sort_by, sort_order);
+    }
+};
+
 window.show_or_hide_files = (item_containers) => {
     const show_hidden_files = window.user_preferences.show_hidden_files;
     const class_to_add = show_hidden_files ? 'item-revealed' : 'item-hidden';
@@ -965,6 +1041,13 @@ window.create_folder = async (basedir, appendto_element) => {
                         data: el_created_dir,
 
                     });
+                }
+
+                const item_container = $(appendto_element).find('.item-container')[0] ?? appendto_element;
+                if ( $(item_container).attr('data-sort_by') === 'kind' ) {
+                    setTimeout(() => {
+                        window.group_items_by_kind(item_container);
+                    }, 10);
                 }
             },
         });
@@ -1748,13 +1831,15 @@ window.move_items = async function (el_items, dest_path, is_undo = false) {
                     if ( window.is_dashboard_mode && window.UIDashboardFileItem ) {
                         window.UIDashboardFileItem(dir);
                     }
-                    window.sort_items(item_container);
+                    // window.sort_items(item_container);
+                    window.sort_or_group_items(item_container);
                 });
 
                 //sort each container
                 $(`.item-container[data-path="${html_encode(dest_path)}" i]`).each(function () {
                     window.sort_items(this, $(this).attr('data-sort_by'), $(this).attr('data-sort_order'));
                 });
+                window.sort_or_group_items(this);
             } catch ( err ) {
                 // -----------------------------------------------------------------------
                 // if item with same name already exists, ask user if they want to overwrite
@@ -2028,85 +2113,86 @@ window.upload_items = async function (items, dest_path) {
     }
 
     puter.fs.upload(
-                    // what to upload
-                    items,
-                    // where to upload
-                    dest_path,
-                    // options
-                    {
-                        generateThumbnails: true,
-                        // init
-                        init: async (operation_id, xhr) => {
-                            opid = operation_id;
-                            // create upload progress window
-                            upload_progress_window = await UIWindowProgress({
-                                title: i18n('upload'),
-                                icon: window.icons['app-icon-uploader.svg'],
-                                operation_id: operation_id,
-                                show_progress: true,
-                                on_cancel: () => {
-                                    window.show_save_account_notice_if_needed();
-                                    xhr.abort();
-                                },
-                            });
-                            // add to active_uploads
-                            window.active_uploads[opid] = 0;
-                        },
-                        // start
-                        start: async function () {
-                            // change upload progress window message to uploading
-                            upload_progress_window.set_status('Uploading');
-                            upload_progress_window.set_progress(0);
-                        },
-                        // progress
-                        progress: async function (operation_id, op_progress) {
-                            upload_progress_window.set_progress(op_progress);
-                            // update active_uploads
-                            window.active_uploads[opid] = op_progress;
-                            // update title if window is not visible
-                            if ( document.visibilityState !== 'visible' ) {
-                                update_title_based_on_uploads();
-                            }
-                        },
-                        // success
-                        success: async function (items) {
-                            // DONE
-                            // Add action to actions_history for undo ability
-                            const files = [];
-                            if ( typeof items[Symbol.iterator] === 'function' ) {
-                                for ( const item of items ) {
-                                    files.push(item.path);
-                                }
-                            } else {
-                                files.push(items.path);
-                            }
+        // what to upload
+        items,
+        // where to upload
+        dest_path,
+        // options
+        {
+            generateThumbnails: true,
+            // init
+            init: async (operation_id, xhr) => {
+                opid = operation_id;
+                // create upload progress window
+                upload_progress_window = await UIWindowProgress({
+                    title: i18n('upload'),
+                    icon: window.icons['app-icon-uploader.svg'],
+                    operation_id: operation_id,
+                    show_progress: true,
+                    on_cancel: () => {
+                        window.show_save_account_notice_if_needed();
+                        xhr.abort();
+                    },
+                });
+                // add to active_uploads
+                window.active_uploads[opid] = 0;
+            },
+            // start
+            start: async function () {
+                // change upload progress window message to uploading
+                upload_progress_window.set_status('Uploading');
+                upload_progress_window.set_progress(0);
+            },
+            // progress
+            progress: async function (operation_id, op_progress) {
+                upload_progress_window.set_progress(op_progress);
+                // update active_uploads
+                window.active_uploads[opid] = op_progress;
+                // update title if window is not visible
+                if ( document.visibilityState !== 'visible' ) {
+                    update_title_based_on_uploads();
+                }
+            },
+            // success
+            success: async function (items) {
+                // DONE
+                // Add action to actions_history for undo ability
+                const files = [];
+                if ( typeof items[Symbol.iterator] === 'function' ) {
+                    for ( const item of items ) {
+                        files.push(item.path);
+                    }
+                } else {
+                    files.push(items.path);
+                }
 
-                            window.actions_history.push({
-                                operation: 'upload',
-                                data: files,
-                            });
-                            // close progress window after a bit of delay for a better UX
-                            setTimeout(() => {
-                                setTimeout(() => {
-                                    upload_progress_window.close();
-                                    window.show_save_account_notice_if_needed();
-                                }, Math.abs(window.upload_progress_hide_delay));
-                            });
-                            // remove from active_uploads
-                            delete window.active_uploads[opid];
-                        },
-                        // error
-                        error: async function (err) {
-                            upload_progress_window.show_error(i18n('error_uploading_files'), err.message);
-                            // remove from active_uploads
-                            delete window.active_uploads[opid];
-                        },
-                        // abort
-                        abort: async function (operation_id) {
-                            // remove from active_uploads
-                            delete window.active_uploads[opid];
-                        },
-                    });
+                window.actions_history.push({
+                    operation: 'upload',
+                    data: files,
+                });
+                // close progress window after a bit of delay for a better UX
+                setTimeout(() => {
+                    setTimeout(() => {
+                        upload_progress_window.close();
+                        window.show_save_account_notice_if_needed();
+                    }, Math.abs(window.upload_progress_hide_delay));
+                });
+                // remove from active_uploads
+                delete window.active_uploads[opid];
+            },
+            // error
+            error: async function (err) {
+                upload_progress_window.show_error(i18n('error_uploading_files'), err.message);
+                // remove from active_uploads
+                delete window.active_uploads[opid];
+            },
+            // abort
+            abort: async function (operation_id) {
+                // remove from active_uploads
+                delete window.active_uploads[opid];
+            },
+        },
+    );
 };
 
 window.empty_trash = async function () {
@@ -2547,30 +2633,31 @@ window.unzipItem = async function (itemPath) {
                 }
             });
             queuedFileWrites.length && puter.fs.upload(
-                            // what to upload
-                            queuedFileWrites,
-                            // where to upload
-                            `${rootdir.path }/`,
-                            // options
-                            {
-                                createFileParent: true,
-                                generateThumbnails: true,
-                                progress: async function (operation_id, op_progress) {
-                                    progwin.set_progress(op_progress);
-                                    // update title if window is not visible
-                                    if ( document.visibilityState !== 'visible' ) {
-                                        update_title_based_on_uploads();
-                                    }
-                                },
-                                success: async function (items) {
-                                    progwin?.set_progress(window.zippingProgressConfig.TOTAL.toPrecision(2));
-                                    // close progress window
-                                    clearTimeout(progwin_timeout);
-                                    setTimeout(() => {
-                                        progwin?.close();
-                                    }, Math.max(0, window.unzip_progress_hide_delay - (Date.now() - start_ts)));
-                                },
-                            });
+                // what to upload
+                queuedFileWrites,
+                // where to upload
+                `${rootdir.path }/`,
+                // options
+                {
+                    createFileParent: true,
+                    generateThumbnails: true,
+                    progress: async function (operation_id, op_progress) {
+                        progwin.set_progress(op_progress);
+                        // update title if window is not visible
+                        if ( document.visibilityState !== 'visible' ) {
+                            update_title_based_on_uploads();
+                        }
+                    },
+                    success: async function (items) {
+                        progwin?.set_progress(window.zippingProgressConfig.TOTAL.toPrecision(2));
+                        // close progress window
+                        clearTimeout(progwin_timeout);
+                        setTimeout(() => {
+                            progwin?.close();
+                        }, Math.max(0, window.unzip_progress_hide_delay - (Date.now() - start_ts)));
+                    },
+                },
+            );
         }
     });
 };
@@ -2798,25 +2885,27 @@ window.untarItem = async function (itemPath) {
             }
         }
 
-        queuedFileWrites.length && puter.fs.upload(queuedFileWrites,
-                        `${rootdir.path }/`,
-                        {
-                            createFileParent: true,
-                            generateThumbnails: true,
-                            progress: async function (operation_id, op_progress) {
-                                progwin.set_progress(op_progress);
-                                if ( document.visibilityState !== 'visible' ) {
-                                    update_title_based_on_uploads();
-                                }
-                            },
-                            success: async function (items) {
-                                progwin?.set_progress(window.zippingProgressConfig.TOTAL.toPrecision(2));
-                                clearTimeout(progwin_timeout);
-                                setTimeout(() => {
-                                    progwin?.close();
-                                }, Math.max(0, window.unzip_progress_hide_delay - (Date.now() - start_ts)));
-                            },
-                        });
+        queuedFileWrites.length && puter.fs.upload(
+            queuedFileWrites,
+            `${rootdir.path }/`,
+            {
+                createFileParent: true,
+                generateThumbnails: true,
+                progress: async function (operation_id, op_progress) {
+                    progwin.set_progress(op_progress);
+                    if ( document.visibilityState !== 'visible' ) {
+                        update_title_based_on_uploads();
+                    }
+                },
+                success: async function (items) {
+                    progwin?.set_progress(window.zippingProgressConfig.TOTAL.toPrecision(2));
+                    clearTimeout(progwin_timeout);
+                    setTimeout(() => {
+                        progwin?.close();
+                    }, Math.max(0, window.unzip_progress_hide_delay - (Date.now() - start_ts)));
+                },
+            },
+        );
     } catch ( err ) {
         UIAlert(err.message);
         clearTimeout(progwin_timeout);

--- a/src/gui/src/helpers/refresh_item_container.js
+++ b/src/gui/src/helpers/refresh_item_container.js
@@ -87,6 +87,8 @@ const refresh_item_container = function (el_item_container, options) {
             $(el_window).find('.window-navbar-path-input').attr('data-path', container_path);
         }
         $(el_item_container).attr('data-sort_by', fsentry.sort_by ?? 'name');
+        $(el_window).attr('data-group_by_kind', 'false');
+        $(el_item_container).find('.group-by-kind-header').remove();
         $(el_item_container).attr('data-sort_order', fsentry.sort_order ?? 'asc');
         // update layout
         if ( el_window && el_window.length > 0 )
@@ -122,155 +124,163 @@ const refresh_item_container = function (el_item_container, options) {
             return;
         }
 
-        setTimeout(async function () {
+        setTimeout(
+            async function () {
             // clear loading timeout
-            clearTimeout(loading_timeout);
+                clearTimeout(loading_timeout);
 
-            // hide loading spinner
-            $(loading_spinner).hide();
+                // hide loading spinner
+                $(loading_spinner).hide();
 
-            // if no items, show empty folder message
-            if ( fsentries.length === 0 ) {
-                $(el_item_container).find('.explorer-empty-message').show();
-            }
-
-            // trash icon
-            if ( container_path === window.trash_path && el_window_head_icon ) {
-                if ( fsentries.length > 0 ) {
-                    $(el_window_head_icon).attr('src', window.icons['trash-full.svg']);
-                } else {
-                    $(el_window_head_icon).attr('src', window.icons['trash.svg']);
-                }
-            }
-
-            // add each item to window
-            for ( let index = 0; index < fsentries.length; index++ ) {
-                const fsentry = fsentries[index];
-                let is_disabled = false;
-
-                // disable files if this is a showDirectoryPicker() window
-                if ( is_directoryPicker && !fsentry.is_dir )
-                {
-                    is_disabled = true;
+                // if no items, show empty folder message
+                if ( fsentries.length === 0 ) {
+                    $(el_item_container).find('.explorer-empty-message').show();
                 }
 
-                // if this item is not allowed because of filetype restrictions, disable it
-                if ( ! window.check_fsentry_against_allowed_file_types_string(fsentry, allowed_file_types) )
-                {
-                    is_disabled = true;
-                }
-
-                // set visibility based on user preferences and whether file is hidden by default
-                const is_hidden_file = fsentry.name.startsWith('.');
-                let visible;
-                if ( ! is_hidden_file ) {
-                    visible = 'visible';
-                } else if ( window.user_preferences.show_hidden_files ) {
-                    visible = 'revealed';
-                } else {
-                    visible = 'hidden';
-                }
-
-                // metadata
-                let metadata;
-                if ( fsentry.metadata !== '' ) {
-                    try {
-                        metadata = JSON.parse(fsentry.metadata);
-                    }
-                    catch (e) {
-                        // Ignored
+                // trash icon
+                if ( container_path === window.trash_path && el_window_head_icon ) {
+                    if ( fsentries.length > 0 ) {
+                        $(el_window_head_icon).attr('src', window.icons['trash-full.svg']);
+                    } else {
+                        $(el_window_head_icon).attr('src', window.icons['trash.svg']);
                     }
                 }
 
-                const item_path = fsentry.path ?? path.join($(el_window).attr('data-path'), fsentry.name);
-                // render any item but Trash/AppData
-                if ( item_path !== window.trash_path && item_path !== window.appdata_path ) {
-                    // if this is trash, get original name from item metadata
-                    fsentry.name = (metadata && metadata.original_name !== undefined) ? metadata.original_name : fsentry.name;
-                    const position = window.desktop_item_positions[fsentry.uid] ?? undefined;
-                    UIItem({
-                        appendTo: el_item_container,
-                        uid: fsentry.uid,
-                        immutable: fsentry.immutable || fsentry.writable === false,
-                        associated_app_name: fsentry.associated_app?.name,
-                        path: item_path,
-                        icon: await item_icon(fsentry),
-                        name: (metadata && metadata.original_name !== undefined) ? metadata.original_name : fsentry.name,
-                        is_dir: fsentry.is_dir,
-                        multiselectable: !is_openFileDialog,
-                        has_website: fsentry.has_website,
-                        is_shared: fsentry.is_shared,
-                        metadata: fsentry.metadata,
-                        is_shortcut: fsentry.is_shortcut,
-                        shortcut_to: fsentry.shortcut_to,
-                        shortcut_to_path: fsentry.shortcut_to_path,
-                        workers: fsentry.workers,
-                        size: fsentry.size,
-                        type: fsentry.type,
-                        modified: fsentry.modified,
-                        suggested_apps: fsentry.suggested_apps,
-                        disabled: is_disabled,
-                        visible: visible,
-                        position: position,
-                    });
-                }
-            }
+                // add each item to window
+                for ( let index = 0; index < fsentries.length; index++ ) {
+                    const fsentry = fsentries[index];
+                    let is_disabled = false;
 
-            // if this is desktop, add Trash
-            if ( $(el_item_container).hasClass('desktop') ) {
-                try {
-                    const trash = await puter.fs.stat({ path: window.trash_path, consistency: options.consistency ?? 'eventual' });
-                    UIItem({
-                        appendTo: el_item_container,
-                        uid: trash.id,
-                        immutable: trash.immutable,
-                        path: window.trash_path,
-                        icon: { image: (trash.is_empty ? window.icons['trash.svg'] : window.icons['trash-full.svg']), type: 'icon' },
-                        name: trash.name,
-                        is_dir: trash.is_dir,
-                        sort_by: trash.sort_by,
-                        type: trash.type,
-                        is_trash: true,
-                        sortable: false,
-                    });
-                    window.sort_items(el_item_container, $(el_item_container).attr('data-sort_by'), $(el_item_container).attr('data-sort_order'));
-                } catch (e) {
-                    // Ignored
-                }
-            }
-            // sort items
-            window.sort_items(el_item_container,
-                            $(el_item_container).attr('data-sort_by'),
-                            $(el_item_container).attr('data-sort_order'));
+                    // disable files if this is a showDirectoryPicker() window
+                    if ( is_directoryPicker && !fsentry.is_dir )
+                    {
+                        is_disabled = true;
+                    }
 
-            if ( options.fadeInItems ) {
-                $(el_item_container).animate({ 'opacity': '1' }, {
-                    complete: () => {
-                        // Call onComplete callback when fade-in animation is done
-                        if ( options.onComplete && typeof options.onComplete === 'function' ) {
-                            options.onComplete();
+                    // if this item is not allowed because of filetype restrictions, disable it
+                    if ( ! window.check_fsentry_against_allowed_file_types_string(fsentry, allowed_file_types) )
+                    {
+                        is_disabled = true;
+                    }
+
+                    // set visibility based on user preferences and whether file is hidden by default
+                    const is_hidden_file = fsentry.name.startsWith('.');
+                    let visible;
+                    if ( ! is_hidden_file ) {
+                        visible = 'visible';
+                    } else if ( window.user_preferences.show_hidden_files ) {
+                        visible = 'revealed';
+                    } else {
+                        visible = 'hidden';
+                    }
+
+                    // metadata
+                    let metadata;
+                    if ( fsentry.metadata !== '' ) {
+                        try {
+                            metadata = JSON.parse(fsentry.metadata);
                         }
-                    },
-                });
-            } else {
-                // If no fade-in animation, call onComplete immediately
-                if ( options.onComplete && typeof options.onComplete === 'function' ) {
-                    options.onComplete();
+                        catch (e) {
+                        // Ignored
+                        }
+                    }
+
+                    const item_path = fsentry.path ?? path.join($(el_window).attr('data-path'), fsentry.name);
+                    // render any item but Trash/AppData
+                    if ( item_path !== window.trash_path && item_path !== window.appdata_path ) {
+                    // if this is trash, get original name from item metadata
+                        fsentry.name = (metadata && metadata.original_name !== undefined) ? metadata.original_name : fsentry.name;
+                        const position = window.desktop_item_positions[fsentry.uid] ?? undefined;
+                        UIItem({
+                            appendTo: el_item_container,
+                            uid: fsentry.uid,
+                            immutable: fsentry.immutable || fsentry.writable === false,
+                            associated_app_name: fsentry.associated_app?.name,
+                            path: item_path,
+                            icon: await item_icon(fsentry),
+                            name: (metadata && metadata.original_name !== undefined) ? metadata.original_name : fsentry.name,
+                            is_dir: fsentry.is_dir,
+                            multiselectable: !is_openFileDialog,
+                            has_website: fsentry.has_website,
+                            is_shared: fsentry.is_shared,
+                            metadata: fsentry.metadata,
+                            is_shortcut: fsentry.is_shortcut,
+                            shortcut_to: fsentry.shortcut_to,
+                            shortcut_to_path: fsentry.shortcut_to_path,
+                            workers: fsentry.workers,
+                            size: fsentry.size,
+                            type: fsentry.type,
+                            modified: fsentry.modified,
+                            suggested_apps: fsentry.suggested_apps,
+                            disabled: is_disabled,
+                            visible: visible,
+                            position: position,
+                        });
+                    }
                 }
-            }
 
-            // update footer item count if this is an explorer window
-            if ( el_window )
-            {
-                window.update_explorer_footer_item_count(el_window);
-            }
+                // if this is desktop, add Trash
+                if ( $(el_item_container).hasClass('desktop') ) {
+                    try {
+                        const trash = await puter.fs.stat({ path: window.trash_path, consistency: options.consistency ?? 'eventual' });
+                        UIItem({
+                            appendTo: el_item_container,
+                            uid: trash.id,
+                            immutable: trash.immutable,
+                            path: window.trash_path,
+                            icon: { image: (trash.is_empty ? window.icons['trash.svg'] : window.icons['trash-full.svg']), type: 'icon' },
+                            name: trash.name,
+                            is_dir: trash.is_dir,
+                            sort_by: trash.sort_by,
+                            type: trash.type,
+                            is_trash: true,
+                            sortable: false,
+                        });
+                        window.sort_items(el_item_container, $(el_item_container).attr('data-sort_by'), $(el_item_container).attr('data-sort_order'));
+                    } catch (e) {
+                    // Ignored
+                    }
+                }
+                // sort items
+                window.sort_items(
+                    el_item_container,
+                    $(el_item_container).attr('data-sort_by'),
+                    $(el_item_container).attr('data-sort_order'),
+                );
 
-            // end the transaction
-            transaction.end();
-        },
-        // This makes sure the loading spinner shows up if the request takes longer than 1 second
-        // and stay there for at least 1 second since the flickering is annoying
-        (Date.now() - start_ts) > 1000 ? 1000 : 1);
+                if ( $(el_item_container).attr('data-sort_by') === 'kind' ) {
+                    window.group_items_by_kind(el_item_container);
+                }
+
+                if ( options.fadeInItems ) {
+                    $(el_item_container).animate({ 'opacity': '1' }, {
+                        complete: () => {
+                        // Call onComplete callback when fade-in animation is done
+                            if ( options.onComplete && typeof options.onComplete === 'function' ) {
+                                options.onComplete();
+                            }
+                        },
+                    });
+                } else {
+                // If no fade-in animation, call onComplete immediately
+                    if ( options.onComplete && typeof options.onComplete === 'function' ) {
+                        options.onComplete();
+                    }
+                }
+
+                // update footer item count if this is an explorer window
+                if ( el_window )
+                {
+                    window.update_explorer_footer_item_count(el_window);
+                }
+
+                // end the transaction
+                transaction.end();
+            },
+            // This makes sure the loading spinner shows up if the request takes longer than 1 second
+            // and stay there for at least 1 second since the flickering is annoying
+            (Date.now() - start_ts) > 1000 ? 1000 : 1,
+        );
     }).catch(e => {
         // end the transaction
         transaction.end();

--- a/src/gui/src/i18n/translations/en.js
+++ b/src/gui/src/i18n/translations/en.js
@@ -334,6 +334,7 @@ const en = {
         skip: 'Skip',
         something_went_wrong: 'Something went wrong.',
         sort_by: 'Sort by',
+        group_by_kind: 'Group by Kind',
         start: 'Start',
         status: 'Status',
         'Storage': 'Storage',


### PR DESCRIPTION
## Summary
Add "Group by Kind" feature to the file manager, similar to macOS Finder's "Group By Kind" option.

## What this PR does
- Adds a "Group by Kind" option to the right-click Sort by menu
- Groups files into categories: Folders, Images, Videos, Audio, Documents, Code, and Other
- Persists when navigating between folders
- Resets grouping when navigating to a different folder
- Desktop items are not affected

## Screenshots

<img width="976" height="721" alt="Screenshot 2026-03-30 at 12 33 24 AM" src="https://github.com/user-attachments/assets/46f45a97-f4e0-49a2-8e7d-dd5c9ab863e4" />
<img width="801" height="603" alt="Screenshot 2026-03-30 at 12 33 06 AM" src="https://github.com/user-attachments/assets/855d6de8-599d-4b1c-873b-e375464e4530" />


## How to test
1. Open any folder in Puter
2. Right-click inside the folder
3. Go to Sort by → Group by Kind
4. Files should be grouped by their type with headers