### PR TITLE
fix: add tooltips to truncated usage table resource names

### DIFF
--- a/src/gui/src/UI/Dashboard/TabUsage.js
+++ b/src/gui/src/UI/Dashboard/TabUsage.js
@@ -20,7 +20,7 @@
 // Sort state for the usage table
 let usageTableSortState = {
     column: 'cost', // default sort by cost
-    direction: 'desc' // default descending (highest cost first)
+    direction: 'desc', // default descending (highest cost first)
 };
 let usageTableData = []; // Store raw data for sorting
 let usageTableExpanded = false; // Track if table is showing all rows
@@ -29,7 +29,7 @@ const USAGE_TABLE_INITIAL_ROWS = 10;
 const TabUsage = {
     id: 'usage',
     label: 'Usage',
-    icon: `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-speedometer2" viewBox="0 0 16 16"> <path d="M8 4a.5.5 0 0 1 .5.5V6a.5.5 0 0 1-1 0V4.5A.5.5 0 0 1 8 4M3.732 5.732a.5.5 0 0 1 .707 0l.915.914a.5.5 0 1 1-.708.708l-.914-.915a.5.5 0 0 1 0-.707M2 10a.5.5 0 0 1 .5-.5h1.586a.5.5 0 0 1 0 1H2.5A.5.5 0 0 1 2 10m9.5 0a.5.5 0 0 1 .5-.5h1.5a.5.5 0 0 1 0 1H12a.5.5 0 0 1-.5-.5m.754-4.246a.39.39 0 0 0-.527-.02L7.547 9.31a.91.91 0 1 0 1.302 1.258l3.434-4.297a.39.39 0 0 0-.029-.518z"/> <path fill-rule="evenodd" d="M0 10a8 8 0 1 1 15.547 2.661c-.442 1.253-1.845 1.602-2.932 1.25C11.309 13.488 9.475 13 8 13c-1.474 0-3.31.488-4.615.911-1.087.352-2.49.003-2.932-1.25A8 8 0 0 1 0 10m8-7a7 7 0 0 0-6.603 9.329c.203.575.923.876 1.68.63C4.397 12.533 6.358 12 8 12s3.604.532 4.923.96c.757.245 1.477-.056 1.68-.631A7 7 0 0 0 8 3"/> </svg>`,
+    icon: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-speedometer2" viewBox="0 0 16 16"> <path d="M8 4a.5.5 0 0 1 .5.5V6a.5.5 0 0 1-1 0V4.5A.5.5 0 0 1 8 4M3.732 5.732a.5.5 0 0 1 .707 0l.915.914a.5.5 0 1 1-.708.708l-.914-.915a.5.5 0 0 1 0-.707M2 10a.5.5 0 0 1 .5-.5h1.586a.5.5 0 0 1 0 1H2.5A.5.5 0 0 1 2 10m9.5 0a.5.5 0 0 1 .5-.5h1.5a.5.5 0 0 1 0 1H12a.5.5 0 0 1-.5-.5m.754-4.246a.39.39 0 0 0-.527-.02L7.547 9.31a.91.91 0 1 0 1.302 1.258l3.434-4.297a.39.39 0 0 0-.029-.518z"/> <path fill-rule="evenodd" d="M0 10a8 8 0 1 1 15.547 2.661c-.442 1.253-1.845 1.602-2.932 1.25C11.309 13.488 9.475 13 8 13c-1.474 0-3.31.488-4.615.911-1.087.352-2.49.003-2.932-1.25A8 8 0 0 1 0 10m8-7a7 7 0 0 0-6.603 9.329c.203.575.923.876 1.68.63C4.397 12.533 6.358 12 8 12s3.604.532 4.923.96c.757.245 1.477-.056 1.68-.631A7 7 0 0 0 8 3"/> </svg>',
     html: () => {
         return `
             <h1>${i18n('usage')}<button class="update-usage-details" style="float:right;"><svg class="update-usage-details-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-clockwise" viewBox="0 0 16 16"> <path fill-rule="evenodd" d="M8 3a5 5 0 1 0 4.546 2.914.5.5 0 0 1 .908-.417A6 6 0 1 1 8 2z"/> <path d="M8 4.466V.534a.25.25 0 0 1 .41-.192l2.36 1.966c.12.1.12.284 0 .384L8.41 4.658A.25.25 0 0 1 8 4.466"/> </svg></button></h1>
@@ -77,7 +77,7 @@ const TabUsage = {
         // Click handler for sortable table headers
         $($el_window).on('click', '.driver-usage-details-content-table th[data-sort]', function () {
             const column = $(this).data('sort');
-            
+
             // Toggle direction if same column, otherwise default to descending
             if ( usageTableSortState.column === column ) {
                 usageTableSortState.direction = usageTableSortState.direction === 'asc' ? 'desc' : 'asc';
@@ -103,11 +103,11 @@ const TabUsage = {
     },
 };
 
-function getSortIcon(column) {
+function getSortIcon (column) {
     const isActive = usageTableSortState.column === column;
     const direction = usageTableSortState.direction;
-    
-    if ( !isActive ) {
+
+    if ( ! isActive ) {
         // Neutral sort icon (both arrows, dimmed)
         return `<span class="sort-icon sort-icon-neutral">
             <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="currentColor" viewBox="0 0 16 16">
@@ -131,11 +131,11 @@ function getSortIcon(column) {
     }
 }
 
-function renderUsageTable() {
+function renderUsageTable () {
     // Sort the data
     const sortedData = [...usageTableData].sort((a, b) => {
         let aVal, bVal;
-        
+
         switch ( usageTableSortState.column ) {
             case 'resource':
                 aVal = a.resource.toLowerCase();
@@ -147,7 +147,7 @@ function renderUsageTable() {
                 bVal = b.rawCost;
                 break;
         }
-        
+
         if ( aVal < bVal ) return usageTableSortState.direction === 'asc' ? -1 : 1;
         if ( aVal > bVal ) return usageTableSortState.direction === 'asc' ? 1 : -1;
         return 0;
@@ -177,9 +177,9 @@ function renderUsageTable() {
     for ( const row of rowsToShow ) {
         h += `
         <tr>
-            <td>${row.resource}</td>
-            <td>${row.formattedUnits}</td>
-            <td>${row.formattedCost}</td>
+            <td title="${html_encode(row.resource)}">${row.resource}</td>
+            <td title="${html_encode(row.formattedUnits)}">${row.formattedUnits}</td>
+            <td title="${html_encode(row.formattedCost)}">${row.formattedCost}</td>
         </tr>`;
     }
     h += '</tbody>';
@@ -244,7 +244,7 @@ async function update_usage_details ($el_window) {
                 rawUnits: rawUnits,
                 formattedUnits: formattedUnits,
                 rawCost: rawCost,
-                formattedCost: window.number_format(rawCost / 100_000_000, { decimals: 2, prefix: '$' })
+                formattedCost: window.number_format(rawCost / 100_000_000, { decimals: 2, prefix: '$' }),
             });
         }
 
@@ -269,9 +269,10 @@ async function update_usage_details ($el_window) {
         $('#storage-used').html(window.byte_format(general_used));
         $('#storage-capacity').html(window.byte_format(res.capacity));
         $('#storage-used-percent').html(
-                        `${usage_percentage }%${
-                            host_usage_percentage > 0
-                                ? ` / ${ host_usage_percentage }%` : ''}`);
+            `${usage_percentage }%${
+                host_usage_percentage > 0
+                    ? ` / ${ host_usage_percentage }%` : ''}`,
+        );
         $('#storage-bar').css('width', `${usage_percentage }%`);
         $('#storage-bar-host').css('width', `${host_usage_percentage }%`);
         if ( usage_percentage >= 100 ) {

--- a/src/gui/src/UI/Settings/UITabUsage.js
+++ b/src/gui/src/UI/Settings/UITabUsage.js
@@ -134,9 +134,9 @@ async function update_usage_details ($el_window) {
 
             h += `
             <tr>
-                <td>${key}</td>
-                <td>${units}</td>
-                <td>${window.number_format(res.usage[key].cost / 100_000_000, { decimals: 2, prefix: '$' })}</td>
+                <td title="${html_encode(key)}">${key}</td>
+                <td title="${html_encode(units)}">${units}</td>
+                <td title="${html_encode(window.number_format(res.usage[key].cost / 100_000_000, { decimals: 2, prefix: '$' }))}">${window.number_format(res.usage[key].cost / 100_000_000, { decimals: 2, prefix: '$' })}</td>
             </tr>`;
         }
         h += '</tbody>';
@@ -163,9 +163,10 @@ async function update_usage_details ($el_window) {
         $('#storage-used').html(window.byte_format(general_used));
         $('#storage-capacity').html(window.byte_format(res.capacity));
         $('#storage-used-percent').html(
-                        `${usage_percentage }%${
-                            host_usage_percentage > 0
-                                ? ` / ${ host_usage_percentage }%` : ''}`);
+            `${usage_percentage }%${
+                host_usage_percentage > 0
+                    ? ` / ${ host_usage_percentage }%` : ''}`,
+        );
         $('#storage-bar').css('width', `${usage_percentage }%`);
         $('#storage-bar-host').css('width', `${host_usage_percentage }%`);
         if ( usage_percentage >= 100 ) {


### PR DESCRIPTION
## Summary

Resource names in the usage details table get cut off by CSS `text-overflow: ellipsis` with no way to see the full text. This adds `title` attributes to all `<td>` elements so the full content shows as a native browser tooltip on hover.

## Changes

Both the Settings and Dashboard usage tables are updated:
- `src/gui/src/UI/Settings/UITabUsage.js` - Resource, Units, and Cost cells now have `title` attributes
- `src/gui/src/UI/Dashboard/TabUsage.js` - Same fix applied to the dashboard variant

All title values use `html_encode()` for XSS safety.

## Context

A previous fix for this was included in PR #1828 but was reverted in #1931 as part of a larger revert. This PR isolates the tooltip fix as a standalone change.

Fixes #1847

This contribution was developed with AI assistance (Codex).

[![CE](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)