### PR TITLE
fix veo video with proxy link

### DIFF
--- a/src/backend/src/routers/puterai/video/proxy.js
+++ b/src/backend/src/routers/puterai/video/proxy.js
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2024-present Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+'use strict';
+
+const { Readable } = require('stream');
+const { sha256 } = require('js-sha256');
+const config = require('../../../config.js');
+const eggspress = require('../../../api/eggspress.js');
+
+const GEMINI_DOWNLOAD_BASE = 'https://generativelanguage.googleapis.com/download/v1beta/files';
+
+module.exports = eggspress('/video/proxy', {
+    allowedMethods: ['GET'],
+}, async (req, res) => {
+    const fileId = req.query.fileId;
+    const provider = req.query.provider;
+    const expires = req.query.expires;
+    const signature = req.query.signature;
+
+    if ( !fileId || typeof fileId !== 'string' || !/^[a-zA-Z0-9_-]+$/.test(fileId) ) {
+        return res.status(400).send('Invalid or missing fileId parameter');
+    }
+
+    if ( !expires || !signature ) {
+        return res.status(403).send('Missing signature');
+    }
+
+    if ( Number(expires) < Date.now() / 1000 ) {
+        return res.status(403).send('Signature expired');
+    }
+
+    const secret = config.url_signature_secret;
+    const expected = sha256(`${fileId}/video-proxy/${secret}/${expires}`);
+    if ( signature !== expected ) {
+        return res.status(403).send('Invalid signature');
+    }
+
+    if ( provider === 'gemini' ) {
+        const geminiConfig = config.services?.gemini;
+        const apiKey = geminiConfig?.apiKey || geminiConfig?.secret_key;
+
+        if ( ! apiKey ) {
+            return res.status(500).send('Gemini API key not configured');
+        }
+
+        const url = `${GEMINI_DOWNLOAD_BASE}/${fileId}:download?alt=media&key=${apiKey}`;
+        const videoUriResponse = await fetch(url);
+
+        if ( ! videoUriResponse.ok ) {
+            return res.status(videoUriResponse.status).send('Failed to fetch video');
+        }
+
+        const contentType = videoUriResponse.headers.get('content-type');
+        if ( contentType ) {
+            res.setHeader('Content-Type', contentType);
+        }
+
+        if ( videoUriResponse.body ) {
+            Readable.fromWeb(videoUriResponse.body).pipe(res);
+        } else {
+            res.status(500).send('Empty response body');
+        }
+    } else {
+        return res.status(400).send('Unsupported provider');
+    }
+});

--- a/src/backend/src/services/ChatAPIService.js
+++ b/src/backend/src/services/ChatAPIService.js
@@ -64,6 +64,7 @@ class ChatAPIService extends BaseService {
         router.use(require('../routers/puterai/openai/chat_completions'));
         router.use(require('../routers/puterai/openai/responses'));
         router.use(require('../routers/puterai/anthropic/messages'));
+        router.use(require('../routers/puterai/video/proxy'));
         // Endpoint to list available AI chat models
         router.use(eggspress('/chat/models', {
             allowedMethods: ['GET'],

--- a/src/backend/src/services/ai/video/AIVideoGenerationService.ts
+++ b/src/backend/src/services/ai/video/AIVideoGenerationService.ts
@@ -112,7 +112,11 @@ export class AIVideoGenerationService extends BaseService {
         const geminiVideoConfig = this.config.providers?.['gemini-video-generation'] || this.global_config?.services?.gemini;
         if ( geminiVideoConfig && (geminiVideoConfig.apiKey || geminiVideoConfig.secret_key) ) {
             this.#providers['gemini-video-generation'] = new GeminiVideoGenerationProvider(
-                { apiKey: geminiVideoConfig.apiKey || geminiVideoConfig.secret_key },
+                {
+                    apiKey: geminiVideoConfig.apiKey || geminiVideoConfig.secret_key,
+                    origin: this.global_config?.api_base_url,
+                    urlSignatureSecret: this.global_config?.url_signature_secret,
+                },
                 this.meteringService,
             );
         }

--- a/src/backend/src/services/ai/video/providers/GeminiVideoGenerationProvider/GeminiVideoGenerationProvider.ts
+++ b/src/backend/src/services/ai/video/providers/GeminiVideoGenerationProvider/GeminiVideoGenerationProvider.ts
@@ -18,6 +18,7 @@
  */
 
 import { GoogleGenAI, GenerateVideosOperation, GenerateVideosParameters } from '@google/genai';
+import { sha256 } from 'js-sha256';
 import APIError from '../../../../../api/APIError.js';
 import { Context } from '../../../../../util/context.js';
 import { MeteringService } from '../../../../MeteringService/MeteringService.js';
@@ -41,13 +42,17 @@ const DIMENSION_MAP: Record<string, { aspectRatio: string; resolution: string }>
 export class GeminiVideoGenerationProvider implements IVideoProvider {
     #client: GoogleGenAI;
     #meteringService: MeteringService;
+    #origin: string;
+    #urlSignatureSecret: string;
 
-    constructor (config: { apiKey: string }, meteringService: MeteringService) {
+    constructor (config: { apiKey: string, origin?: string, urlSignatureSecret?: string }, meteringService: MeteringService) {
         if ( ! config.apiKey ) {
             throw new Error('Gemini video generation requires an API key');
         }
         this.#client = new GoogleGenAI({ apiKey: config.apiKey });
         this.#meteringService = meteringService;
+        this.#origin = config.origin || 'https://api.puter.com';
+        this.#urlSignatureSecret = config.urlSignatureSecret || '';
     }
 
     getDefaultModel (): string {
@@ -201,10 +206,18 @@ export class GeminiVideoGenerationProvider implements IVideoProvider {
         await this.#meteringService.incrementUsage(actor, usageKey, durationSeconds, costInMicroCents);
 
         if ( video.uri ) {
+            const fileIdMatch = video.uri.match(/\/files\/([^/:]+)/);
+            if ( ! fileIdMatch ) {
+                throw new Error('Could not extract file ID from Gemini video URI');
+            }
+            const fileId = fileIdMatch[1];
+            const expires = Math.ceil(Date.now() / 1000) + 48 * 3600; // from google docs: Generated videos are stored on the server for 2 days
+            const signature = sha256(`${fileId}/video-proxy/${this.#urlSignatureSecret}/${expires}`);
+            const proxyUrl = `${this.#origin}/puterai/video/proxy?fileId=${encodeURIComponent(fileId)}&provider=gemini&expires=${expires}&signature=${signature}`;
             return new TypedValue({
                 $: 'string:url:web',
                 content_type: 'video',
-            }, video.uri);
+            }, proxyUrl);
         }
 
         if ( video.videoBytes ) {


### PR DESCRIPTION
fixes issue where gemini video provider returns link that requires auth to access
now proxied with fileid + access signature
testing:
```js
await puter.ai.txt2vid('A cat walking on a beach at sunset', {"model":"google:google/veo-3.1-lite"})
```
returns
```
http://api.puter.localhost:4100
/puterai/video/proxy
?fileId=ttzx0324nd16 <- gemini file download id
&provider=gemini
&expires=1776014720 <- 48h expiration
&signature=18a1491ad9bea510fc57a210a9f6baeeea6560e0fc275d59b7769c6c263e8ad5
^ signature created similarly to other parts of codebase
```