### PR TITLE
add opus 4.7, adjust thinking

### DIFF
--- a/src/backend/src/services/ai/chat/providers/ClaudeProvider/ClaudeProvider.ts
+++ b/src/backend/src/services/ai/chat/providers/ClaudeProvider/ClaudeProvider.ts
@@ -174,8 +174,15 @@ export class ClaudeProvider implements IChatProvider {
             reasoningEffort: requestedReasoningEffort,
             maxTokens: max_tokens,
         });
-        // Anthropic requires temperature=1 whenever thinking is enabled.
-        const resolvedTemperature = thinkingConfig ? 1 : (temperature ?? 0);
+        // Opus 4.7 errors on non-default sampling params; omit temperature entirely.
+        // Other models require temperature=1 when thinking is enabled.
+        const isOpus47 = modelUsed.id === 'claude-opus-4-7';
+        const resolvedTemperature = isOpus47 ? undefined : (thinkingConfig ? 1 : (temperature ?? 0));
+        const supportsEffort = [
+            'claude-opus-4-7',
+            'claude-opus-4-6',
+            'claude-sonnet-4-6',
+        ].includes(modelUsed.id);
         const sdkParams: MessageCreateParams = {
             model: modelUsed.id,
             max_tokens: Math.floor(max_tokens ||
@@ -183,7 +190,7 @@ export class ClaudeProvider implements IChatProvider {
                     model === 'claude-3-5-sonnet-20241022'
                     || model === 'claude-3-5-sonnet-20240620'
                 ) ? 8192 : this.models().filter(e => (e.name === model || e.aliases?.includes(model)))[0]?.max_tokens || 4096)), //required
-            temperature: resolvedTemperature, // required
+            ...(resolvedTemperature !== undefined ? { temperature: resolvedTemperature } : {}),
             ...( (system_prompts && system_prompts[0]?.content) ? {
                 system: system_prompts[0]?.content,
             } : {}),
@@ -194,6 +201,7 @@ export class ClaudeProvider implements IChatProvider {
             messages,
             ...(tools ? { tools } : {}),
             ...(thinkingConfig ? { thinking: thinkingConfig } : {}),
+            ...(supportsEffort && requestedReasoningEffort ? { output_config: { effort: requestedReasoningEffort } } : {}),
         } as MessageCreateParams;
 
         let beta_mode = false;
@@ -432,6 +440,7 @@ export class ClaudeProvider implements IChatProvider {
     };
 
     #buildThinkingConfig ({
+        modelId,
         reasoningEffort,
         maxTokens,
     }: {
@@ -440,6 +449,17 @@ export class ClaudeProvider implements IChatProvider {
         maxTokens?: number;
     }) {
         if ( ! reasoningEffort ) return undefined;
+
+        // Opus 4.7, 4.6, and Sonnet 4.6 use adaptive thinking (budget_tokens
+        // is deprecated on 4.6/Sonnet 4.6 and removed on 4.7).
+        // Opus 4.7 omits thinking content by default; display: 'summarized'
+        // restores visible reasoning in the stream.
+        if ( modelId === 'claude-opus-4-7' ) {
+            return { type: 'adaptive' as const, display: 'summarized' as const };
+        }
+        if ( modelId === 'claude-opus-4-6' || modelId === 'claude-sonnet-4-6' ) {
+            return { type: 'adaptive' as const };
+        }
 
         const requestedBudget = {
             low: 1024,

--- a/src/backend/src/services/ai/chat/providers/ClaudeProvider/models.ts
+++ b/src/backend/src/services/ai/chat/providers/ClaudeProvider/models.ts
@@ -3,6 +3,30 @@ import { IChatModel } from '../types';
 // Hardcoded from https://models.dev/api.json
 export const CLAUDE_MODELS: IChatModel[] = [
     {
+        puterId: 'anthropic:anthropic/claude-opus-4-7',
+        id: 'claude-opus-4-7',
+        modalities: { 'input': ['text', 'image', 'pdf'], 'output': ['text'] },
+        open_weights: false,
+        tool_call: true,
+        knowledge: '2025-08',
+        release_date: '2026-04-16',
+        aliases: ['claude-opus', 'claude-opus-latest', 'claude-opus-4-7-latest', 'claude-opus-4.7', 'claude-opus-4-7', 'anthropic/claude-opus-4-7'],
+        name: 'Claude Opus 4.7',
+        costs_currency: 'usd-cents',
+        input_cost_key: 'input_tokens',
+        output_cost_key: 'output_tokens',
+        costs: {
+            tokens: 1_000_000,
+            input_tokens: 500,
+            ephemeral_5m_input_tokens: 500 * 1.25,
+            ephemeral_1h_input_tokens: 500 * 2,
+            cache_read_input_tokens: 500 * 0.1,
+            output_tokens: 2500,
+        },
+        context: 1000000,
+        max_tokens: 128000,
+    },
+    {
         puterId: 'anthropic:anthropic/claude-sonnet-4-6',
         id: 'claude-sonnet-4-6',
         modalities: { 'input': ['text', 'image', 'pdf'], 'output': ['text'] },
@@ -23,7 +47,7 @@ export const CLAUDE_MODELS: IChatModel[] = [
             cache_read_input_tokens: 300 * 0.1,
             output_tokens: 1500,
         },
-        context: 200000,
+        context: 1000000,
         max_tokens: 64000,
     },
     {
@@ -34,7 +58,7 @@ export const CLAUDE_MODELS: IChatModel[] = [
         tool_call: true,
         knowledge: '2025-05',
         release_date: '2026-02-05',
-        aliases: ['claude-opus', 'claude-opus-latest', 'claude-opus-4-6-latest', 'claude-opus-4.6', 'claude-opus-4-6', 'anthropic/claude-opus-4-6'],
+        aliases: ['claude-opus-4-6-latest', 'claude-opus-4.6', 'claude-opus-4-6', 'anthropic/claude-opus-4-6'],
         name: 'Claude Opus 4.6',
         costs_currency: 'usd-cents',
         input_cost_key: 'input_tokens',
@@ -47,7 +71,7 @@ export const CLAUDE_MODELS: IChatModel[] = [
             cache_read_input_tokens: 500 * 0.1,
             output_tokens: 2500,
         },
-        context: 200000,
+        context: 1000000,
         max_tokens: 128000,
     },
     {


### PR DESCRIPTION
added opus 4.7 (see its [breaking changes](https://platform.claude.com/docs/en/about-claude/models/migration-guide#breaking-changes))
adjusted opus and sonnet 4.6 to use adaptive thinking instead of the old deprecated budget
set opus 4.7, 4.6 and sonnet 4.6 to 1M context as [long context is now priced at standard rates](https://platform.claude.com/docs/en/about-claude/pricing#long-context-pricing)
test:
```js
await puter.ai.chat('What is 127 * 43?', {model: 'claude-opus-4-7', reasoning: {effort: 'medium'}})
```
sends
```js
...
"thinking": {
    "type": "adaptive",
    "display": "summarized"
},
"output_config": {
    "effort": "medium"
}
...
```

closes #2812 