### PR TITLE
Mb/2807 webauthn support for accounts

### DIFF
--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -24,6 +24,7 @@
     "@opentelemetry/sdk-metrics": "^1.14.0",
     "@opentelemetry/sdk-node": "^0.49.1",
     "@pagerduty/pdjs": "^2.2.4",
+    "@simplewebauthn/server": "^13.3.0",
     "@smithy/node-http-handler": "^2.2.2",
     "@socket.io/redis-streams-adapter": "^0.3.1",
     "args": "^5.0.3",

--- a/src/backend/src/CoreModule.js
+++ b/src/backend/src/CoreModule.js
@@ -274,6 +274,9 @@ const install = async ({ context, services, app, useapi, modapi }) => {
     const { OTPService } = require('./services/auth/OTPService');
     services.registerService('otp', OTPService);
 
+    const { WebAuthnService } = require('./services/auth/WebAuthnService');
+    services.registerService('webauthn', WebAuthnService);
+
     const { OIDCService } = require('./services/auth/OIDCService');
     services.registerService('oidc', OIDCService);
 

--- a/src/backend/src/modules/web/WebServerService.js
+++ b/src/backend/src/modules/web/WebServerService.js
@@ -828,6 +828,7 @@ class WebServerService extends BaseService {
             const allowed_headers = [
                 'Origin', 'X-Requested-With', 'Content-Type', 'Accept', 'Authorization', 'sentry-trace', 'baggage',
                 'Depth', 'Destination', 'Overwrite', 'If', 'Lock-Token', 'DAV', 'stripe-signature',
+                'X-Puter-Add-Password',
             ];
 
             // Request headers to allow

--- a/src/backend/src/routers/auth/webauthn.js
+++ b/src/backend/src/routers/auth/webauthn.js
@@ -1,0 +1,299 @@
+/*
+ * Copyright (C) 2024-present Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+'use strict';
+const express = require('express');
+const router = new express.Router();
+const { get_user, body_parser_error_handler, invalidate_cached_user_by_id } = require('../../helpers');
+const { UserActorType } = require('../../services/auth/Actor');
+const { Context } = require('../../util/context');
+const { DB_WRITE } = require('../../services/database/consts');
+const config = require('../../config');
+const validator = require('validator');
+const auth2 = require('../../middleware/auth2');
+
+// ---- Registration: begin (requires auth) ----
+router.post(
+    '/auth/webauthn/register/begin',
+    express.json(),
+    body_parser_error_handler,
+    auth2,
+    async (req, res) => {
+        const actor = Context.get('actor');
+        if ( !actor || !(actor.type instanceof UserActorType) ) {
+            return res.status(403).json({ error: 'Forbidden' });
+        }
+
+        const svc_webauthn = req.services.get('webauthn');
+        const user = await get_user({ id: req.user.id, force: true });
+
+        try {
+            const options = await svc_webauthn.generate_registration_options({ user, req });
+            res.json(options);
+        } catch (e) {
+            console.error('[webauthn] register/begin error:', e);
+            res.status(500).json({ error: e.message });
+        }
+    },
+);
+
+// ---- Registration: complete (requires auth) ----
+router.post(
+    '/auth/webauthn/register/complete',
+    express.json(),
+    body_parser_error_handler,
+    auth2,
+    async (req, res) => {
+        const actor = Context.get('actor');
+        if ( !actor || !(actor.type instanceof UserActorType) ) {
+            return res.status(403).json({ error: 'Forbidden' });
+        }
+
+        if ( ! req.body.response ) return res.status(400).json({ error: 'response is required' });
+
+        const svc_webauthn = req.services.get('webauthn');
+        const user = await get_user({ id: req.user.id, force: true });
+
+        try {
+            const credential_data = await svc_webauthn.verify_registration({
+                user,
+                response: req.body.response,
+                req,
+            });
+            await svc_webauthn.save_credential({
+                user_id: user.id,
+                credential_data,
+                name: req.body.name,
+            });
+            invalidate_cached_user_by_id(user.id);
+            res.json({ ok: true });
+        } catch (e) {
+            console.error('[webauthn] register/complete error:', e);
+            res.status(400).json({ error: e.message });
+        }
+    },
+);
+
+// ---- List credentials (requires auth) ----
+router.get('/auth/webauthn/credentials', auth2, async (req, res) => {
+    const actor = Context.get('actor');
+    if ( !actor || !(actor.type instanceof UserActorType) ) {
+        return res.status(403).json({ error: 'Forbidden' });
+    }
+
+    const svc_webauthn = req.services.get('webauthn');
+    const credentials = await svc_webauthn.list_credentials(req.user.id);
+    const db = req.services.get('database').get(DB_WRITE, 'webauthn');
+    const [user_row] = await db.read(
+        'SELECT password_required FROM user WHERE id = ? LIMIT 1',
+        [req.user.id],
+    );
+    res.json({
+        credentials,
+        password_required: Number(user_row?.password_required ?? 1),
+    });
+});
+
+// ---- Delete credential (requires auth) ----
+router.delete('/auth/webauthn/credentials/:id', auth2, async (req, res) => {
+    const actor = Context.get('actor');
+    if ( !actor || !(actor.type instanceof UserActorType) ) {
+        return res.status(403).json({ error: 'Forbidden' });
+    }
+
+    const svc_webauthn = req.services.get('webauthn');
+    const db = req.services.get('database').get(DB_WRITE, 'webauthn');
+    const [user_row] = await db.read(
+        'SELECT password_required FROM user WHERE id = ? LIMIT 1',
+        [req.user.id],
+    );
+    const credentials = await svc_webauthn.list_credentials(req.user.id);
+
+    // Prevent account lockout: in passwordless mode a user must keep at least one passkey.
+    if ( Number(user_row?.password_required ?? 1) === 0 && credentials.length <= 1 ) {
+        return res.status(400).json({
+            error: 'Cannot delete your last passkey while passwordless login is enabled. Add a password first.',
+        });
+    }
+
+    await svc_webauthn.delete_credential({
+        user_id: req.user.id,
+        credential_id: req.params.id,
+    });
+    invalidate_cached_user_by_id(req.user.id);
+    res.json({ ok: true });
+});
+
+// ---- Rename credential (requires auth) ----
+router.post(
+    '/auth/webauthn/credentials/:id/rename',
+    express.json(),
+    body_parser_error_handler,
+    auth2,
+    async (req, res) => {
+        const actor = Context.get('actor');
+        if ( !actor || !(actor.type instanceof UserActorType) ) {
+            return res.status(403).json({ error: 'Forbidden' });
+        }
+
+        if ( ! req.body.name ) return res.status(400).json({ error: 'name is required' });
+
+        const svc_webauthn = req.services.get('webauthn');
+        await svc_webauthn.rename_credential({
+            user_id: req.user.id,
+            credential_id: req.params.id,
+            name: req.body.name,
+        });
+        res.json({ ok: true });
+    },
+);
+
+// ---- Authentication: begin (PUBLIC - no auth needed) ----
+router.post('/auth/webauthn/authenticate/begin', express.json(), body_parser_error_handler, async (req, res) => {
+    const svc_webauthn = req.services.get('webauthn');
+    let user = null;
+
+    if ( req.body.email && validator.isEmail(req.body.email) ) {
+        user = await get_user({ email: req.body.email, cached: false });
+    } else if ( req.body.username ) {
+        user = await get_user({ username: req.body.username, cached: false });
+    }
+
+    try {
+        const options = await svc_webauthn.generate_authentication_options({ user, req });
+        res.json(options);
+    } catch (e) {
+        console.error('[webauthn] authenticate/begin error:', e);
+        res.status(500).json({ error: e.message });
+    }
+});
+
+// ---- Authentication: complete (PUBLIC - creates session) ----
+router.post('/auth/webauthn/authenticate/complete', express.json(), body_parser_error_handler, async (req, res) => {
+    const svc_webauthn = req.services.get('webauthn');
+    const svc_auth     = req.services.get('auth');
+
+    if ( ! req.body.response ) return res.status(400).json({ proceed: false, error: 'response is required' });
+
+    // 2FA path: jwt token was issued after password check in /login
+    let user_id = null;
+    if ( req.body.webauthn_jwt_token ) {
+        const svc_token = req.services.get('token');
+        let decoded;
+        try {
+            decoded = svc_token.verify('webauthn', req.body.webauthn_jwt_token);
+        } catch (e) {
+            return res.status(400).json({ proceed: false, error: 'Invalid token' });
+        }
+        const u = await get_user({ uuid: decoded.user_uid, cached: false });
+        if ( ! u ) return res.status(400).json({ proceed: false, error: 'User not found' });
+        user_id = u.id;
+    }
+
+    try {
+        const result = await svc_webauthn.verify_authentication({
+            user_id,
+            response: req.body.response,
+            req,
+        });
+
+        const user = await get_user({ id: result.user_id, cached: false });
+        if ( ! user ) return res.status(400).json({ proceed: false, error: 'User not found' });
+
+        const { session, token: session_token } = await svc_auth.create_session_token(user, { req });
+        const gui_token = svc_auth.create_gui_token(user, session);
+
+        res.cookie(config.cookie_name, session_token, {
+            sameSite: 'none',
+            secure: true,
+            httpOnly: true,
+        });
+
+        return res.json({
+            proceed: true,
+            next_step: 'complete',
+            token: gui_token,
+            user: {
+                username: user.username,
+                uuid: user.uuid,
+                email: user.email,
+                email_confirmed: user.email_confirmed,
+                is_temp: (user.password === null && user.email === null),
+            },
+        });
+    } catch (e) {
+        console.error('[webauthn] authenticate/complete error:', e);
+        return res.status(400).json({ proceed: false, error: e.message });
+    }
+});
+
+// ---- Remove password - passkey-only login (requires auth) ----
+router.post(
+    '/auth/webauthn/remove-password',
+    express.json(),
+    body_parser_error_handler,
+    auth2,
+    async (req, res) => {
+        const actor = Context.get('actor');
+        if ( !actor || !(actor.type instanceof UserActorType) ) {
+            return res.status(403).json({ error: 'Forbidden' });
+        }
+
+        const svc_webauthn = req.services.get('webauthn');
+        const credentials  = await svc_webauthn.list_credentials(req.user.id);
+
+        if ( credentials.length === 0 ) {
+            return res.status(400).json({ error: 'Must have at least one passkey registered first' });
+        }
+
+        const has_synced_passkey = credentials.some(c => c.backed_up);
+        if ( ! has_synced_passkey ) {
+            return res.status(400).json({ error: 'Must have at least one synced passkey (not only security keys) to remove password' });
+        }
+
+        const db = req.services.get('database').get(DB_WRITE, 'webauthn');
+        const update_result = await db.write(
+            'UPDATE user SET password_required = 0 WHERE id = ?',
+            [req.user.id],
+        );
+        if ( ! update_result?.anyRowsAffected ) {
+            return res.status(500).json({ error: 'Failed to update password_required' });
+        }
+
+        // Disable 2FA when switching to passwordless — avoids a state where
+        // the user has no password but still has OTP configured (which would
+        // require entering an OTP after a passkey assertion, a confusing UX).
+        await db.write(
+            'UPDATE user SET otp_enabled = 0, otp_recovery_codes = NULL, otp_secret = NULL WHERE id = ?',
+            [req.user.id],
+        );
+
+        const [updated_user_row] = await db.read(
+            'SELECT password_required FROM user WHERE id = ? LIMIT 1',
+            [req.user.id],
+        );
+        invalidate_cached_user_by_id(req.user.id);
+        res.json({
+            ok: true,
+            password_required: Number(updated_user_row?.password_required ?? 1),
+            otp_disabled: true,
+        });
+    },
+);
+
+module.exports = router;

--- a/src/backend/src/routers/login.js
+++ b/src/backend/src/routers/login.js
@@ -176,6 +176,25 @@ router.post('/login', express.json(), body_parser_error_handler, (req, res, next
                 });
             }
 
+            // WebAuthn 2FA step (only when OTP is not also enabled)
+            if ( user.webauthn_enabled ) {
+                const svc_token = req.services.get('token');
+                const svc_webauthn = req.services.get('webauthn');
+
+                const webauthn_jwt_token = svc_token.sign('webauthn', {
+                    user_uid: user.uuid,
+                }, { expiresIn: '5m' });
+
+                const webauthn_options = await svc_webauthn.generate_authentication_options({ user, req });
+
+                return res.status(202).send({
+                    proceed: true,
+                    next_step: 'webauthn',
+                    webauthn_jwt_token,
+                    webauthn_options,
+                });
+            }
+
             return await complete_({ req, res, user });
         } else {
             svc_edgeRateLimit.incr('login');

--- a/src/backend/src/routers/user-protected/change-password.js
+++ b/src/backend/src/routers/user-protected/change-password.js
@@ -80,7 +80,7 @@ module.exports = eggspress('/change-password', {
     const { new_pass } = req.body;
     const { overallPass: strong } = check_password_strength(new_pass);
     if ( ! strong ) {
-        req.status(400).send('Password does not meet requirements.');
+        return res.status(400).send('Password does not meet requirements.');
     }
 
     // Update user
@@ -88,7 +88,7 @@ module.exports = eggspress('/change-password', {
     const bcrypt = require('bcrypt');
     const db = req.services.get('database').get(DB_WRITE, 'auth');
     await db.write(
-        'UPDATE user SET password=?, `pass_recovery_token` = NULL, `change_email_confirm_token` = NULL WHERE `id` = ?',
+        'UPDATE user SET password=?, password_required = 1, `pass_recovery_token` = NULL, `change_email_confirm_token` = NULL WHERE `id` = ?',
         [await bcrypt.hash(req.body.new_pass, 8), req.user.id],
     );
     invalidate_cached_user(req.user);

--- a/src/backend/src/services/PuterAPIService.js
+++ b/src/backend/src/services/PuterAPIService.js
@@ -22,6 +22,7 @@ import appsRouter from '../routers/apps.js';
 import authAppUidFromOriginRouter from '../routers/auth/app-uid-from-origin.js';
 import authCheckAppRouter from '../routers/auth/check-app.js';
 import configure2faRouter from '../routers/auth/configure-2fa.js';
+import webauthnRouter from '../routers/auth/webauthn.js';
 import createAccessTokenRouter from '../routers/auth/create-access-token.js';
 import listSessionsRouter from '../routers/auth/list-sessions.js';
 import { router as oidcRouter } from '../routers/auth/oidc.js';
@@ -98,6 +99,7 @@ export class PuterAPIService extends BaseService {
         app.use(createAccessTokenRouter);
         app.use(revokeAccessTokenRouter);
         app.use(configure2faRouter);
+        app.use(webauthnRouter);
         app.use(driverCallRouter);
         app.use(driverListInterfacesRouter);
         app.use(driverUsageRouter);

--- a/src/backend/src/services/auth/WebAuthnService.js
+++ b/src/backend/src/services/auth/WebAuthnService.js
@@ -1,0 +1,278 @@
+/*
+ * Copyright (C) 2024-present Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+const { BaseService } = require('../BaseService');
+const { DB_READ, DB_WRITE } = require('../database/consts');
+
+class WebAuthnService extends BaseService {
+
+    _get_rpid (req) {
+        if ( this.global_config.webauthn_rpid ) return this.global_config.webauthn_rpid;
+        if ( req && req.hostname ) {
+            // Strip 'api.' prefix so RP ID matches the page's domain, not the API subdomain
+            const h = req.hostname;
+            return h.startsWith('api.') ? h.slice(4) : h;
+        }
+        return 'puter.com';
+    }
+
+    _get_rpname () {
+        return this.global_config.webauthn_rpname || 'Puter';
+    }
+
+    // Origin is supplied by the frontend (window.location.origin) so it always
+    // matches the page domain, regardless of which API subdomain handled the request.
+    _get_origin (req, body_origin) {
+        if ( this.global_config.webauthn_origin ) return this.global_config.webauthn_origin;
+        if ( body_origin ) return body_origin;
+        const hostname = (req && req.hostname) || 'puter.com';
+        const protocol = hostname === 'localhost' ? 'http' : 'https';
+        return `${protocol}://${hostname}`;
+    }
+
+    async _cleanup_expired_challenges (db) {
+        const now = Math.floor(Date.now() / 1000);
+        await db.write('DELETE FROM webauthn_challenges WHERE expires_at < ?', [now]);
+    }
+
+    async generate_registration_options ({ user, req }) {
+        const { generateRegistrationOptions } = await import('@simplewebauthn/server');
+        const db = await this.services.get('database').get(DB_WRITE, 'webauthn');
+
+        await this._cleanup_expired_challenges(db);
+
+        const existing = await db.read(
+            'SELECT credential_id, transports FROM webauthn_credentials WHERE user_id = ?',
+            [user.id],
+        );
+
+        const options = await generateRegistrationOptions({
+            rpName: this._get_rpname(),
+            rpID: this._get_rpid(req),
+            userID: Buffer.from(user.uuid),
+            userName: user.username,
+            userDisplayName: user.username,
+            attestationType: 'none',
+            authenticatorSelection: {
+                residentKey: 'preferred',
+                userVerification: 'preferred',
+            },
+            excludeCredentials: existing.map(c => ({
+                id: c.credential_id,
+                transports: JSON.parse(c.transports || '[]'),
+            })),
+        });
+
+        const expires_at = Math.floor(Date.now() / 1000) + 300;
+        await db.write(
+            'INSERT INTO webauthn_challenges (user_id, challenge, type, expires_at) VALUES (?, ?, ?, ?)',
+            [user.id, options.challenge, 'registration', expires_at],
+        );
+
+        return options;
+    }
+
+    async verify_registration ({ user, response, req }) {
+        const { verifyRegistrationResponse } = await import('@simplewebauthn/server');
+        const db = await this.services.get('database').get(DB_WRITE, 'webauthn');
+
+        const rows = await db.read(
+            `SELECT * FROM webauthn_challenges
+             WHERE user_id = ? AND type = 'registration'
+             ORDER BY id DESC LIMIT 1`,
+            [user.id],
+        );
+
+        if ( !rows || rows.length === 0 ) throw new Error('No pending registration challenge');
+
+        const challenge = rows[0];
+        if ( challenge.expires_at < Math.floor(Date.now() / 1000) ) {
+            throw new Error('Challenge expired');
+        }
+
+        const verification = await verifyRegistrationResponse({
+            response,
+            expectedChallenge: challenge.challenge,
+            expectedOrigin: this._get_origin(req, req.body?.page_origin),
+            expectedRPID: this._get_rpid(req),
+            requireUserVerification: false,
+        });
+
+        if ( ! verification.verified ) throw new Error('Registration verification failed');
+
+        await db.write('DELETE FROM webauthn_challenges WHERE id = ?', [challenge.id]);
+
+        const { credential, credentialDeviceType, credentialBackedUp } = verification.registrationInfo;
+
+        return {
+            credential_id: credential.id,
+            public_key: Buffer.from(credential.publicKey).toString('base64url'),
+            counter: credential.counter,
+            device_type: credentialDeviceType,
+            backed_up: credentialBackedUp ? 1 : 0,
+            transports: JSON.stringify(response.response?.transports || []),
+        };
+    }
+
+    async save_credential ({ user_id, credential_data, name }) {
+        const db = await this.services.get('database').get(DB_WRITE, 'webauthn');
+
+        await db.write(
+            `INSERT INTO webauthn_credentials
+             (user_id, credential_id, public_key, counter, device_type, backed_up, transports, name)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+            [
+                user_id,
+                credential_data.credential_id,
+                credential_data.public_key,
+                credential_data.counter,
+                credential_data.device_type,
+                credential_data.backed_up,
+                credential_data.transports,
+                name || 'My Key',
+            ],
+        );
+
+        await db.write('UPDATE user SET webauthn_enabled = 1 WHERE id = ?', [user_id]);
+    }
+
+    async generate_authentication_options ({ user, req }) {
+        const { generateAuthenticationOptions } = await import('@simplewebauthn/server');
+        const db = await this.services.get('database').get(DB_WRITE, 'webauthn');
+
+        await this._cleanup_expired_challenges(db);
+
+        let allow_credentials = [];
+        if ( user ) {
+            const creds = await db.read(
+                'SELECT credential_id, transports FROM webauthn_credentials WHERE user_id = ?',
+                [user.id],
+            );
+            allow_credentials = creds.map(c => ({
+                id: c.credential_id,
+                transports: JSON.parse(c.transports || '[]'),
+            }));
+        }
+
+        const options = await generateAuthenticationOptions({
+            rpID: this._get_rpid(req),
+            userVerification: 'preferred',
+            allowCredentials: allow_credentials,
+        });
+
+        const expires_at = Math.floor(Date.now() / 1000) + 300;
+        await db.write(
+            'INSERT INTO webauthn_challenges (user_id, challenge, type, expires_at) VALUES (?, ?, ?, ?)',
+            [user ? user.id : null, options.challenge, 'authentication', expires_at],
+        );
+
+        return options;
+    }
+
+    async verify_authentication ({ user_id, response, req }) {
+        const { verifyAuthenticationResponse } = await import('@simplewebauthn/server');
+        const db = await this.services.get('database').get(DB_WRITE, 'webauthn');
+
+        const cred_rows = await db.read(
+            'SELECT * FROM webauthn_credentials WHERE credential_id = ?',
+            [response.id],
+        );
+
+        if ( !cred_rows || cred_rows.length === 0 ) throw new Error('Credential not found');
+        const cred = cred_rows[0];
+
+        if ( user_id && cred.user_id !== user_id ) throw new Error('Credential does not belong to user');
+
+        const challenge_rows = await db.read(
+            `SELECT * FROM webauthn_challenges
+             WHERE type = 'authentication' AND (user_id = ? OR user_id IS NULL)
+             ORDER BY id DESC LIMIT 1`,
+            [cred.user_id],
+        );
+
+        if ( !challenge_rows || challenge_rows.length === 0 ) throw new Error('No pending authentication challenge');
+
+        const challenge = challenge_rows[0];
+        if ( challenge.expires_at < Math.floor(Date.now() / 1000) ) throw new Error('Challenge expired');
+
+        const verification = await verifyAuthenticationResponse({
+            response,
+            expectedChallenge: challenge.challenge,
+            expectedOrigin: this._get_origin(req, req.body?.page_origin),
+            expectedRPID: this._get_rpid(req),
+            credential: {
+                id: cred.credential_id,
+                publicKey: Buffer.from(cred.public_key, 'base64url'),
+                counter: cred.counter,
+                transports: JSON.parse(cred.transports || '[]'),
+            },
+            requireUserVerification: false,
+        });
+
+        if ( ! verification.verified ) throw new Error('Authentication verification failed');
+
+        await db.write(
+            'UPDATE webauthn_credentials SET counter = ?, last_used_at = datetime(\'now\') WHERE id = ?',
+            [verification.authenticationInfo.newCounter, cred.id],
+        );
+
+        await db.write('DELETE FROM webauthn_challenges WHERE id = ?', [challenge.id]);
+
+        return { user_id: cred.user_id };
+    }
+
+    async list_credentials (user_id) {
+        const db = await this.services.get('database').get(DB_READ, 'webauthn');
+        return await db.read(
+            `SELECT id, name, device_type, backed_up, transports, created_at, last_used_at
+             FROM webauthn_credentials WHERE user_id = ?`,
+            [user_id],
+        );
+    }
+
+    async delete_credential ({ user_id, credential_id }) {
+        const db = await this.services.get('database').get(DB_WRITE, 'webauthn');
+
+        await db.write(
+            'DELETE FROM webauthn_credentials WHERE id = ? AND user_id = ?',
+            [credential_id, user_id],
+        );
+
+        const remaining = await db.read(
+            'SELECT COUNT(*) as cnt FROM webauthn_credentials WHERE user_id = ?',
+            [user_id],
+        );
+
+        if ( remaining[0].cnt === 0 ) {
+            await db.write(
+                'UPDATE user SET webauthn_enabled = 0, password_required = 1 WHERE id = ?',
+                [user_id],
+            );
+        }
+    }
+
+    async rename_credential ({ user_id, credential_id, name }) {
+        const db = await this.services.get('database').get(DB_WRITE, 'webauthn');
+        await db.write(
+            'UPDATE webauthn_credentials SET name = ? WHERE id = ? AND user_id = ?',
+            [name, credential_id, user_id],
+        );
+    }
+}
+
+module.exports = { WebAuthnService };

--- a/src/backend/src/services/database/SqliteDatabaseAccessService.js
+++ b/src/backend/src/services/database/SqliteDatabaseAccessService.js
@@ -176,6 +176,9 @@ class SqliteDatabaseAccessService extends BaseDatabaseAccessService {
             [42, [
                 '0046_is-private-apps.sql',
             ]],
+            [43, [
+                '0047_webauthn.sql',
+            ]],
         ];
 
         // Database upgrade logic

--- a/src/backend/src/services/database/sqlite_setup/0047_webauthn.sql
+++ b/src/backend/src/services/database/sqlite_setup/0047_webauthn.sql
@@ -1,0 +1,26 @@
+CREATE TABLE webauthn_credentials (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id       INTEGER NOT NULL,
+    credential_id TEXT    NOT NULL UNIQUE,
+    public_key    TEXT    NOT NULL,
+    counter       INTEGER NOT NULL DEFAULT 0,
+    device_type   TEXT,
+    backed_up     TINYINT(1) DEFAULT 0,
+    transports    TEXT,
+    name          TEXT,
+    created_at    TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    last_used_at  TIMESTAMP,
+    FOREIGN KEY(user_id) REFERENCES user(id) ON DELETE CASCADE
+);
+
+CREATE TABLE webauthn_challenges (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    INTEGER,
+    challenge  TEXT    NOT NULL UNIQUE,
+    type       TEXT    NOT NULL,
+    expires_at INTEGER NOT NULL,
+    FOREIGN KEY(user_id) REFERENCES user(id) ON DELETE CASCADE
+);
+
+ALTER TABLE user ADD COLUMN webauthn_enabled  TINYINT(1) DEFAULT 0;
+ALTER TABLE user ADD COLUMN password_required TINYINT(1) DEFAULT 1;

--- a/src/backend/src/services/web/UserProtectedEndpointsService.js
+++ b/src/backend/src/services/web/UserProtectedEndpointsService.js
@@ -131,7 +131,7 @@ class UserProtectedEndpointsService extends BaseService {
             const is_change_password = req.path === '/change-password';
             const is_add_password_mode = is_change_password &&
                 req.headers['x-puter-add-password'] === '1' &&
-                user.password === null;
+                (user.password === null || Number(user.password_required) === 0);
 
             if ( user.password === null && user.email === null ) {
                 return next();

--- a/src/backend/src/services/web/UserProtectedEndpointsService.js
+++ b/src/backend/src/services/web/UserProtectedEndpointsService.js
@@ -128,8 +128,18 @@ class UserProtectedEndpointsService extends BaseService {
 
             const user = await get_user({ id: req.user.id, force: true });
             const revalidationCookie = req.cookies && req.cookies[REVALIDATION_COOKIE_NAME];
+            const is_change_password = req.path === '/change-password';
+            const is_add_password_mode = is_change_password &&
+                req.headers['x-puter-add-password'] === '1' &&
+                user.password === null;
 
             if ( user.password === null && user.email === null ) {
+                return next();
+            }
+
+            // Add-password mode should not require current password.
+            // This exception is intentionally scoped to only /change-password.
+            if ( is_add_password_mode ) {
                 return next();
             }
 

--- a/src/gui/package.json
+++ b/src/gui/package.json
@@ -45,6 +45,7 @@
     ]
   },
   "dependencies": {
+    "@simplewebauthn/browser": "^13.3.0",
     "file-type": "21.3.3",
     "json-colorizer": "^3.0.1",
     "mocha": "7.2.0",

--- a/src/gui/src/UI/Settings/UITabSecurity.js
+++ b/src/gui/src/UI/Settings/UITabSecurity.js
@@ -124,11 +124,11 @@ export default {
         // button is disabled.
         const $tip = $('<div style="position:fixed;background:#1a1a1a;color:#fff;font-size:11px;line-height:1.4;padding:5px 8px;border-radius:5px;pointer-events:none;display:none;z-index:99999;max-width:220px;white-space:normal;text-align:center;box-shadow:0 2px 6px rgba(0,0,0,.3);"></div>').appendTo('body');
         $el_window
-            .on('mouseenter', '[data-tooltip]', function () {
-                const text = $(this).attr('data-tooltip');
+            .on('mouseenter', '[data-tooltip]', function (event) {
+                const text = $(event.currentTarget).attr('data-tooltip');
                 if ( ! text ) return;
                 $tip.text(text).show();
-                const r = this.getBoundingClientRect();
+                const r = event.currentTarget.getBoundingClientRect();
                 const tw = $tip.outerWidth(), th = $tip.outerHeight();
                 let top = r.top - th - 6;
                 let left = Math.max(4, Math.min(r.left + r.width / 2 - tw / 2, window.innerWidth - tw - 4));
@@ -324,8 +324,8 @@ export default {
             $el_window.find('.passwordless-warning').show();
         });
 
-        $el_window.find('.confirm-remove-password-btn').on('click', async function () {
-            const $btn = $(this);
+        $el_window.find('.confirm-remove-password-btn').on('click', async function (event) {
+            const $btn = $(event.currentTarget);
             $btn.prop('disabled', true).text('Removing…');
 
             const showStatus = (msg, color) => {

--- a/src/gui/src/UI/Settings/UITabSecurity.js
+++ b/src/gui/src/UI/Settings/UITabSecurity.js
@@ -18,6 +18,11 @@
  */
 import UIWindow2FASetup from '../UIWindow2FASetup.js';
 import UIWindowDisable2FA from './UIWindowDisable2FA.js';
+import UIWindowWebAuthnSetup from '../UIWindowWebAuthnSetup.js';
+import UIWindowChangePassword from '../UIWindowChangePassword.js';
+import UIAlert from '../UIAlert.js';
+
+const CARD_STYLE = 'border:1px solid #cccccc8f; border-radius:4px; background:#f7f7f7a1; margin-bottom:20px; padding:10px 15px;';
 
 export default {
     id: 'security',
@@ -32,7 +37,7 @@ export default {
             h += '<div class="settings-card">';
             h += `<strong>${i18n('password')}</strong>`;
             h += '<div style="flex-grow:1;">';
-            h += `<button class="button change-password" style="float:right;">${i18n('change_password')}</button>`;
+            h += `<button class="button password-action-btn" style="float:right;">${i18n('change_password')}</button>`;
             h += '</div>';
             h += '</div>';
         }
@@ -45,9 +50,10 @@ export default {
         h += '</div>';
         h += '</div>';
 
-        // configure 2FA
+        // configure 2FA (OTP)
         if ( !user.is_temp && user.email_confirmed ) {
             h += `<div class="settings-card settings-card-security ${user.otp ? 'settings-card-success' : 'settings-card-warning'}">`;
+            h += '<div style="display:flex; align-items:center; width:100%;">';
             h += '<div>';
             h += `<strong style="display:block;">${i18n('two_factor')}</strong>`;
             h += `<span class="user-otp-state" style="display:block; margin-top:5px;">${
@@ -55,41 +61,321 @@ export default {
             }</span>`;
             h += '</div>';
             h += '<div style="flex-grow:1;">';
-            h += `<button class="button enable-2fa" style="float:right;${user.otp ? 'display:none;' : ''}">${i18n('enable_2fa')}</button>`;
+            h += `<span class="enable-2fa-wrapper" style="float:right;${user.otp ? 'display:none;' : 'display:inline-block;'}">`;
+            h += `<button class="button enable-2fa">${i18n('enable_2fa')}</button>`;
+            h += '</span>';
             h += `<button class="button disable-2fa" style="float:right;${user.otp ? '' : 'display:none;'}">${i18n('disable_2fa')}</button>`;
             h += '</div>';
+            h += '</div>';
+            h += '</div>';
+        }
+
+        // Passkeys & Security Keys (WebAuthn)
+        if ( !user.is_temp && window.PublicKeyCredential ) {
+            // Custom card: same look as settings-card but column layout, no overflow:hidden
+            h += `<div style="${CARD_STYLE}">`;
+            // Header row: title left, button right — same as Password/Sessions cards
+            h += '<div style="display:flex; align-items:center;">';
+            h += `<strong>${i18n('webauthn_section_title')}</strong>`;
+            h += '<div style="flex-grow:1;">';
+            h += `<button class="button add-webauthn-key" style="float:right;">${i18n('webauthn_add_key')}</button>`;
+            h += '</div>';
+            h += '</div>';
+            // Content area below header (text when empty, rows when populated)
+            h += `<div class="webauthn-credentials-list" style="margin-top:8px; font-size:13px; color:#888;">${i18n('loading')}</div>`;
+            h += '</div>';
+        }
+
+        // Passwordless login toggle — hidden initially, shown by render_credentials() once
+        // we know at least one passkey is registered (avoids depending on window.user.webauthn_enabled)
+        if ( !user.is_temp && window.PublicKeyCredential ) {
+            h += `<div class="passwordless-card" style="${CARD_STYLE} display:none;">`;
+            h += '<div style="display:flex; align-items:center;">';
+            h += '<div>';
+            h += `<strong style="display:block;">${i18n('passwordless_login_title')}</strong>`;
+            h += '<span class="passwordless-state" style="display:block; margin-top:4px; font-size:13px; color:#888;"></span>';
+            h += '</div>';
+            h += '<div style="flex-grow:1;">';
+            h += `<button class="button remove-password-btn" style="float:right; display:none;">${i18n('passwordless_remove_password')}</button>`;
+            h += `<span class="passwordless-active-badge" style="float:right; padding:6px 10px; color:#27ae60; font-weight:600; display:none;">${i18n('passwordless_login_active')}</span>`;
+            h += '</div>';
+            h += '</div>';
+            // Inline confirm row — shown when user clicks "Remove Password" (avoids UIAlert/.close() issues)
+            h += '<div class="passwordless-confirm-row" style="display:none; margin-top:10px; padding:8px 10px; background:#fff3cd; border-radius:6px; border:1px solid #ffc107;">';
+            h += `<span style="font-size:12px; color:#856404;">${i18n('passwordless_confirm_message')}</span>`;
+            h += '<div style="margin-top:8px;">';
+            h += `<button class="button button-small button-danger confirm-remove-password-btn">${i18n('confirm')}</button>`;
+            h += `<button class="button button-small cancel-remove-password-btn" style="margin-left:6px;">${i18n('cancel')}</button>`;
+            h += '</div>';
+            h += '</div>';
+            // Inline status message — shows success or error without a modal
+            h += '<p class="passwordless-status-msg" style="margin:8px 0 0; font-size:12px; display:none;"></p>';
+            h += `<p class="passwordless-warning" style="margin:8px 0 0 0; font-size:12px; color:#e67e22; display:none;">${i18n('passwordless_warning')}</p>`;
             h += '</div>';
         }
 
         return h;
     },
     init: ($el_window) => {
-        $el_window.find('.enable-2fa').on('click', async function (e) {
+        let is_passwordless_mode = false;
 
+        // Fast custom tooltip — native title has ~1s delay and doesn't work on disabled elements.
+        // Elements use data-tooltip="text"; the wrapper span receives hover even when the inner
+        // button is disabled.
+        const $tip = $('<div style="position:fixed;background:#1a1a1a;color:#fff;font-size:11px;line-height:1.4;padding:5px 8px;border-radius:5px;pointer-events:none;display:none;z-index:99999;max-width:220px;white-space:normal;text-align:center;box-shadow:0 2px 6px rgba(0,0,0,.3);"></div>').appendTo('body');
+        $el_window
+            .on('mouseenter', '[data-tooltip]', function () {
+                const text = $(this).attr('data-tooltip');
+                if ( ! text ) return;
+                $tip.text(text).show();
+                const r = this.getBoundingClientRect();
+                const tw = $tip.outerWidth(), th = $tip.outerHeight();
+                let top = r.top - th - 6;
+                let left = Math.max(4, Math.min(r.left + r.width / 2 - tw / 2, window.innerWidth - tw - 4));
+                if ( top < 4 ) top = r.bottom + 6;
+                $tip.css({ top, left });
+            })
+            .on('mouseleave', '[data-tooltip]', () => $tip.hide());
+        $el_window.on('remove', () => $tip.remove());
+
+        // OTP 2FA (unchanged)
+        $el_window.find('.enable-2fa').on('click', async function () {
             const { promise } = await UIWindow2FASetup();
             const tfa_was_enabled = await promise;
-
             if ( tfa_was_enabled ) {
-                $el_window.find('.enable-2fa').hide();
+                $el_window.find('.enable-2fa-wrapper').hide();
                 $el_window.find('.disable-2fa').show();
                 $el_window.find('.user-otp-state').text(i18n('two_factor_enabled'));
-                $el_window.find('.settings-card-security').removeClass('settings-card-warning');
-                $el_window.find('.settings-card-security').addClass('settings-card-success');
+                $el_window.find('.settings-card-security').removeClass('settings-card-warning').addClass('settings-card-success');
             }
-
-            return;
         });
 
-        $el_window.find('.disable-2fa').on('click', async function (e) {
+        $el_window.find('.disable-2fa').on('click', async function () {
             const { promise } = await UIWindowDisable2FA();
             const tfa_was_disabled = await promise;
-
             if ( tfa_was_disabled ) {
-                $el_window.find('.enable-2fa').show();
+                $el_window.find('.enable-2fa-wrapper').show();
                 $el_window.find('.disable-2fa').hide();
                 $el_window.find('.user-otp-state').text(i18n('two_factor_disabled'));
-                $el_window.find('.settings-card-security').removeClass('settings-card-success');
-                $el_window.find('.settings-card-security').addClass('settings-card-warning');
+                $el_window.find('.settings-card-security').removeClass('settings-card-success').addClass('settings-card-warning');
+            }
+        });
+
+        // WebAuthn: render credentials list
+        const render_credentials = async () => {
+            const $list = $el_window.find('.webauthn-credentials-list');
+            if ( ! $list.length ) return;
+
+            $list.css({ display: 'block', 'font-size': '13px', color: '#888', 'margin-top': '8px' })
+                .html(i18n('loading'));
+
+            try {
+                const resp = await fetch(`${window.api_origin}/auth/webauthn/credentials`, {
+                    headers: { Authorization: `Bearer ${puter.authToken}` },
+                });
+                const data = await resp.json();
+                const creds = data.credentials || [];
+
+                // Always sync the authoritative password_required value from the API
+                const is_passwordless = Number(data.password_required) === 0;
+                is_passwordless_mode = is_passwordless;
+                $el_window.find('.password-action-btn')
+                    .text(i18n(is_passwordless ? 'add_password' : 'change_password'));
+
+                if ( creds.length === 0 ) {
+                    $list.css({ display: 'block', 'font-size': '13px', color: '#888', 'margin-top': '8px' })
+                        .html(i18n('webauthn_no_keys'));
+                    $el_window.find('.passwordless-card').hide();
+                    return;
+                }
+
+                // At least one passkey exists — reveal the passwordless card with correct state
+                $el_window.find('.passwordless-card').show();
+                $el_window.find('.passwordless-state')
+                    .text(i18n(is_passwordless ? 'passwordless_login_enabled' : 'passwordless_login_disabled'));
+                $el_window.find('.remove-password-btn').toggle(!is_passwordless);
+                $el_window.find('.passwordless-active-badge').toggle(is_passwordless);
+                $el_window.find('.passwordless-warning').toggle(!is_passwordless);
+                // Always reset the inline confirm row and status message on re-render
+                $el_window.find('.passwordless-confirm-row').hide();
+                $el_window.find('.confirm-remove-password-btn').prop('disabled', false).text(i18n('confirm'));
+                $el_window.find('.passwordless-status-msg').hide().text('');
+
+                // Disable the Enable 2FA button while passwordless login is active
+                $el_window.find('.enable-2fa').prop('disabled', is_passwordless);
+                $el_window.find('.enable-2fa-wrapper')
+                    .attr('data-tooltip', is_passwordless ? i18n('two_factor_disabled_passwordless') : null)
+                    .css('cursor', is_passwordless ? 'not-allowed' : '');
+
+                // Show credential rows
+                $list.css({ display: 'flex',
+                    'flex-direction': 'column',
+                    gap: '8px',
+                    'font-size': '',
+                    color: '',
+                    'margin-top': '12px' })
+                    .html('');
+
+                creds.forEach(cred => {
+                    const type_label = cred.backed_up
+                        ? i18n('webauthn_type_passkey')
+                        : i18n('webauthn_type_security_key');
+                    const last_used = cred.last_used_at
+                        ? new Date(cred.last_used_at).toLocaleDateString()
+                        : i18n('webauthn_never_used');
+                    const display_name = $('<span>').text(cred.name || i18n('webauthn_unnamed_key')).html();
+
+                    const $row = $(`
+                        <div style="display:flex; align-items:center; padding:8px 10px; background:#fff; border-radius:6px; border:1px solid #e0e0e0;">
+                            <div style="flex-grow:1; min-width:0;">
+                                <strong style="display:block;">${display_name}</strong>
+                                <span style="font-size:12px; color:#888;">${type_label} · ${i18n('webauthn_last_used')}: ${last_used}</span>
+                            </div>
+                            <button class="button button-small rename-key" style="margin-right:6px; flex-shrink:0;">${i18n('rename')}</button>
+                            <span class="delete-key-wrapper" style="flex-shrink:0; display:inline-block;">
+                                <button class="button button-small button-danger delete-key">${i18n('delete')}</button>
+                            </span>
+                        </div>
+                    `);
+
+                    if ( is_passwordless ) {
+                        $row.find('.delete-key').prop('disabled', true);
+                        $row.find('.delete-key-wrapper')
+                            .attr('data-tooltip', i18n('webauthn_delete_disabled_passwordless'))
+                            .css('cursor', 'not-allowed');
+                    }
+
+                    $row.find('.rename-key').on('click', async function () {
+                        const new_name = prompt(i18n('webauthn_rename_prompt'), cred.name || '');
+                        if ( !new_name || !new_name.trim() ) return;
+                        await fetch(`${window.api_origin}/auth/webauthn/credentials/${cred.id}/rename`, {
+                            method: 'POST',
+                            headers: {
+                                Authorization: `Bearer ${puter.authToken}`,
+                                'Content-Type': 'application/json',
+                            },
+                            body: JSON.stringify({ name: new_name.trim() }),
+                        });
+                        await render_credentials();
+                    });
+
+                    $row.find('.delete-key').on('click', async function () {
+                        if ( ! confirm(i18n('webauthn_delete_confirm')) ) return;
+                        const resp = await fetch(`${window.api_origin}/auth/webauthn/credentials/${cred.id}`, {
+                            method: 'DELETE',
+                            headers: { Authorization: `Bearer ${puter.authToken}` },
+                        });
+                        if ( ! resp.ok ) {
+                            let message = i18n('something_went_wrong');
+                            try {
+                                const data = await resp.json();
+                                message = data.error || message;
+                            } catch {
+                                // Keep generic error message fallback.
+                            }
+                            await UIAlert({
+                                message,
+                                parent_uuid: $el_window.attr('data-element_uuid'),
+                            });
+                            return;
+                        }
+                        await render_credentials();
+                    });
+
+                    $list.append($row);
+                });
+            } catch (e) {
+                $list.css({ display: 'block', 'font-size': '13px', color: '#e74c3c', 'margin-top': '8px' })
+                    .html(i18n('something_went_wrong'));
+                $el_window.find('.passwordless-card').hide();
+            }
+        };
+
+        $el_window.find('.password-action-btn').on('click', function () {
+            UIWindowChangePassword({
+                mode: is_passwordless_mode ? 'add' : 'change',
+                on_success: async () => {
+                    await render_credentials();
+                },
+                window_options: {
+                    parent_uuid: $el_window.attr('data-element_uuid'),
+                },
+            });
+        });
+
+        $el_window.find('.add-webauthn-key').on('click', async function () {
+            const registered = await UIWindowWebAuthnSetup();
+            if ( registered ) await render_credentials();
+        });
+
+        render_credentials();
+
+        // Passwordless login: show inline confirm row (avoids UIAlert/.close() reliability issues)
+        $el_window.find('.remove-password-btn').on('click', function () {
+            $el_window.find('.remove-password-btn').hide();
+            $el_window.find('.passwordless-warning').hide();
+            $el_window.find('.passwordless-status-msg').hide().text('');
+            $el_window.find('.passwordless-confirm-row').show();
+        });
+
+        $el_window.find('.cancel-remove-password-btn').on('click', function () {
+            $el_window.find('.passwordless-confirm-row').hide();
+            $el_window.find('.remove-password-btn').show();
+            $el_window.find('.passwordless-warning').show();
+        });
+
+        $el_window.find('.confirm-remove-password-btn').on('click', async function () {
+            const $btn = $(this);
+            $btn.prop('disabled', true).text('Removing…');
+
+            const showStatus = (msg, color) => {
+                $el_window.find('.passwordless-status-msg')
+                    .text(msg).css('color', color).show();
+            };
+
+            try {
+                const resp = await fetch(`${window.api_origin}/auth/webauthn/remove-password`, {
+                    method: 'POST',
+                    headers: { Authorization: `Bearer ${puter.authToken}` },
+                });
+                const data = await resp.json();
+
+                if ( ! resp.ok ) {
+                    $btn.prop('disabled', false).text(i18n('confirm'));
+                    $el_window.find('.passwordless-confirm-row').hide();
+                    $el_window.find('.remove-password-btn').show();
+                    $el_window.find('.passwordless-warning').show();
+                    showStatus(data.error || i18n('something_went_wrong'), '#e74c3c');
+                    return;
+                }
+
+                // Re-read state from backend and update UI (hides confirm row, resets button)
+                await render_credentials();
+
+                if ( Number(data.password_required) === 0 ) {
+                    showStatus(i18n('passwordless_login_enabled'), '#27ae60');
+                    setTimeout(() => $el_window.find('.passwordless-status-msg').fadeOut(400), 3000);
+
+                    // 2FA was disabled server-side alongside password removal; reflect in UI
+                    if ( data.otp_disabled ) {
+                        $el_window.find('.disable-2fa').hide();
+                        $el_window.find('.enable-2fa-wrapper').show();
+                        $el_window.find('.user-otp-state').text(i18n('two_factor_disabled'));
+                        $el_window.find('.settings-card-security')
+                            .removeClass('settings-card-success')
+                            .addClass('settings-card-warning');
+                        // render_credentials() already disables the enable-2fa button
+                        // for passwordless mode, so no extra call needed here
+                    }
+                } else {
+                    showStatus('Password removal did not persist on the server. Please try again.', '#e74c3c');
+                }
+            } catch (e) {
+                $btn.prop('disabled', false).text(i18n('confirm'));
+                $el_window.find('.passwordless-confirm-row').hide();
+                $el_window.find('.remove-password-btn').show();
+                $el_window.find('.passwordless-warning').show();
+                showStatus(e?.message || i18n('something_went_wrong'), '#e74c3c');
             }
         });
     },

--- a/src/gui/src/UI/UIWindow.js
+++ b/src/gui/src/UI/UIWindow.js
@@ -1837,9 +1837,15 @@ async function UIWindow (options) {
     // Close button
     // --------------------------------------------------------
     $(`#window-${win_id} > .window-head > .window-close-btn`).click(function () {
-        $(el_window).close({
-            shrink_to_target: options.on_close_shrink_to_target,
-        });
+        const $window = $(el_window);
+        if ( typeof $window.close === 'function' ) {
+            $window.close({
+                shrink_to_target: options.on_close_shrink_to_target,
+            });
+            return;
+        }
+        // Fallback for cases where jQuery window extensions fail to load.
+        delete_window_element(el_window);
     });
 
     // --------------------------------------------------------
@@ -3699,22 +3705,38 @@ $.fn.close = async function (options) {
             // FileDialog closed
             if ( $(this).hasClass('window-filedialog') || $(this).attr('data-disable_parent_window') === 'true' ) {
                 // re-enable this FileDialog's parent window
-                $(`.window[data-element_uuid="${$(this).attr('data-parent_uuid')}"]`).addClass('window-active');
-                $(`.window[data-element_uuid="${$(this).attr('data-parent_uuid')}"]`).removeClass('window-disabled');
-                $(`.window[data-element_uuid="${$(this).attr('data-parent_uuid')}"]`).find('.window-disable-mask').hide();
+                const $parent_window = $(`.window[data-element_uuid="${$(this).attr('data-parent_uuid')}"]`);
+                $parent_window.addClass('window-active');
+                $parent_window.removeClass('window-disabled');
+                $parent_window.find('.window-disable-mask').hide();
                 // bring focus back to app iframe, if needed
-                $(`.window[data-element_uuid="${$(this).attr('data-parent_uuid')}"]`).focusWindow();
+                if ( typeof $parent_window.focusWindow === 'function' ) {
+                    $parent_window.focusWindow();
+                } else {
+                    $parent_window.addClass('window-active');
+                }
             }
             // Other types of windows closed
             else {
                 // close any open FileDialogs belonging to this window
-                $(`.window-filedialog[data-parent_uuid="${window_uuid}"]`).close();
+                const $file_dialogs = $(`.window-filedialog[data-parent_uuid="${window_uuid}"]`);
+                if ( typeof $file_dialogs.close === 'function' ) {
+                    $file_dialogs.close();
+                } else {
+                    $file_dialogs.each(function () {
+                        delete_window_element(this);
+                    });
+                }
                 // bring focus to the last window in the window-stack (only if not minimized)
                 if ( ! _.isEmpty(window.window_stack) ) {
                     const $last_window_in_stack = $(`.window[data-id="${window.window_stack[window.window_stack.length - 1]}"]`);
                     // check if previous window is not minimized
                     if ( $last_window_in_stack !== null && $last_window_in_stack.attr('data-is_minimized') !== '1' && $last_window_in_stack.attr('data-is_minimized') !== 'true' ) {
-                        $(`.window[data-id="${window.window_stack[window.window_stack.length - 1]}"]`).focusWindow();
+                        if ( typeof $last_window_in_stack.focusWindow === 'function' ) {
+                            $last_window_in_stack.focusWindow();
+                        } else {
+                            $last_window_in_stack.addClass('window-active');
+                        }
                     }
                     // otherwise, change URL/Title to desktop
                     else {
@@ -3734,7 +3756,14 @@ $.fn.close = async function (options) {
                 }
             }
             // close child windows
-            $(`.window[data-parent_uuid="${window_uuid}"]`).close();
+            const $child_windows = $(`.window[data-parent_uuid="${window_uuid}"]`);
+            if ( typeof $child_windows.close === 'function' ) {
+                $child_windows.close();
+            } else {
+                $child_windows.each(function () {
+                    delete_window_element(this);
+                });
+            }
 
             // notify other apps that we're closing
             window.report_app_closed(window_uuid, options.status_code ?? 0);

--- a/src/gui/src/UI/UIWindowChangePassword.js
+++ b/src/gui/src/UI/UIWindowChangePassword.js
@@ -23,6 +23,7 @@ import UIWindow from './UIWindow.js';
 
 async function UIWindowChangePassword (options) {
     options = options ?? {};
+    const is_add_password = options.mode === 'add';
 
     const internal_id = window.uuidv4();
     let h = '';
@@ -31,17 +32,19 @@ async function UIWindowChangePassword (options) {
     h += '<div class="form-error-msg"></div>';
     // success msg
     h += '<div class="form-success-msg"></div>';
-    // current password / OIDC revalidate
-    h += '<div class="change-password-auth-row" style="overflow: hidden; margin-bottom: 20px;">';
-    h += '<div class="change-password-current-wrap">';
-    h += `<label for="current-password-${internal_id}">${i18n('current_password')}</label>`;
-    h += `<input id="current-password-${internal_id}" class="current-password" type="password" name="current-password" autocomplete="current-password" />`;
-    h += '</div>';
-    h += '<div class="change-password-oidc-wrap" style="display:none;">';
-    h += '<p class="change-password-oidc-flow-notice" style="margin:0;font-size:12px;color:#666;"></p>';
-    h += '<span class="change-password-revalidated-msg" style="display:none;"></span>';
-    h += '</div>';
-    h += '</div>';
+    // current password / OIDC revalidate (hidden in add-password mode)
+    if ( ! is_add_password ) {
+        h += '<div class="change-password-auth-row" style="overflow: hidden; margin-bottom: 20px;">';
+        h += '<div class="change-password-current-wrap">';
+        h += `<label for="current-password-${internal_id}">${i18n('current_password')}</label>`;
+        h += `<input id="current-password-${internal_id}" class="current-password" type="password" name="current-password" autocomplete="current-password" />`;
+        h += '</div>';
+        h += '<div class="change-password-oidc-wrap" style="display:none;">';
+        h += '<p class="change-password-oidc-flow-notice" style="margin:0;font-size:12px;color:#666;"></p>';
+        h += '<span class="change-password-revalidated-msg" style="display:none;"></span>';
+        h += '</div>';
+        h += '</div>';
+    }
     // new password
     h += '<div style="overflow: hidden; margin-top: 20px; margin-bottom: 20px;">';
     h += `<label for="new-password-${internal_id}">${i18n('new_password')}</label>`;
@@ -54,12 +57,11 @@ async function UIWindowChangePassword (options) {
     h += '</div>';
     h += '<p class="change-password-oidc-hint" style="margin-top:6px;font-size:12px;color:#666;display:none;"></p>';
 
-    // Change Password
-    h += `<button class="change-password-btn button button-primary button-block button-normal">${i18n('change_password')}</button>`;
+    h += `<button class="change-password-btn button button-primary button-block button-normal">${i18n(is_add_password ? 'add_password' : 'change_password')}</button>`;
     h += '</div>';
 
     const el_window = await UIWindow({
-        title: i18n('window_title_change_password'),
+        title: i18n(is_add_password ? 'add_password' : 'window_title_change_password'),
         app: 'change-passowrd',
         single_instance: true,
         icon: null,
@@ -80,6 +82,10 @@ async function UIWindowChangePassword (options) {
         dominant: true,
         show_in_taskbar: false,
         onAppend: function (this_window) {
+            if ( is_add_password ) {
+                $(this_window).find('.new-password').get(0)?.focus({ preventScroll: true });
+                return;
+            }
             $(this_window).find('.current-password').get(0)?.focus({ preventScroll: true });
             const oidc_only = !!(window.user && window.user.oidc_only);
             const authRow = $(this_window).find('.change-password-auth-row');
@@ -135,7 +141,7 @@ async function UIWindowChangePassword (options) {
             return;
         }
         // For password users, current password is required; for OIDC, we need revalidated or will open popup
-        if ( !oidc_only && !current_password ) {
+        if ( !is_add_password && !oidc_only && !current_password ) {
             $(el_window).find('.form-error-msg').html('All fields are required.');
             $(el_window).find('.form-error-msg').fadeIn();
             return;
@@ -152,7 +158,7 @@ async function UIWindowChangePassword (options) {
             return;
         }
 
-        if ( oidc_only && !revalidated && !current_password ) {
+        if ( !is_add_password && oidc_only && !revalidated && !current_password ) {
             await myOpenRevalidatePopup();
 
             const res = await doSubmit({ new_password });
@@ -184,10 +190,14 @@ async function UIWindowChangePassword (options) {
     });
 
     function doSubmit ({ new_password, current_password }) {
+        const headers = { 'Content-Type': 'application/json' };
+        if ( is_add_password ) {
+            headers['X-Puter-Add-Password'] = '1';
+        }
         return fetch(apiUrl, {
             method: 'POST',
             credentials: 'include',
-            headers: { 'Content-Type': 'application/json' },
+            headers,
             body: JSON.stringify({
                 password: current_password,
                 new_pass: new_password,
@@ -208,6 +218,7 @@ async function UIWindowChangePassword (options) {
         $(el_window).find('input').val('');
         $(el_window).find('.change-password-btn').removeClass('disabled');
         $(el_window).find('.current-password, .new-password, .confirm-new-password').attr('disabled', false);
+        if ( options.on_success ) options.on_success();
     }
 }
 

--- a/src/gui/src/UI/UIWindowChangePassword.js
+++ b/src/gui/src/UI/UIWindowChangePassword.js
@@ -127,7 +127,7 @@ async function UIWindowChangePassword (options) {
         }
     };
 
-    $(el_window).find('.change-password-btn').on('click', async function (e) {
+    $(el_window).find('.change-password-btn').on('click', async function (_e) {
         const current_password = $(el_window).find('.current-password').val();
         const new_password = $(el_window).find('.new-password').val();
         const confirm_new_password = $(el_window).find('.confirm-new-password').val();

--- a/src/gui/src/UI/UIWindowLogin.js
+++ b/src/gui/src/UI/UIWindowLogin.js
@@ -94,6 +94,13 @@ async function UIWindowLogin (options) {
         h += `<div style="text-align:center; margin: 10px 0; font-size:13px; color:var(--color-text-muted);">${ i18n('or') }</div>`;
         h += `<button type="button" class="oidc-google-btn button button-block button-normal" style="display:flex; align-items:center; justify-content:center; gap:8px;"><img style="width: 20px; height: 20px;" src="data:image/webp;base64,UklGRu4GAABXRUJQVlA4WAoAAAAQAAAAXwAAXwAAQUxQSAUDAAABoATJtmnbGs+23+vZtm3btm3btnHxjG/btm3bnI197tljzjXjtSNiAnAjmbNs8x5DR40e2qtFhTzuVJ2e+rrE/ODKwsZe5J90n9CfXVw6vLEvifIH87OHVOK0mLxSLpSyd4vZhyuGkP+amL45j7lVYn6+rQpfSYDvFzO0QgIdYeZJCTbNRpnfJeDXLTSQsH/X6yiBj1TrIoEPgnZzCXwwtMtL4AOhnfP/wPpC/X0Jux/Uj4jySzsGVskJADkq9dn4JKEP1NuJ6gMDELvrrTF6QP9fjX0FQc2xLZme0E8Tfko20LOmZdAD+tWF/lVlqNb7I9IFBt+hpUD9CZGuMNhT2ONh8GJvWPyK1QZedhdyS7j5Bqkf3Kwo3A3w8yTneTgq3NyOdOZMhqPplM/h6Z+Urp6UF+ZX8HQGZZIrVylw9SvGnRqP33ev2QdSEwlzpIaYTlCOUtSLQpGujN/hRePIFMZDbgyOrGUcdGNe5CBjoRtbIimMMW4ciVxgDHQjxb0LkRTGGF8OMha6kRZZyzjkxrHIFMbDbmyPdGX84cbiSDmGFPNiZASU0V60SvAV4y4vyiS4yhCNSuXZxb5lIOEMyngFRSF+nqg85YsAOjNuSoQ/GdLJXhpjfgbplE/tCbN2Bp0pMtHaBAoy5khOY78yHkjiJOdZW3OEOSmJihxZaymPUPMlgTc40sfQy5RnkWx3kjQ3c0ioI5LClyRpZWSRcJF8T5aMNbFKuHti4B2WnDVwUcj541SnyVeVlCp/KeQ0xE6jiZzNppD1jNDzxcO/PJG9BUhF9gl/B4jtNEQeGBAv55gnRfFfUI+oiMhLOwZWyRnJXKbltLOfim4nDt5XMn0N5Jz/e/Eb6OW9KMtDcx8GQrOLB6ug2zG8fdBuENoB6Jf5PaiVMPlkQP1hdEUov5aH2QpfBXETTK+y91dnGM9/zdh2BFj2bkNn8iHMEqeN7MiJgMe+pPZwP4Sef9J9vL8vD8oMH6tOT309zo+P7BlcAs7mLNu8x9BRY4b1aVO9MG4cAQBWUDggwgMAABAVAJ0BKmAAYAA+bSyTRqQiIaEtVEyQgA2JbAC++hZa3jl94/Jj2rrA/Tvv9y7x+OzH+L5o/8p7APMA/TPpD+YD+bf4T9bPfW/mfqo/wHqAf0v/hdYB6AH7Aemp+5HwS/uN+6XtXdQB1N/Rj+m/RWYp6GESYsQNCm+TZ3BvtEgBK+isF38GQzHNMrw+tkbAm5lUM4rWqU9srOS+RuAUa8nFYoFrGH73Fzd++s+LPyEGAAD+Yg+gQRuJCapqteWj86DdkHmfHdS+mWVn7Ue8RiK5AaWCIe7RXaDKn0baNe80expR5tTBclgnd+SEzNZ6N3NL1suPhGwRqKzB5wNnWUXD7R0IkT5uIwUhTsO/1ucVEMKvTZRe4j7WwrA+e53P8J1/cdIvKtrtZv9AH5u1heZ1dGQELuxMxbQUnrw6IUh0YLBKEjNnR3JIsFNwkC+WLw4wkCMati73lcMjT6U2KIYsr0g5bPzSmo3ir9qRjtIqthpPIvuvYt8AbMewSj96NIqTM14M6ABtOaY87d8HOU7baFGGQjU1f8vf7SV5AjDrfW0VVzQcBez+PYiPApyQUAozEmZFKBDvX9ifFFacoulG9NCPDXa1mRPVwzrKuN3VfwUfv8Bx8QJ88prsOCDd8UvNDnUzbRqBXOmQ4co+/xYy/iQV89GHs4pb0D2LYwv6aY8yPLCrYyAPUe4dKEh/FBqRBJ/716CJVMTCrvB+gSgPwNjN5LlnNQqkBsHnSqdUFddjvBKNdm6zm8ggLFJl14S37sJW1fAEbiB0IqxcqlJOWol+ecJy9xdESchmlROmo/4/9V34VN2cw8NUB5POPUNzivyMFfgF27QTFXgya/LF3OsfHMF6Itejgy4ab38VPFjez5f8Z/b/dhYV21SflE4KtUj8LZDrQXRp+Pzdf/gWfvm2oLh0x+Fr+ggo2jjG3DFn95Wj1P3ra1RtzYE8ffXBeR2lDhL+GPJiiZaVinGMkjVYup0AghAhIfVgFtsL8lhMyJY84ccksHz92o1/J3NfrGSM8NwOv7ieeBjq2eqCOmrUHpG3mlr8Hj/fR4d+orLlpipLTh3+cRY7suXQXw9SPYZieoKS/JE9y0f+BcWCzdNshWl2oVpeK2qm36iFltfGZUvXdfBKufE9RkZcyOBDUVeONlBchjuaLPNd6fSlk41Pp57nF5MmES2Kl7HqY+f2pvS71eIgUXpqtAFIY94JSmNre+g49tL8VnZlJNqgVhj/De//5zH/84h//5uJfunlawY99GgDkm8cYFbIAAAA" />${i18n('sign_in_with_google')}</button>`;
         h += '</div>';
+        // Passkey login (shown only if browser supports WebAuthn)
+        h += '<div class="webauthn-login-wrapper" style="display:none; padding: 0 0 10px 0;">';
+        h += `<div style="text-align:center; margin: 10px 0; font-size:13px; color:var(--color-text-muted);">${i18n('or')}</div>`;
+        h += '<button type="button" class="passkey-login-btn button button-block button-normal" style="display:flex; align-items:center; justify-content:center; gap:8px;">';
+        h += '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="4"/><path d="M4 20v-1a8 8 0 0 1 16 0v1"/></svg>';
+        h += `${i18n('sign_in_with_passkey')}</button>`;
+        h += '</div>';
         h += '</form>';
         h += '</div>';
         // create account link
@@ -187,6 +194,64 @@ async function UIWindowLogin (options) {
             } catch (_) {
             }
         })();
+
+        // Show passkey button if browser supports WebAuthn
+        if ( window.PublicKeyCredential ) {
+            $(el_window).find('.webauthn-login-wrapper').show();
+        }
+
+        // Passkey login — passwordless discoverable credential flow
+        $(el_window).find('.passkey-login-btn').on('click', async function () {
+            const { startAuthentication } = await import('@simplewebauthn/browser');
+            $(el_window).find('.login-error-msg').hide();
+
+            let auth_options;
+            try {
+                const resp = await fetch(`${window.api_origin}/auth/webauthn/authenticate/begin`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({}),
+                });
+                auth_options = await resp.json();
+                if ( auth_options.error ) throw new Error(auth_options.error);
+            } catch (e) {
+                $(el_window).find('.login-error-msg').html(e.message || i18n('something_went_wrong')).fadeIn();
+                return;
+            }
+
+            let assertion;
+            try {
+                assertion = await startAuthentication({ optionsJSON: auth_options });
+            } catch (e) {
+                if ( e.name !== 'NotAllowedError' ) {
+                    $(el_window).find('.login-error-msg').html(i18n('something_went_wrong')).fadeIn();
+                }
+                return;
+            }
+
+            try {
+                const complete_resp = await fetch(`${window.api_origin}/auth/webauthn/authenticate/complete`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ response: assertion, page_origin: window.location.origin }),
+                });
+                const data = await complete_resp.json();
+                if ( data.proceed && data.next_step === 'complete' ) {
+                    await window.update_auth_data(data.token, data.user);
+                    if ( options.reload_on_success ) {
+                        window.onbeforeunload = null;
+                        const cleanUrl = options.redirect_url || window.location.origin + window.location.pathname;
+                        window.location.replace(cleanUrl);
+                    } else {
+                        resolve(true);
+                    }
+                } else {
+                    $(el_window).find('.login-error-msg').html(data.error || i18n('webauthn_failed')).fadeIn();
+                }
+            } catch (e) {
+                $(el_window).find('.login-error-msg').html(e.message || i18n('something_went_wrong')).fadeIn();
+            }
+        });
 
         $(el_window).find('.login-btn').on('click', function (e) {
             // Prevent default button behavior (important for async requests)
@@ -402,6 +467,42 @@ async function UIWindowLogin (options) {
                             },
                         });
                         component.focus();
+                    } else if ( data.next_step === 'webauthn' ) {
+                        // WebAuthn 2FA: trigger authenticator immediately (no manual input needed)
+                        p = new TeePromise();
+                        const { startAuthentication } = await import('@simplewebauthn/browser');
+
+                        let assertion;
+                        try {
+                            assertion = await startAuthentication({ optionsJSON: data.webauthn_options });
+                        } catch (e) {
+                            const msg = e.name === 'NotAllowedError'
+                                ? i18n('webauthn_cancelled')
+                                : i18n('something_went_wrong');
+                            $(el_window).find('.login-error-msg').html(msg).fadeIn();
+                            $(el_window).find('.login-btn').prop('disabled', false);
+                            return;
+                        }
+
+                        const complete_resp = await fetch(`${window.gui_origin}/auth/webauthn/authenticate/complete`, {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({
+                                response: assertion,
+                                webauthn_jwt_token: data.webauthn_jwt_token,
+                                page_origin: window.location.origin,
+                            }),
+                        });
+                        const next_data = await complete_resp.json();
+
+                        if ( next_data.proceed && next_data.next_step === 'complete' ) {
+                            data = next_data;
+                            p.resolve();
+                        } else {
+                            $(el_window).find('.login-error-msg').html(i18n('webauthn_failed')).fadeIn();
+                            $(el_window).find('.login-btn').prop('disabled', false);
+                            return;
+                        }
                     }
 
                     await p;

--- a/src/gui/src/UI/UIWindowLogin.js
+++ b/src/gui/src/UI/UIWindowLogin.js
@@ -192,6 +192,7 @@ async function UIWindowLogin (options) {
                     });
                 }
             } catch (_) {
+                // ignore: OIDC providers endpoint unavailable
             }
         })();
 

--- a/src/gui/src/UI/UIWindowWebAuthnSetup.js
+++ b/src/gui/src/UI/UIWindowWebAuthnSetup.js
@@ -1,0 +1,188 @@
+/*
+ * Copyright (C) 2024-present Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import UIWindow from './UIWindow.js';
+import * as SimpleWebAuthn from '@simplewebauthn/browser';
+
+const UIWindowWebAuthnSetup = async function UIWindowWebAuthnSetup () {
+    return new Promise(async (resolve) => {
+        let is_resolved = false;
+        const settle = (value) => {
+            if ( is_resolved ) return;
+            is_resolved = true;
+            resolve(value);
+        };
+        const close_window = () => {
+            const $window = $(el_window);
+            if ( typeof $window.close === 'function' ) {
+                $window.close();
+                return;
+            }
+            // Fallback in case close animation/handler is interrupted.
+            setTimeout(() => {
+                if ( document.body.contains(el_window) ) {
+                    $(el_window).closest('.window-backdrop').remove();
+                    $(el_window).remove();
+                }
+            }, 500);
+        };
+
+        let h = '';
+        h += '<div style="padding: 20px;">';
+
+        // Step 1: name + register
+        h += '<div class="webauthn-step-1">';
+        h += `<h3 style="text-align:center; font-weight:500; font-size:20px; margin-bottom:8px;">${i18n('webauthn_register_title')}</h3>`;
+        h += `<p style="text-align:center; color:#3b4863; margin-bottom:16px;">${i18n('webauthn_register_instructions')}</p>`;
+        h += `<label style="display:block; margin-bottom:5px; font-weight:500;">${i18n('webauthn_key_name_label')}</label>`;
+        h += `<input type="text" class="webauthn-key-name" placeholder="${i18n('webauthn_key_name_placeholder')}" maxlength="64" style="width:100%; box-sizing:border-box; padding:8px; border:1px solid #ccc; border-radius:4px; font-size:14px; margin-bottom:8px;" />`;
+        h += '<div class="webauthn-error" style="color:#e74c3c; margin-bottom:8px; display:none;"></div>';
+        h += `<button class="button button-primary button-block webauthn-register-btn" style="margin-top:4px;">${i18n('webauthn_register_button')}</button>`;
+        h += '</div>';
+
+        // Step 2: success
+        h += '<div class="webauthn-step-2" style="display:none; text-align:center; padding:10px 0;">';
+        h += '<div style="font-size:48px; color:#27ae60; margin-bottom:12px;">✓</div>';
+        h += `<h3 style="font-weight:500; font-size:20px; margin-bottom:8px;">${i18n('webauthn_registered_success_title')}</h3>`;
+        h += `<p style="color:#3b4863; margin-bottom:16px;">${i18n('webauthn_registered_success_body')}</p>`;
+        h += '<button class="button button-primary button-block webauthn-done-btn">Done</button>';
+        h += '</div>';
+
+        h += '</div>';
+
+        const el_window = await UIWindow({
+            title: i18n('webauthn_register_title'),
+            app: 'webauthn-setup',
+            single_instance: true,
+            icon: null,
+            uid: null,
+            is_dir: false,
+            body_content: h,
+            has_head: true,
+            selectable_body: false,
+            draggable_body: false,
+            allow_context_menu: false,
+            is_draggable: true,
+            is_droppable: false,
+            is_resizable: false,
+            stay_on_top: true,
+            allow_native_ctxmenu: false,
+            allow_user_select: true,
+            width: 480,
+            dominant: false,
+            on_close: () => {
+                settle(false); return true;
+            },
+            window_css: { height: 'initial' },
+            body_css: {
+                width: 'initial',
+                padding: '0',
+                'background-color': 'rgb(245 247 249)',
+            },
+        });
+
+        const $win   = $(el_window);
+        const $step1 = $win.find('.webauthn-step-1');
+        const $step2 = $win.find('.webauthn-step-2');
+        const $error = $win.find('.webauthn-error');
+        const $btn   = $win.find('.webauthn-register-btn');
+
+        $win.find('.webauthn-done-btn').on('click', () => {
+            settle(true);
+            close_window();
+        });
+
+        $win.find('.window-close-btn').on('click', () => {
+            settle(false);
+            close_window();
+        });
+
+        $btn.on('click', async function () {
+            const key_name = $win.find('.webauthn-key-name').val().trim();
+            $error.hide();
+
+            if ( ! key_name ) {
+                $error.text(i18n('webauthn_key_name_required')).show();
+                return;
+            }
+
+            $btn.prop('disabled', true).text('...');
+
+            // 1. Get registration options from server
+            let reg_options;
+            try {
+                const resp = await fetch(`${window.api_origin}/auth/webauthn/register/begin`, {
+                    method: 'POST',
+                    headers: {
+                        Authorization: `Bearer ${puter.authToken}`,
+                        'Content-Type': 'application/json',
+                    },
+                    body: JSON.stringify({ page_origin: window.location.origin }),
+                });
+                reg_options = await resp.json();
+                if ( reg_options.error ) throw new Error(reg_options.error);
+            } catch (e) {
+                console.error('[webauthn] register/begin failed:', e);
+                $error.text(e.message || i18n('something_went_wrong')).show();
+                $btn.prop('disabled', false).text(i18n('webauthn_register_button'));
+                return;
+            }
+
+            // 2. Trigger browser passkey/security key dialog
+            let credential;
+            try {
+                const { startRegistration } = SimpleWebAuthn;
+                credential = await startRegistration({ optionsJSON: reg_options });
+            } catch (e) {
+                console.error('[webauthn] startRegistration failed:', e);
+                const msg = e.name === 'NotAllowedError'
+                    ? i18n('webauthn_cancelled')
+                    : (e.message || i18n('something_went_wrong'));
+                $error.text(msg).show();
+                $btn.prop('disabled', false).text(i18n('webauthn_register_button'));
+                return;
+            }
+
+            // 3. Send credential to server for verification and storage
+            try {
+                const resp = await fetch(`${window.api_origin}/auth/webauthn/register/complete`, {
+                    method: 'POST',
+                    headers: {
+                        Authorization: `Bearer ${puter.authToken}`,
+                        'Content-Type': 'application/json',
+                    },
+                    body: JSON.stringify({ response: credential, name: key_name, page_origin: window.location.origin }),
+                });
+                const data = await resp.json();
+                if ( ! data.ok ) throw new Error(data.error || 'Verification failed');
+            } catch (e) {
+                console.error('[webauthn] register/complete failed:', e);
+                $error.text(e.message || i18n('something_went_wrong')).show();
+                $btn.prop('disabled', false).text(i18n('webauthn_register_button'));
+                return;
+            }
+
+            // Success
+            $step1.hide();
+            $step2.show();
+        });
+    });
+};
+
+export default UIWindowWebAuthnSetup;

--- a/src/gui/src/UI/UIWindowWebAuthnSetup.js
+++ b/src/gui/src/UI/UIWindowWebAuthnSetup.js
@@ -21,168 +21,174 @@ import UIWindow from './UIWindow.js';
 import * as SimpleWebAuthn from '@simplewebauthn/browser';
 
 const UIWindowWebAuthnSetup = async function UIWindowWebAuthnSetup () {
-    return new Promise(async (resolve) => {
-        let is_resolved = false;
-        const settle = (value) => {
-            if ( is_resolved ) return;
-            is_resolved = true;
-            resolve(value);
-        };
-        const close_window = () => {
-            const $window = $(el_window);
-            if ( typeof $window.close === 'function' ) {
-                $window.close();
-                return;
-            }
-            // Fallback in case close animation/handler is interrupted.
-            setTimeout(() => {
-                if ( document.body.contains(el_window) ) {
-                    $(el_window).closest('.window-backdrop').remove();
-                    $(el_window).remove();
-                }
-            }, 500);
-        };
-
-        let h = '';
-        h += '<div style="padding: 20px;">';
-
-        // Step 1: name + register
-        h += '<div class="webauthn-step-1">';
-        h += `<h3 style="text-align:center; font-weight:500; font-size:20px; margin-bottom:8px;">${i18n('webauthn_register_title')}</h3>`;
-        h += `<p style="text-align:center; color:#3b4863; margin-bottom:16px;">${i18n('webauthn_register_instructions')}</p>`;
-        h += `<label style="display:block; margin-bottom:5px; font-weight:500;">${i18n('webauthn_key_name_label')}</label>`;
-        h += `<input type="text" class="webauthn-key-name" placeholder="${i18n('webauthn_key_name_placeholder')}" maxlength="64" style="width:100%; box-sizing:border-box; padding:8px; border:1px solid #ccc; border-radius:4px; font-size:14px; margin-bottom:8px;" />`;
-        h += '<div class="webauthn-error" style="color:#e74c3c; margin-bottom:8px; display:none;"></div>';
-        h += `<button class="button button-primary button-block webauthn-register-btn" style="margin-top:4px;">${i18n('webauthn_register_button')}</button>`;
-        h += '</div>';
-
-        // Step 2: success
-        h += '<div class="webauthn-step-2" style="display:none; text-align:center; padding:10px 0;">';
-        h += '<div style="font-size:48px; color:#27ae60; margin-bottom:12px;">✓</div>';
-        h += `<h3 style="font-weight:500; font-size:20px; margin-bottom:8px;">${i18n('webauthn_registered_success_title')}</h3>`;
-        h += `<p style="color:#3b4863; margin-bottom:16px;">${i18n('webauthn_registered_success_body')}</p>`;
-        h += '<button class="button button-primary button-block webauthn-done-btn">Done</button>';
-        h += '</div>';
-
-        h += '</div>';
-
-        const el_window = await UIWindow({
-            title: i18n('webauthn_register_title'),
-            app: 'webauthn-setup',
-            single_instance: true,
-            icon: null,
-            uid: null,
-            is_dir: false,
-            body_content: h,
-            has_head: true,
-            selectable_body: false,
-            draggable_body: false,
-            allow_context_menu: false,
-            is_draggable: true,
-            is_droppable: false,
-            is_resizable: false,
-            stay_on_top: true,
-            allow_native_ctxmenu: false,
-            allow_user_select: true,
-            width: 480,
-            dominant: false,
-            on_close: () => {
-                settle(false); return true;
-            },
-            window_css: { height: 'initial' },
-            body_css: {
-                width: 'initial',
-                padding: '0',
-                'background-color': 'rgb(245 247 249)',
-            },
-        });
-
-        const $win   = $(el_window);
-        const $step1 = $win.find('.webauthn-step-1');
-        const $step2 = $win.find('.webauthn-step-2');
-        const $error = $win.find('.webauthn-error');
-        const $btn   = $win.find('.webauthn-register-btn');
-
-        $win.find('.webauthn-done-btn').on('click', () => {
-            settle(true);
-            close_window();
-        });
-
-        $win.find('.window-close-btn').on('click', () => {
-            settle(false);
-            close_window();
-        });
-
-        $btn.on('click', async function () {
-            const key_name = $win.find('.webauthn-key-name').val().trim();
-            $error.hide();
-
-            if ( ! key_name ) {
-                $error.text(i18n('webauthn_key_name_required')).show();
-                return;
-            }
-
-            $btn.prop('disabled', true).text('...');
-
-            // 1. Get registration options from server
-            let reg_options;
-            try {
-                const resp = await fetch(`${window.api_origin}/auth/webauthn/register/begin`, {
-                    method: 'POST',
-                    headers: {
-                        Authorization: `Bearer ${puter.authToken}`,
-                        'Content-Type': 'application/json',
-                    },
-                    body: JSON.stringify({ page_origin: window.location.origin }),
-                });
-                reg_options = await resp.json();
-                if ( reg_options.error ) throw new Error(reg_options.error);
-            } catch (e) {
-                console.error('[webauthn] register/begin failed:', e);
-                $error.text(e.message || i18n('something_went_wrong')).show();
-                $btn.prop('disabled', false).text(i18n('webauthn_register_button'));
-                return;
-            }
-
-            // 2. Trigger browser passkey/security key dialog
-            let credential;
-            try {
-                const { startRegistration } = SimpleWebAuthn;
-                credential = await startRegistration({ optionsJSON: reg_options });
-            } catch (e) {
-                console.error('[webauthn] startRegistration failed:', e);
-                const msg = e.name === 'NotAllowedError'
-                    ? i18n('webauthn_cancelled')
-                    : (e.message || i18n('something_went_wrong'));
-                $error.text(msg).show();
-                $btn.prop('disabled', false).text(i18n('webauthn_register_button'));
-                return;
-            }
-
-            // 3. Send credential to server for verification and storage
-            try {
-                const resp = await fetch(`${window.api_origin}/auth/webauthn/register/complete`, {
-                    method: 'POST',
-                    headers: {
-                        Authorization: `Bearer ${puter.authToken}`,
-                        'Content-Type': 'application/json',
-                    },
-                    body: JSON.stringify({ response: credential, name: key_name, page_origin: window.location.origin }),
-                });
-                const data = await resp.json();
-                if ( ! data.ok ) throw new Error(data.error || 'Verification failed');
-            } catch (e) {
-                console.error('[webauthn] register/complete failed:', e);
-                $error.text(e.message || i18n('something_went_wrong')).show();
-                $btn.prop('disabled', false).text(i18n('webauthn_register_button'));
-                return;
-            }
-
-            // Success
-            $step1.hide();
-            $step2.show();
-        });
+    let resolve_outer;
+    const result = new Promise((resolve) => {
+        resolve_outer = resolve;
     });
+
+    let is_resolved = false;
+    const settle = (value) => {
+        if ( is_resolved ) return;
+        is_resolved = true;
+        resolve_outer(value);
+    };
+
+    let h = '';
+    h += '<div style="padding: 20px;">';
+
+    // Step 1: name + register
+    h += '<div class="webauthn-step-1">';
+    h += `<h3 style="text-align:center; font-weight:500; font-size:20px; margin-bottom:8px;">${i18n('webauthn_register_title')}</h3>`;
+    h += `<p style="text-align:center; color:#3b4863; margin-bottom:16px;">${i18n('webauthn_register_instructions')}</p>`;
+    h += `<label style="display:block; margin-bottom:5px; font-weight:500;">${i18n('webauthn_key_name_label')}</label>`;
+    h += `<input type="text" class="webauthn-key-name" placeholder="${i18n('webauthn_key_name_placeholder')}" maxlength="64" style="width:100%; box-sizing:border-box; padding:8px; border:1px solid #ccc; border-radius:4px; font-size:14px; margin-bottom:8px;" />`;
+    h += '<div class="webauthn-error" style="color:#e74c3c; margin-bottom:8px; display:none;"></div>';
+    h += `<button class="button button-primary button-block webauthn-register-btn" style="margin-top:4px;">${i18n('webauthn_register_button')}</button>`;
+    h += '</div>';
+
+    // Step 2: success
+    h += '<div class="webauthn-step-2" style="display:none; text-align:center; padding:10px 0;">';
+    h += '<div style="font-size:48px; color:#27ae60; margin-bottom:12px;">✓</div>';
+    h += `<h3 style="font-weight:500; font-size:20px; margin-bottom:8px;">${i18n('webauthn_registered_success_title')}</h3>`;
+    h += `<p style="color:#3b4863; margin-bottom:16px;">${i18n('webauthn_registered_success_body')}</p>`;
+    h += '<button class="button button-primary button-block webauthn-done-btn">Done</button>';
+    h += '</div>';
+
+    h += '</div>';
+
+    const el_window = await UIWindow({
+        title: i18n('webauthn_register_title'),
+        app: 'webauthn-setup',
+        single_instance: true,
+        icon: null,
+        uid: null,
+        is_dir: false,
+        body_content: h,
+        has_head: true,
+        selectable_body: false,
+        draggable_body: false,
+        allow_context_menu: false,
+        is_draggable: true,
+        is_droppable: false,
+        is_resizable: false,
+        stay_on_top: true,
+        allow_native_ctxmenu: false,
+        allow_user_select: true,
+        width: 480,
+        dominant: false,
+        on_close: () => {
+            settle(false); return true;
+        },
+        window_css: { height: 'initial' },
+        body_css: {
+            width: 'initial',
+            padding: '0',
+            'background-color': 'rgb(245 247 249)',
+        },
+    });
+
+    const close_window = () => {
+        const $window = $(el_window);
+        if ( typeof $window.close === 'function' ) {
+            $window.close();
+            return;
+        }
+        // Fallback in case close animation/handler is interrupted.
+        setTimeout(() => {
+            if ( document.body.contains(el_window) ) {
+                $(el_window).closest('.window-backdrop').remove();
+                $(el_window).remove();
+            }
+        }, 500);
+    };
+
+    const $win   = $(el_window);
+    const $step1 = $win.find('.webauthn-step-1');
+    const $step2 = $win.find('.webauthn-step-2');
+    const $error = $win.find('.webauthn-error');
+    const $btn   = $win.find('.webauthn-register-btn');
+
+    $win.find('.webauthn-done-btn').on('click', () => {
+        settle(true);
+        close_window();
+    });
+
+    $win.find('.window-close-btn').on('click', () => {
+        settle(false);
+        close_window();
+    });
+
+    $btn.on('click', async function () {
+        const key_name = $win.find('.webauthn-key-name').val().trim();
+        $error.hide();
+
+        if ( ! key_name ) {
+            $error.text(i18n('webauthn_key_name_required')).show();
+            return;
+        }
+
+        $btn.prop('disabled', true).text('...');
+
+        // 1. Get registration options from server
+        let reg_options;
+        try {
+            const resp = await fetch(`${window.api_origin}/auth/webauthn/register/begin`, {
+                method: 'POST',
+                headers: {
+                    Authorization: `Bearer ${puter.authToken}`,
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({ page_origin: window.location.origin }),
+            });
+            reg_options = await resp.json();
+            if ( reg_options.error ) throw new Error(reg_options.error);
+        } catch (e) {
+            console.error('[webauthn] register/begin failed:', e);
+            $error.text(e.message || i18n('something_went_wrong')).show();
+            $btn.prop('disabled', false).text(i18n('webauthn_register_button'));
+            return;
+        }
+
+        // 2. Trigger browser passkey/security key dialog
+        let credential;
+        try {
+            const { startRegistration } = SimpleWebAuthn;
+            credential = await startRegistration({ optionsJSON: reg_options });
+        } catch (e) {
+            console.error('[webauthn] startRegistration failed:', e);
+            const msg = e.name === 'NotAllowedError'
+                ? i18n('webauthn_cancelled')
+                : (e.message || i18n('something_went_wrong'));
+            $error.text(msg).show();
+            $btn.prop('disabled', false).text(i18n('webauthn_register_button'));
+            return;
+        }
+
+        // 3. Send credential to server for verification and storage
+        try {
+            const resp = await fetch(`${window.api_origin}/auth/webauthn/register/complete`, {
+                method: 'POST',
+                headers: {
+                    Authorization: `Bearer ${puter.authToken}`,
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({ response: credential, name: key_name, page_origin: window.location.origin }),
+            });
+            const data = await resp.json();
+            if ( ! data.ok ) throw new Error(data.error || 'Verification failed');
+        } catch (e) {
+            console.error('[webauthn] register/complete failed:', e);
+            $error.text(e.message || i18n('something_went_wrong')).show();
+            $btn.prop('disabled', false).text(i18n('webauthn_register_button'));
+            return;
+        }
+
+        // Success
+        $step1.hide();
+        $step2.show();
+    });
+
+    return result;
 };
 
 export default UIWindowWebAuthnSetup;

--- a/src/gui/src/i18n/translations/en.js
+++ b/src/gui/src/i18n/translations/en.js
@@ -608,6 +608,42 @@ const en = {
         authorization_cancelled: 'Authorization Cancelled',
         authorization_cancelled_desc: 'You have declined the authorization request.',
         authorization_cancelled_message: 'The app will not receive access to your account. You can close this window safely.',
+
+        // WebAuthn / Passkeys
+        webauthn_section_title: 'Passkeys & Security Keys',
+        webauthn_add_key: 'Add a key',
+        webauthn_register_title: 'Register a Passkey or Security Key',
+        webauthn_register_instructions: 'Give this key a name, then follow your browser\'s prompts.',
+        webauthn_key_name_label: 'Key name',
+        webauthn_key_name_placeholder: 'e.g. iPhone 15, YubiKey 5',
+        webauthn_key_name_required: 'Please enter a name for this key.',
+        webauthn_register_button: 'Register key',
+        webauthn_registered_success_title: 'Key registered!',
+        webauthn_registered_success_body: 'You can now use this key to sign in.',
+        webauthn_no_keys: 'No passkeys or security keys registered yet.',
+        webauthn_type_passkey: 'Passkey',
+        webauthn_type_security_key: 'Security Key',
+        webauthn_last_used: 'Last used',
+        webauthn_never_used: 'Never used',
+        webauthn_unnamed_key: 'Unnamed key',
+        webauthn_rename_prompt: 'Enter a new name for this key:',
+        webauthn_delete_confirm: 'Remove this key? You may lose access if this is your only login method.',
+        webauthn_delete_disabled_passwordless: 'Cannot delete passkeys while passwordless login is active. Add a password first.',
+        two_factor_disabled_passwordless: '2FA cannot be enabled while passwordless login is active. Add a password first.',
+        webauthn_cancelled: 'Authentication was cancelled.',
+        webauthn_failed: 'WebAuthn verification failed. Please try again.',
+        sign_in_with_passkey: 'Sign in with a Passkey',
+
+        add_password: 'Add Password',
+
+        // Passwordless login toggle
+        passwordless_login_title: 'Passwordless Login',
+        passwordless_login_enabled: 'Password removed — sign in with passkey only',
+        passwordless_login_disabled: 'Password still required alongside passkeys',
+        passwordless_login_active: 'Active',
+        passwordless_remove_password: 'Remove Password',
+        passwordless_warning: 'Once removed, you can only sign in with a registered passkey. Make sure you have a synced passkey (e.g. iCloud Keychain, Google Password Manager) before continuing.',
+        passwordless_confirm_message: 'Are you sure you want to remove your password? You will only be able to sign in using a passkey. This cannot be undone without account recovery.',
     },
 };
 

--- a/src/gui/src/initgui.js
+++ b/src/gui/src/initgui.js
@@ -132,6 +132,38 @@ const launch_services = async function (options) {
 // behavior is prevented when necessary, thereby improving page scroll performance.
 // More info: https://stackoverflow.com/a/62177358
 if ( jQuery ) {
+    // Defensive shims: in some runtime load orders, jQuery plugin extensions
+    // can be unavailable temporarily. Provide safe fallbacks to prevent
+    // critical UI actions (open/close/focus/context-menu) from crashing.
+    if ( ! jQuery.fn.close ) {
+        jQuery.fn.close = function () {
+            this.each(function () {
+                const $window = jQuery(this);
+                $window.closest('.window-backdrop').remove();
+                $window.remove();
+            });
+            return this;
+        };
+    }
+
+    if ( ! jQuery.fn.focusWindow ) {
+        jQuery.fn.focusWindow = function () {
+            this.each(function () {
+                const $window = jQuery(this);
+                jQuery('.window').removeClass('window-active');
+                $window.addClass('window-active');
+            });
+            return this;
+        };
+    }
+
+    if ( ! jQuery.fn.menuAim ) {
+        jQuery.fn.menuAim = function () {
+            // noop fallback keeps context menus usable without hover intent
+            return this;
+        };
+    }
+
     jQuery.event.special.touchstart = {
         setup: function ( _, ns, handle ) {
             this.addEventListener('touchstart', handle, { passive: !ns.includes('noPreventDefault') });


### PR DESCRIPTION
Add WebAuthn/Passkey authentication support

This PR adds passkey (WebAuthn) support as a second authentication factor and login method for Puter accounts.

What's changed:

Backend: New WebAuthnService handles credential registration and verification using @simplewebauthn/server. A new /api/v3/auth/webauthn router exposes endpoints for registration and authentication challenges/responses. A SQLite migration (0047) stores passkey credentials per user.

Frontend: New UIWindowWebAuthnSetup guides users through registering a passkey using @simplewebauthn/browser. The Security settings tab (UITabSecurity) now lists registered passkeys and allows removing them. The login window (UIWindowLogin) supports signing in with a passkey instead of a password.

How to test:

Log in to Puter and open Settings → Security
Click "Add Passkey" and complete the browser prompt
Log out and log back in using the "Sign in with Passkey" option