### PR TITLE
Add xAI (Grok) TTS and STT providers and integrate client/docs

### DIFF
--- a/src/backend/drivers/ai-speech2txt/XAISpeechToTextDriver.ts
+++ b/src/backend/drivers/ai-speech2txt/XAISpeechToTextDriver.ts
@@ -1,0 +1,246 @@
+/**
+ * Copyright (C) 2024-present Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { Context } from '../../core/context.js';
+import { HttpError } from '../../core/http/HttpError.js';
+import { PuterDriver } from '../types.js';
+import { loadFileInput } from '../util/fileInput.js';
+
+/**
+ * Driver implementing `puter-speech2txt` for the xAI (Grok) STT API.
+ *
+ * Uses the xAI /v1/stt REST endpoint which accepts multipart/form-data
+ * with an audio file and returns a JSON transcript with word-level timestamps.
+ *
+ * Pricing: $0.10/hr REST = 10 cents/hr = 10 * 1_000_000 / 3600 ≈ 2778 microcents/second
+ */
+
+const API_BASE = 'https://api.x.ai/v1';
+const MAX_AUDIO_FILE_SIZE = 500 * 1024 * 1024; // 500 MB per xAI docs
+// $0.10 per hour = 10 cents per hour = 10 * 1_000_000 microcents per hour
+// Per second: 10_000_000 / 3600 ≈ 2778 microcents per second
+const UCENTS_PER_SECOND = 2778;
+
+const SAMPLE_TRANSCRIPT = {
+    text: 'Hello! This is a sample transcription returned while test mode is enabled.',
+    language: 'English',
+    duration: 2.0,
+    words: [
+        { text: 'Hello!', start: 0.0, end: 0.5 },
+        { text: 'This', start: 0.6, end: 0.8 },
+        { text: 'is', start: 0.8, end: 0.9 },
+        { text: 'a', start: 0.9, end: 1.0 },
+        { text: 'sample', start: 1.0, end: 1.3 },
+        { text: 'transcription.', start: 1.3, end: 2.0 },
+    ],
+};
+
+interface TranscribeArgs {
+    file: unknown;
+    language?: string;
+    format?: boolean;
+    diarize?: boolean;
+    multichannel?: boolean;
+    channels?: number;
+    audio_format?: string;
+    sample_rate?: number;
+    test_mode?: boolean;
+}
+
+export class XAISpeechToTextDriver extends PuterDriver {
+    readonly driverInterface = 'puter-speech2txt';
+    readonly driverName = 'xai-speech2txt';
+
+    #apiKey: string | null = null;
+
+    override getReportedCosts(): Record<string, unknown>[] {
+        return [
+            {
+                usageType: 'xai:stt:second',
+                ucentsPerUnit: UCENTS_PER_SECOND,
+                unit: 'second',
+                source: 'driver:aiSpeech2Txt/xai',
+            },
+        ];
+    }
+
+    override onServerStart() {
+        const providers = (this.config.providers ?? {}) as Record<
+            string,
+            Record<string, unknown> | undefined
+        >;
+        const xai = providers['xai'];
+        if (!xai) return;
+        const key =
+            (xai.apiKey as string | undefined) ??
+            (xai.secret_key as string | undefined) ??
+            (xai.api_key as string | undefined) ??
+            (xai.key as string | undefined);
+        if (key) this.#apiKey = key;
+    }
+
+    async list_models() {
+        return [
+            {
+                id: 'xai-stt',
+                name: 'xAI Speech to Text',
+                type: 'transcription',
+                response_formats: ['json'],
+                supports_prompt: false,
+                supports_logprobs: false,
+                supports_diarization: true,
+            },
+        ];
+    }
+
+    async transcribe(args: TranscribeArgs) {
+        return this.#handleTranscription(args);
+    }
+
+    async translate(args: TranscribeArgs) {
+        // xAI STT doesn't have a separate translation endpoint;
+        // delegate to transcribe which auto-detects language
+        return this.#handleTranscription(args);
+    }
+
+    #isHttpUrl(value: unknown): value is string {
+        return (
+            typeof value === 'string' &&
+            (value.startsWith('https://') || value.startsWith('http://'))
+        );
+    }
+
+    async #handleTranscription(args: TranscribeArgs) {
+        if (args.test_mode) {
+            return { ...SAMPLE_TRANSCRIPT, model: 'xai-stt' };
+        }
+
+        if (!this.#apiKey) {
+            throw new HttpError(500, 'xAI API key not configured');
+        }
+        if (!args.file) {
+            throw new HttpError(400, '`file` is required');
+        }
+
+        const actor = Context.get('actor');
+        if (!actor) throw new HttpError(401, 'Authentication required');
+
+        // Determine if the input is an HTTP URL or a filesystem/data-URL reference
+        const isUrl = this.#isHttpUrl(args.file);
+
+        // For URLs we use xAI's native `url` param — no local fetch needed.
+        // For files we load from the Puter FS / data-URL.
+        let fileBuffer: Buffer | null = null;
+        let filename = 'audio.mp3';
+        let mimeType = 'audio/mpeg';
+
+        if (!isUrl) {
+            const loaded = await loadFileInput(
+                this.stores,
+                this.services.fs,
+                actor,
+                args.file,
+                { maxBytes: MAX_AUDIO_FILE_SIZE },
+            );
+            fileBuffer = loaded.buffer;
+            filename = loaded.filename || 'audio.mp3';
+            mimeType = loaded.mimeType || 'audio/mpeg';
+        }
+
+        // Pre-flight credit check. For URLs we can't know the duration
+        // upfront, so use a conservative 60-second estimate; actual usage
+        // is metered from the API response duration afterwards.
+        const estimatedSeconds = fileBuffer
+            ? Math.max(1, Math.ceil(fileBuffer.byteLength / 16000))
+            : 60;
+        const estimatedCost = UCENTS_PER_SECOND * estimatedSeconds;
+        const allowed = await this.services.metering.hasEnoughCredits(
+            actor,
+            estimatedCost,
+        );
+        if (!allowed) throw new HttpError(402, 'Insufficient credits');
+
+        // Build multipart form data
+        const formData = new FormData();
+
+        if (args.language) formData.append('language', args.language);
+        if (args.format !== undefined)
+            formData.append('format', String(args.format));
+        if (args.diarize) formData.append('diarize', 'true');
+        if (args.multichannel) formData.append('multichannel', 'true');
+        if (args.channels) formData.append('channels', String(args.channels));
+        if (args.audio_format)
+            formData.append('audio_format', args.audio_format);
+        if (args.sample_rate)
+            formData.append('sample_rate', String(args.sample_rate));
+
+        if (isUrl) {
+            // Pass URL directly to xAI — it downloads server-side
+            formData.append('url', args.file as string);
+        } else {
+            // File must be the last field per xAI docs
+            const blob = new Blob([fileBuffer!], { type: mimeType });
+            formData.append('file', blob, filename);
+        }
+
+        let response: Response;
+        try {
+            response = await fetch(`${API_BASE}/stt`, {
+                method: 'POST',
+                headers: {
+                    Authorization: `Bearer ${this.#apiKey}`,
+                },
+                body: formData,
+            });
+        } catch (e: unknown) {
+            const msg = (e as Error).message ?? String(e);
+            console.error('[XAISpeechToTextDriver] API error:', msg);
+            throw new HttpError(502, `xAI STT API error: ${msg}`);
+        }
+
+        if (!response.ok) {
+            const errText = await response.text().catch(() => '');
+            console.error(
+                `[XAISpeechToTextDriver] API returned ${response.status}: ${errText}`,
+            );
+            throw new HttpError(
+                502,
+                `xAI STT API error (${response.status}): ${errText}`,
+            );
+        }
+
+        const result = await response.json();
+
+        // Meter actual usage using returned duration, or estimated
+        const actualSeconds =
+            typeof result.duration === 'number'
+                ? Math.ceil(result.duration)
+                : estimatedSeconds;
+        const actualCost = UCENTS_PER_SECOND * actualSeconds;
+
+        this.services.metering.incrementUsage(
+            actor,
+            'xai:stt:second',
+            actualSeconds,
+            actualCost,
+        );
+
+        return result;
+    }
+}

--- a/src/backend/drivers/ai-tts/TTSDriver.ts
+++ b/src/backend/drivers/ai-tts/TTSDriver.ts
@@ -25,6 +25,7 @@ import { AWSPollyTTSProvider } from './providers/awsPolly/AWSPollyTTSProvider.js
 import { ElevenLabsTTSProvider } from './providers/elevenlabs/ElevenLabsTTSProvider.js';
 import { GeminiTTSProvider } from './providers/gemini/GeminiTTSProvider.js';
 import { OpenAITTSProvider } from './providers/openai/OpenAITTSProvider.js';
+import { XAITTSProvider } from './providers/xai/XAITTSProvider.js';
 import type {
     ISynthesizeArgs,
     ITTSEngine,
@@ -49,6 +50,7 @@ const TTS_ALIASES = [
     'openai-tts',
     'elevenlabs-tts',
     'gemini-tts',
+    'xai-tts',
 ] as const;
 type TTSAlias = (typeof TTS_ALIASES)[number];
 const ALIAS_TO_PROVIDER: Record<TTSAlias, string> = {
@@ -56,6 +58,7 @@ const ALIAS_TO_PROVIDER: Record<TTSAlias, string> = {
     'openai-tts': 'openai',
     'elevenlabs-tts': 'elevenlabs',
     'gemini-tts': 'gemini',
+    'xai-tts': 'xai',
 };
 
 export class TTSDriver extends PuterDriver {
@@ -256,6 +259,7 @@ export class TTSDriver extends PuterDriver {
         }
 
         this.#registerGeminiProvider(providers);
+        this.#registerXAIProvider(providers);
     }
 
     #registerGeminiProvider(providers: Record<string, unknown>) {
@@ -275,6 +279,29 @@ export class TTSDriver extends PuterDriver {
             } catch (e) {
                 console.warn(
                     '[TTSDriver] Failed to init Gemini TTS provider:',
+                    (e as Error).message,
+                );
+            }
+        }
+    }
+
+    #registerXAIProvider(providers: Record<string, unknown>) {
+        const m = this.services.metering;
+        const xai = (providers['xai'] ?? providers['xai-tts']) as
+            | Record<string, unknown>
+            | undefined;
+        const xaiKey =
+            (xai?.apiKey as string | undefined) ??
+            (xai?.api_key as string | undefined) ??
+            (xai?.key as string | undefined);
+        if (xaiKey) {
+            try {
+                this.#providers['xai'] = new XAITTSProvider(m, {
+                    apiKey: xaiKey,
+                });
+            } catch (e) {
+                console.warn(
+                    '[TTSDriver] Failed to init xAI TTS provider:',
                     (e as Error).message,
                 );
             }

--- a/src/backend/drivers/ai-tts/providers/xai/XAITTSProvider.ts
+++ b/src/backend/drivers/ai-tts/providers/xai/XAITTSProvider.ts
@@ -1,0 +1,213 @@
+/**
+ * Copyright (C) 2024-present Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { Readable } from 'node:stream';
+import { HttpError } from '../../../../core/http/HttpError.js';
+import { Context } from '../../../../core/context.js';
+import type { MeteringService } from '../../../../services/metering/MeteringService.js';
+import type { DriverStreamResult } from '../../../meta.js';
+import type { ITTSVoice, ITTSEngine, ISynthesizeArgs } from '../../types.js';
+import { TTSProvider } from '../TTSProvider.js';
+import { XAI_TTS_COSTS } from './costs.js';
+
+const API_BASE = 'https://api.x.ai/v1';
+const SAMPLE_AUDIO_URL = 'https://puter-sample-data.puter.site/tts_example.mp3';
+
+const XAI_TTS_VOICES = [
+    { id: 'eve', name: 'Eve', description: 'Energetic, upbeat' },
+    { id: 'ara', name: 'Ara', description: 'Warm, friendly' },
+    { id: 'rex', name: 'Rex', description: 'Confident, clear' },
+    { id: 'sal', name: 'Sal', description: 'Smooth, balanced' },
+    { id: 'leo', name: 'Leo', description: 'Authoritative, strong' },
+];
+
+const DEFAULT_VOICE = 'eve';
+
+const CODEC_CONTENT_TYPES: Record<string, string> = {
+    mp3: 'audio/mpeg',
+    wav: 'audio/wav',
+    pcm: 'audio/pcm',
+    mulaw: 'audio/basic',
+    alaw: 'audio/alaw',
+};
+
+/**
+ * xAI (Grok) TTS provider. Calls the xAI /v1/tts REST endpoint.
+ * Returns audio as a DriverStreamResult.
+ */
+export class XAITTSProvider extends TTSProvider {
+    readonly providerName = 'xai';
+
+    #apiKey: string;
+
+    constructor(meteringService: MeteringService, config: { apiKey: string }) {
+        super(meteringService, config);
+        if (!config.apiKey) {
+            throw new Error('xAI TTS requires an API key');
+        }
+        this.#apiKey = config.apiKey;
+    }
+
+    async listVoices(): Promise<ITTSVoice[]> {
+        return XAI_TTS_VOICES.map((voice) => ({
+            id: voice.id,
+            name: voice.name,
+            description: voice.description,
+            provider: 'xai',
+        }));
+    }
+
+    async listEngines(): Promise<ITTSEngine[]> {
+        return [
+            {
+                id: 'xai-tts',
+                name: 'xAI TTS',
+                provider: 'xai',
+                pricing_per_million_chars: 420,
+            },
+        ];
+    }
+
+    override getReportedCosts(): Record<string, unknown>[] {
+        return Object.entries(XAI_TTS_COSTS).map(([model, ucentsPerUnit]) => ({
+            usageType: `xai:${model}:character`,
+            ucentsPerUnit,
+            unit: 'character',
+            source: 'driver:aiTts/xai',
+        }));
+    }
+
+    async synthesize(
+        args: ISynthesizeArgs,
+    ): Promise<DriverStreamResult | { url: string; content_type: string }> {
+        const {
+            text,
+            voice: voiceArg,
+            language,
+            response_format,
+            output_format,
+            test_mode,
+        } = args;
+
+        if (test_mode) {
+            return { url: SAMPLE_AUDIO_URL, content_type: 'audio' };
+        }
+
+        if (typeof text !== 'string' || !text.trim()) {
+            throw new HttpError(400, 'Missing required field: text', {
+                legacyCode: 'field_required',
+                fields: { key: 'text' },
+            });
+        }
+
+        if (text.length > 15000) {
+            throw new HttpError(
+                400,
+                'Text exceeds maximum length of 15,000 characters',
+            );
+        }
+
+        const voice = voiceArg || DEFAULT_VOICE;
+
+        const actor = Context.get('actor')!;
+        const ucentsPerChar = XAI_TTS_COSTS['xai-tts'] ?? 0;
+        const totalCost = ucentsPerChar * text.length;
+
+        const usageAllowed = await this.meteringService.hasEnoughCredits(
+            actor,
+            totalCost,
+        );
+        if (!usageAllowed) {
+            throw new HttpError(402, 'Insufficient funds', {
+                legacyCode: 'insufficient_funds',
+            });
+        }
+
+        // Build request body
+        const body: Record<string, unknown> = {
+            text,
+            voice_id: voice,
+            language: language || 'en',
+        };
+
+        // Handle output format
+        const formatStr = output_format || response_format;
+        if (formatStr) {
+            const codec = typeof formatStr === 'string' ? formatStr : 'mp3';
+            body.output_format = { codec };
+        }
+
+        let response: Response;
+        try {
+            response = await fetch(`${API_BASE}/tts`, {
+                method: 'POST',
+                headers: {
+                    Authorization: `Bearer ${this.#apiKey}`,
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify(body),
+            });
+        } catch (e: unknown) {
+            const msg = (e as Error).message ?? String(e);
+            console.error('[XAITTSProvider] API error:', msg);
+            throw new HttpError(502, `xAI TTS API error: ${msg}`, {
+                fields: { provider: 'xai' },
+            });
+        }
+
+        if (!response.ok) {
+            const errText = await response.text().catch(() => '');
+            console.error(
+                `[XAITTSProvider] API returned ${response.status}: ${errText}`,
+            );
+            throw new HttpError(
+                502,
+                `xAI TTS API error (${response.status}): ${errText}`,
+                { fields: { provider: 'xai' } },
+            );
+        }
+
+        const arrayBuffer = await response.arrayBuffer();
+        const buffer = Buffer.from(arrayBuffer);
+        const stream = Readable.from(buffer);
+
+        // Determine content type from response or codec
+        const respContentType =
+            response.headers.get('content-type') || 'audio/mpeg';
+        const codec =
+            (body.output_format as { codec?: string } | undefined)?.codec ??
+            'mp3';
+        const contentType = CODEC_CONTENT_TYPES[codec] || respContentType;
+
+        // Meter usage
+        this.meteringService.incrementUsage(
+            actor,
+            'xai:xai-tts:character',
+            text.length,
+            totalCost,
+        );
+
+        return {
+            dataType: 'stream',
+            content_type: contentType,
+            chunked: true,
+            stream,
+        };
+    }
+}

--- a/src/backend/drivers/ai-tts/providers/xai/costs.ts
+++ b/src/backend/drivers/ai-tts/providers/xai/costs.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2024-present Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// xAI TTS pricing: $4.20 per 1M characters
+// = 420 cents per 1M characters
+// = 0.00042 cents per character
+// = 0.42 microcents per character
+// We store microcents per character (cents * 1_000_000 / 1_000_000 chars).
+// $4.20 / 1M chars = 420 cents / 1M chars = 0.00042 cents/char = 0.42 ucents/char
+// But metering uses integer microcents, so we round up to 1 microcent per char
+// to avoid undercharging. More precisely: 420 * 1_000_000 / 1_000_000 = 420 ucents per char? No.
+// Let's be precise:
+// $4.20 per 1M chars = 420 cents per 1M chars
+// In microcents: 420 * 1_000_000 = 420_000_000 microcents per 1M chars
+// Per character: 420_000_000 / 1_000_000 = 420 microcents per character
+export const XAI_TTS_COSTS: Record<string, number> = {
+    'xai-tts': 420,
+};

--- a/src/backend/drivers/index.ts
+++ b/src/backend/drivers/index.ts
@@ -24,6 +24,7 @@ import { TTSDriver } from './ai-tts/TTSDriver';
 import { VideoGenerationDriver } from './ai-video/VideoGenerationDriver';
 import { VoiceChangerDriver } from './ai-speech2speech/VoiceChangerDriver';
 import { SpeechToTextDriver } from './ai-speech2txt/SpeechToTextDriver';
+import { XAISpeechToTextDriver } from './ai-speech2txt/XAISpeechToTextDriver';
 import { OCRDriver } from './ai-ocr/OCRDriver';
 import { AppDriver } from './apps/AppDriver.js';
 import { KVStoreDriver } from './kv/KVStoreDriver';
@@ -42,6 +43,7 @@ export const puterDrivers = {
     aiVideo: VideoGenerationDriver,
     aiSpeech2Speech: VoiceChangerDriver,
     aiSpeech2Txt: SpeechToTextDriver,
+    aiSpeech2TxtXai: XAISpeechToTextDriver,
     aiOcr: OCRDriver,
     apps: AppDriver,
     subdomains: SubdomainDriver,

--- a/src/docs/src/AI/speech2txt.md
+++ b/src/docs/src/AI/speech2txt.md
@@ -1,10 +1,10 @@
 ---
 title: puter.ai.speech2txt()
-description: Transcribe or translate audio into text using OpenAI speech-to-text models.
+description: Transcribe or translate audio into text using OpenAI or xAI speech-to-text models.
 platforms: [websites, apps, nodejs, workers]
 ---
 
-Converts spoken audio into text with optional English translation and diarization support. This helper wraps the Puter driver-backed OpenAI transcription API so you can work with local files, remote URLs, or in-memory blobs from the browser.
+Converts spoken audio into text with optional English translation and diarization support. This helper wraps the Puter driver-backed transcription API (OpenAI and xAI) so you can work with local files, remote URLs, or in-memory blobs from the browser.
 
 ## Syntax
 
@@ -32,6 +32,7 @@ When you omit `source`, supply `options.file` or `options.audio` instead.
 Fine-tune how transcription runs.
 
 - `file` / `audio` (String | File | Blob): Alternative way to pass the audio input.
+- `provider` (String): STT provider to use. `'openai'` (default) or `'xai'`.
 - `model` (String): One of `gpt-4o-mini-transcribe`, `gpt-4o-transcribe`, `gpt-4o-transcribe-diarize`, `whisper-1`, or any future backend-supported model. Defaults to `gpt-4o-mini-transcribe` for transcription and `whisper-1` for translation.
 - `translate` (Boolean): Set to `true` to force English output (uses the translations endpoint).
 - `response_format` (String): Desired output shape. Examples: `json`, `text`, `diarized_json`, `srt`, `verbose_json`, `vtt` (depends on the model).
@@ -45,6 +46,16 @@ Fine-tune how transcription runs.
 - `extra_body` (Object): Forwarded verbatim to the OpenAI API for experimental flags.
 - `stream` (Boolean): Reserved for future streaming support. Currently rejected when `true`.
 - `test_mode` (Boolean): When `true`, returns a sample response without using credits. Defaults to `false`.
+
+**xAI-specific options** (when `provider: 'xai'`):
+
+- `language` (String): Language code (e.g. `en`, `fr`). Enables text formatting when `format` is `true`.
+- `format` (Boolean): When `true`, enables Inverse Text Normalization (numbers/currency to written form). Requires `language`.
+- `diarize` (Boolean): When `true`, words include a `speaker` field identifying the detected speaker.
+- `multichannel` (Boolean): When `true`, transcribes each audio channel independently.
+- `channels` (Number): Number of audio channels (2–8). Required for multichannel raw audio.
+- `audio_format` (String): Format hint for raw/headerless audio: `pcm`, `mulaw`, `alaw`.
+- `sample_rate` (Number): Sample rate in Hz. Required for raw audio.
 
 #### `testMode` (Boolean) (optional)
 
@@ -94,6 +105,33 @@ Returns a `Promise` that resolves to either:
             meeting.segments.forEach(segment => {
                 console.log(`${segment.speaker}: ${segment.text}`);
             });
+        })();
+    </script>
+</body>
+</html>
+```
+
+<strong class="example-title">Transcribe with xAI (Grok)</strong>
+
+```html;ai-speech2txt-xai
+<html>
+<body>
+    <script src="https://js.puter.com/v2/"></script>
+    <script>
+        (async () => {
+            const transcript = await puter.ai.speech2txt({
+                file: 'https://assets.puter.site/example.mp3',
+                provider: 'xai',
+                language: 'en',
+                format: true
+            });
+            puter.print('Transcript:', transcript.text);
+            puter.print('Duration:', transcript.duration + 's');
+            if (transcript.words) {
+                transcript.words.forEach(w => {
+                    puter.print(`  ${w.start.toFixed(2)}s - ${w.end.toFixed(2)}s: ${w.text}`);
+                });
+            }
         })();
     </script>
 </body>

--- a/src/docs/src/AI/txt2speech.md
+++ b/src/docs/src/AI/txt2speech.md
@@ -32,7 +32,7 @@ Additional settings for the generation request. Available options depend on the 
 
 | Option | Type | Description |
 |--------|------|-------------|
-| `provider` | `String` | TTS provider to use. `'aws-polly'` (default), `'openai'`, `'elevenlabs'`, `'gemini'` |
+| `provider` | `String` | TTS provider to use. `'aws-polly'` (default), `'openai'`, `'elevenlabs'`, `'gemini'`, `'xai'` |
 | `model` | `String` | Model identifier (provider-specific) |
 | `voice` | `String` | Voice ID used for synthesis (provider-specific) |
 | `test_mode` | `Boolean` | When `true`, returns a sample audio without using credits |
@@ -85,6 +85,20 @@ Available when `provider: 'gemini'`:
 | `instructions` | `String` | Natural language instructions to control speaking style (tone, speed, mood, etc.) |
 
 For more details about Gemini TTS, see the [Google Gemini TTS documentation](https://ai.google.dev/gemini-api/docs/text-to-speech).
+
+#### xAI (Grok) Options
+
+Available when `provider: 'xai'`:
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `voice` | `String` | Voice ID. Available: `'eve'` (default, energetic), `'ara'` (warm), `'rex'` (confident), `'sal'` (smooth), `'leo'` (authoritative) |
+| `language` | `String` | BCP-47 language code. Defaults to `'en'`. Supports `'auto'` for auto-detection and 20+ languages |
+| `output_format` | `String` | Output codec. Available: `'mp3'` (default), `'wav'`, `'pcm'`, `'mulaw'`, `'alaw'` |
+
+Text supports inline speech tags like `[pause]`, `[laugh]` and wrapping tags like `<whisper>text</whisper>` for expressive delivery. Maximum 15,000 characters per request.
+
+For more details, see the [xAI TTS documentation](https://x.ai/news/grok-stt-and-tts-apis).
 
 ## Return value
 
@@ -199,6 +213,30 @@ A `Promise` that resolves to an `HTMLAudioElement`. The element’s `src` points
                     model: "gemini-2.5-flash-preview-tts",
                     voice: "Puck",
                     instructions: "Speak in a friendly, upbeat tone."
+                }
+            );
+            audio.play();
+        });
+    </script>
+</body>
+</html>
+```
+
+<strong class="example-title">Use xAI (Grok) voices</strong>
+
+```html;ai-txt2speech-xai
+<html>
+<body>
+    <script src="https://js.puter.com/v2/"></script>
+    <button id="play">Use xAI voice</button>
+    <script>
+        document.getElementById('play').addEventListener('click', async ()=>{
+            const audio = await puter.ai.txt2speech(
+                "Hello! This sample uses the xAI Eve voice.",
+                {
+                    provider: "xai",
+                    voice: "eve",
+                    language: "en"
                 }
             );
             audio.play();

--- a/src/docs/src/playground/examples/ai-speech2txt-xai.html
+++ b/src/docs/src/playground/examples/ai-speech2txt-xai.html
@@ -1,0 +1,22 @@
+<html>
+<body>
+    <script src="https://js.puter.com/v2/"></script>
+    <script>
+        (async () => {
+            const transcript = await puter.ai.speech2txt({
+                file: 'https://assets.puter.site/example.mp3',
+                provider: 'xai',
+                language: 'en',
+                format: true
+            });
+            puter.print('Transcript: ' + transcript.text);
+            puter.print('Duration: ' + transcript.duration + 's');
+            if (transcript.words) {
+                transcript.words.forEach(w => {
+                    puter.print('  ' + w.start.toFixed(2) + 's - ' + w.end.toFixed(2) + 's: ' + w.text);
+                });
+            }
+        })();
+    </script>
+</body>
+</html>

--- a/src/docs/src/playground/examples/ai-txt2speech-xai.html
+++ b/src/docs/src/playground/examples/ai-txt2speech-xai.html
@@ -1,0 +1,19 @@
+<html>
+<body>
+    <script src="https://js.puter.com/v2/"></script>
+    <button id="play">Use xAI voice</button>
+    <script>
+        document.getElementById('play').addEventListener('click', async ()=>{
+            const audio = await puter.ai.txt2speech(
+                "Hello! This sample uses the xAI Eve voice.",
+                {
+                    provider: "xai",
+                    voice: "eve",
+                    language: "en"
+                }
+            );
+            audio.play();
+        });
+    </script>
+</body>
+</html>

--- a/src/puter-js/src/modules/AI.js
+++ b/src/puter-js/src/modules/AI.js
@@ -8,6 +8,7 @@ const normalizeTTSProvider = (value) => {
     if ( lower === 'openai' ) return 'openai';
     if ( ['elevenlabs', 'eleven', '11labs', '11-labs', 'eleven-labs', 'elevenlabs-tts'].includes(lower) ) return 'elevenlabs';
     if ( ['gemini', 'google', 'gemini-tts', 'google-tts'].includes(lower) ) return 'gemini';
+    if ( ['xai', 'grok', 'x-ai', 'xai-tts', 'grok-tts'].includes(lower) ) return 'xai';
     if ( lower === 'aws' || lower === 'polly' || lower === 'aws-polly' ) return 'aws-polly';
     return value;
 };
@@ -275,6 +276,10 @@ class AI {
             provider = 'gemini';
         }
 
+        if ( options.engine && normalizeTTSProvider(options.engine) === 'xai' && !options.provider ) {
+            provider = 'xai';
+        }
+
         if ( provider === 'openai' ) {
             if ( !options.model && typeof options.engine === 'string' ) {
                 options.model = options.engine;
@@ -317,6 +322,14 @@ class AI {
                 options.model = 'gemini-2.5-flash-preview-tts';
             }
             delete options.engine;
+        } else if ( provider === 'xai' ) {
+            if ( ! options.voice ) {
+                options.voice = 'eve';
+            }
+            if ( ! options.language ) {
+                options.language = 'en';
+            }
+            delete options.engine;
         } else {
             provider = 'aws-polly';
 
@@ -352,6 +365,7 @@ class AI {
             'openai': 'openai-tts',
             'elevenlabs': 'elevenlabs-tts',
             'gemini': 'gemini-tts',
+            'xai': 'xai-tts',
         };
         const driverName = driverNameMap[provider] || 'aws-polly';
 
@@ -554,9 +568,19 @@ class AI {
         const driverArgs = { ...options };
         delete driverArgs.translate;
 
+        const sttProvider = driverArgs.provider;
+        delete driverArgs.provider;
+
+        const sttDriverNameMap = {
+            'xai': 'xai-speech2txt',
+            'grok': 'xai-speech2txt',
+            'x-ai': 'xai-speech2txt',
+        };
+        const sttDriverName = (sttProvider && sttDriverNameMap[sttProvider.toLowerCase()]) || 'openai-speech2txt';
+
         const responseFormat = driverArgs.response_format;
 
-        return await utils.make_driver_method([], 'puter-speech2txt', 'openai-speech2txt', driverMethod, {
+        return await utils.make_driver_method([], 'puter-speech2txt', sttDriverName, driverMethod, {
             test_mode: testMode,
             transform: async (result) => {
                 if ( responseFormat === 'text' && result && typeof result === 'object' && typeof result.text === 'string' ) {
@@ -597,10 +621,15 @@ class AI {
                 params.provider = 'gemini';
             }
 
+            if ( provider === 'xai' ) {
+                params.provider = 'xai';
+            }
+
             const driverNameMap = {
                 'openai': 'openai-tts',
                 'elevenlabs': 'elevenlabs-tts',
                 'gemini': 'gemini-tts',
+                'xai': 'xai-tts',
             };
             const driverName = driverNameMap[provider] || 'aws-polly';
 
@@ -640,10 +669,16 @@ class AI {
                 delete params.engine;
             }
 
+            if ( provider === 'xai' ) {
+                params.provider = 'xai';
+                delete params.engine;
+            }
+
             const driverNameMap2 = {
                 'openai': 'openai-tts',
                 'elevenlabs': 'elevenlabs-tts',
                 'gemini': 'gemini-tts',
+                'xai': 'xai-tts',
             };
             const driverName = driverNameMap2[provider] || 'aws-polly';
 

--- a/src/puter-js/types/modules/ai.d.ts
+++ b/src/puter-js/types/modules/ai.d.ts
@@ -132,6 +132,7 @@ export interface Speech2TxtResult {
 interface BaseSpeech2TxtOptions {
     file?: string | File | Blob;
     audio?: string | File | Blob;
+    provider?: string;
     model?: string;
     language?: string;
     prompt?: string;
@@ -144,6 +145,12 @@ interface BaseSpeech2TxtOptions {
     known_speaker_names?: string[];
     known_speaker_references?: string[];
     extra_body?: Record<string, unknown>;
+    format?: boolean;
+    diarize?: boolean;
+    multichannel?: boolean;
+    channels?: number;
+    audio_format?: string;
+    sample_rate?: number;
     test_mode?: boolean;
 }
 


### PR DESCRIPTION
  - Add XAITTSProvider calling POST /v1/tts with 5 voices (eve, ara, rex, sal, leo), speech tags, and configurable output format
  - Add XAISpeechToTextDriver calling POST /v1/stt with support for diarization, multichannel, text formatting, and xAI's native URL param for remote audio files
  - Register both providers in TTSDriver and driver index using existing xAI API key from config
  - Update puter.js client to route provider:'xai' for both txt2speech and speech2txt, including listVoices/listEngines
  - Add TypeScript types for new STT options (provider, format, diarize, multichannel, etc.)
  - Update txt2speech.md and speech2txt.md with xAI options and examples
  - Add playground examples for both TTS and STT

  Cost metering:
    TTS: 420 microcents/char ($4.20/1M chars) STT: 2778 microcents/sec ($0.10/hr)