### PR TITLE
Update Z.AI vision model id to z-ai/z-ai for consistency

### DIFF
--- a/src/backend/drivers/ai-chat/providers/zai/models.ts
+++ b/src/backend/drivers/ai-chat/providers/zai/models.ts
@@ -63,7 +63,7 @@ const visionModel = (
     maxTokens: number,
     costs: IChatModel['costs'],
 ): IChatModel => ({
-    puterId: `z-ai:zai/${id}`,
+    puterId: `z-ai:z-ai/${id}`,
     id,
     name,
     aliases: [`z-ai/${id}`, `zai/${id}`],


### PR DESCRIPTION
Right now the vision model showing as `z-ai:zai/{id}`
<img width="386" height="184" alt="image" src="https://github.com/user-attachments/assets/06308a27-901b-47c9-b595-4690f410b473" />

compared to text model which are using `z-ai:z-ai/{id}`
https://github.com/HeyPuter/puter/blob/224ea5f7f835e57c65ac194f75c614246b276409/src/backend/drivers/ai-chat/providers/zai/models.ts#L44

to keep it consistent, i also updated the vision model id to use `z-ai:z-ai/{id}`

the zai/{id} version should still work since we have alias for it, plus this shouldn't really be a concern because we always document Z.AI model as z-ai (with a hyphen)
