### PR TITLE
Fix: support defaultValue in UIPrompt (app environment)

### DIFF
--- a/src/gui/src/UI/UIPrompt.js
+++ b/src/gui/src/UI/UIPrompt.js
@@ -47,7 +47,7 @@ function UIPrompt (options) {
         h += `<div class="window-prompt-message">${options.message}</div>`;
         // prompt
         h += '<div class="window-alert-prompt" style="margin-top: 20px;">';
-        h += `<input type="text" class="prompt-input" placeholder="${options.placeholder ?? ''}" value="${options.value ?? ''}">`;
+        h += `<input type="text" class="prompt-input" placeholder="${options.placeholder ?? ''}" value="${options.defaultValue ?? options.value ?? ''}">`;
         h += '</div>';
         // buttons
         if ( options.buttons && options.buttons.length > 0 ) {


### PR DESCRIPTION
Closes #2894

I’d be happy to work on this issue. I’m new to contributing here, so any feedback or suggestions would be greatly appreciated.

In the app environment, the prompt input was initialized using `options.value`, so `defaultValue` was not reflected.

This change ensures that `defaultValue` is used when provided, while keeping backward compatibility with `options.value`.