### PR TITLE
fix: support defaultValue in showColorPicker app env

### DIFF
--- a/src/gui/src/UI/UIWindowColorPicker.js
+++ b/src/gui/src/UI/UIWindowColorPicker.js
@@ -74,7 +74,7 @@ async function UIWindowColorPicker (options) {
             },
             onAppend: function (window) {
                 colorPickerWidget = UIColorPickerWidget($(window).find('.picker'), {
-                    default: options.default ?? '#f00',
+                    default: options.defaultValue ?? options.default ?? '#f00',
                 });
             },
             window_class: 'window-login',

--- a/src/puter-js/src/modules/UI.js
+++ b/src/puter-js/src/modules/UI.js
@@ -881,7 +881,7 @@ class UI extends EventListener {
         return new Promise((resolve) => {
             const opts = typeof options === 'string' ? { defaultColor: options } : (options ?? {});
             const el = document.createElement('puter-color-picker');
-            const defaultColor = opts.defaultColor || opts.default || '#3b82f6';
+            const defaultColor = opts.defaultValue || opts.defaultColor || opts.default || '#3b82f6';
             el.setAttribute('default-color', defaultColor);
             el.addEventListener('response', (e) => resolve(e.detail));
             document.body.appendChild(el);


### PR DESCRIPTION
Fixes #2895.

Mirrors the pattern from #2930 (puter.ui.prompt): accept `defaultValue` first, then fall back to the existing option name. Two-line change — one in `UIWindowColorPicker.js` (puter app env) and one in `puter-js/UI.js` (web standalone fallback) — so callers can use the same `defaultValue` key in both environments.

Existing `default` (and `defaultColor` in web) keep working unchanged.