### PR TITLE
fix: thread referrer through OIDC state so signup records acquisition…

### DIFF
--- a/src/backend/controllers/oidc/OIDCController.ts
+++ b/src/backend/controllers/oidc/OIDCController.ts
@@ -163,10 +163,19 @@ export class OIDCController extends PuterController {
                     }
                 }
 
+                const rawReferrer = Array.isArray(req.query.referrer)
+                    ? req.query.referrer[0]
+                    : req.query.referrer;
+                const referrer =
+                    rawReferrer != null && rawReferrer !== ''
+                        ? String(rawReferrer)
+                        : null;
+
                 const statePayload: Record<string, unknown> = {
                     provider,
                     redirect_uri: appRedirectUri,
                 };
+                if (referrer) statePayload.referrer = referrer;
                 if (embeddedInPopup && msgId) {
                     statePayload.embedded_in_popup = true;
                     statePayload.msg_id = msgId;
@@ -228,6 +237,7 @@ export class OIDCController extends PuterController {
             const resolved = await this.#resolveOrCreateOIDCUser(
                 provider,
                 userinfo,
+                stateDecoded,
             );
             if ('error' in resolved) {
                 console.warn(
@@ -288,6 +298,7 @@ export class OIDCController extends PuterController {
             const resolved = await this.#resolveOrCreateOIDCUser(
                 provider,
                 userinfo,
+                stateDecoded,
             );
             if ('error' in resolved) {
                 return res.redirect(
@@ -431,6 +442,7 @@ if (window.opener) {
     async #resolveOrCreateOIDCUser(
         provider: string,
         userinfo: { sub: string; email?: unknown; [k: string]: unknown },
+        stateDecoded: Record<string, unknown>,
     ): Promise<
         | { error: string }
         | {
@@ -472,9 +484,14 @@ if (window.opener) {
         }
 
         // 3. Fresh account.
+        const referrer =
+            typeof stateDecoded.referrer === 'string'
+                ? stateDecoded.referrer
+                : null;
         const outcome = await this.services.oidc.createUserFromOIDC(
             provider,
             userinfo as { sub: string; email?: string },
+            { referrer },
         );
         if (!outcome.success || !outcome.user) {
             return { error: outcome.error ?? 'Account creation failed.' };

--- a/src/backend/services/auth/OIDCService.ts
+++ b/src/backend/services/auth/OIDCService.ts
@@ -360,6 +360,7 @@ export class OIDCService extends PuterService {
     async createUserFromOIDC(
         providerId: string,
         claims: OIDCUserInfo,
+        options?: { referrer?: string | null },
     ): Promise<{ success: boolean; user?: UserRow; error?: string }> {
         if (claims.email_verified === false) {
             return {
@@ -477,7 +478,7 @@ export class OIDCService extends PuterService {
             signup_user_agent: req?.headers?.['user-agent'] ?? null,
             signup_origin: req?.headers?.origin,
             signup_server: this.config.serverId,
-            referrer: req?.body?.referrer ?? null,
+            referrer: options?.referrer ?? null,
         });
 
         if (!created) {

--- a/src/gui/src/UI/UIWindowSignup.js
+++ b/src/gui/src/UI/UIWindowSignup.js
@@ -178,6 +178,10 @@ function UIWindowSignup (options) {
                             $(el_window).find(btnClass).css('display', 'flex');
                             $(el_window).find(btnClass).on('click', function () {
                                 let url = `${window.gui_origin}/auth/oidc/${provider}/start?flow=signup`;
+                                const referrer = options.referrer ?? window.referrerStr;
+                                if ( referrer ) {
+                                    url += `&referrer=${encodeURIComponent(referrer)}`;
+                                }
                                 if ( window.embedded_in_popup && window.url_query_params?.get('msg_id') ) {
                                     url += `&embedded_in_popup=true&msg_id=${encodeURIComponent(window.url_query_params.get('msg_id'))}`;
                                     if ( window.openerOrigin ) {


### PR DESCRIPTION
OIDC signups never had the referrer field set because the callback request from the IdP doesn't carry the frontend's JSON body. Fix by passing referrer as a query param to the OIDC start endpoint, embedding it in the signed state JWT, and forwarding it to createUserFromOIDC.