### PR TITLE
Fix duplicate textract result

### DIFF
--- a/src/backend/drivers/ai-ocr/OCRDriver.ts
+++ b/src/backend/drivers/ai-ocr/OCRDriver.ts
@@ -273,6 +273,7 @@ export class OCRDriver extends PuterDriver {
                     'MERGED_CELL',
                     'LAYOUT_FIGURE',
                     'LAYOUT_TEXT',
+                    'WORD',
                 ].includes(block.BlockType ?? '')
             )
                 continue;


### PR DESCRIPTION
fix an issue where `img2txt` via textract returning duplicate OCR result

current
<img width="968" height="831" alt="image" src="https://github.com/user-attachments/assets/808678d0-46b1-4351-b8f3-77f2d56e13fb" />

fix
<img width="598" height="328" alt="image" src="https://github.com/user-attachments/assets/564663c8-d347-436c-af25-f6da963797a8" />


so what's happening is, Textract by default will return LINE item and WORD item
https://docs.aws.amazon.com/textract/latest/dg/how-it-works-lines-words.html
currently we always output both resulting in the result being duplicated


notes:
- LINE will always still be returned even if we exclude WORD, because they are hierarchical, LINE is the parent of WORD
- the trade off for omitting WORD is, the user has to manually split the text, if they want to get word for word
  - but then again, we are returning pure string for this textract result
  - in the future if we ever do a v3, or maybe v2 with custom options, we might revisit just outputting the proper textract output
  - because it contains a lot more valuable data, which are the individual words, and the bounding box, if users wants to visualize the ocr


in any case, right now this is sufficient for our usecase
user input image, they want to get string result, and we provide it to them without it being duplicated