### PR TITLE
Use GA version of gemini 3.1 flash lite

### DIFF
--- a/src/backend/drivers/ai-chat/providers/gemini/models.ts
+++ b/src/backend/drivers/ai-chat/providers/gemini/models.ts
@@ -196,8 +196,8 @@ export const GEMINI_MODELS: IChatModel[] = [
         max_tokens: 65536,
     },
     {
-        puterId: 'google:google/gemini-3.1-flash-lite-preview',
-        id: 'gemini-3.1-flash-lite-preview',
+        puterId: 'google:google/gemini-3.1-flash-lite',
+        id: 'gemini-3.1-flash-lite',
         modalities: {
             input: ['text', 'image', 'video', 'audio', 'pdf'],
             output: ['text'],
@@ -207,7 +207,10 @@ export const GEMINI_MODELS: IChatModel[] = [
         knowledge: '2025-01',
         release_date: '2026-03-18',
         name: 'Gemini 3.1 Flash-Lite',
-        aliases: ['google/gemini-3.1-flash-lite-preview'],
+        aliases: [
+            'google/gemini-3.1-flash-lite',
+            'google/gemini-3.1-flash-lite-preview',
+        ],
         context: 1_048_576,
         costs_currency: 'usd-cents',
         input_cost_key: 'prompt_tokens',

--- a/src/backend/drivers/ai-chat/providers/gemini/models.ts
+++ b/src/backend/drivers/ai-chat/providers/gemini/models.ts
@@ -209,6 +209,7 @@ export const GEMINI_MODELS: IChatModel[] = [
         name: 'Gemini 3.1 Flash-Lite',
         aliases: [
             'google/gemini-3.1-flash-lite',
+            'gemini-3.1-flash-lite-preview',
             'google/gemini-3.1-flash-lite-preview',
         ],
         context: 1_048_576,


### PR DESCRIPTION
- use the generally available version of gemini 3.1 flash lite
- the `-preview` prefix will still be supported via alias
- doing it now, because the preview one will be deprecated in ~2 weeks (May 25, 2026)

https://cloud.google.com/blog/products/ai-machine-learning/gemini-3-1-flash-lite-is-now-generally-available

<img width="838" height="315" alt="image" src="https://github.com/user-attachments/assets/4583c972-9531-4c28-8a5a-70952ddf167b" />
