### PR TITLE
Fix minor typo for tls cert in self hosting docs

### DIFF
--- a/doc/self-hosting.md
+++ b/doc/self-hosting.md
@@ -14,7 +14,7 @@ Generates secrets, writes `.env` + `puter/config/config.json`, downloads `docker
 
 - **Docker** with the `compose` plugin.
 - A **domain** with DNS access — you need a wildcard record (`*.your-domain.com` → server IP). Puter routes by subdomain (`api.<domain>`, `site.<domain>`, `app.<domain>`).
-- Optional: **TLS certs** (or `certbot` to grab them — see Step 4).
+- Optional: **TLS certs** (or `certbot` to grab them — see Step 3).
 
 ## What's running
 


### PR DESCRIPTION
TLS related section is in step 3 🙏 

<img width="822" height="402" alt="image" src="https://github.com/user-attachments/assets/b0b00326-83b2-4af1-8136-44e0005e062d" />
