### PR TITLE
test: add unit tests for ai-chat utils

### DIFF
--- a/src/backend/drivers/ai-chat/utils/FunctionCalling.test.ts
+++ b/src/backend/drivers/ai-chat/utils/FunctionCalling.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Copyright (C) 2024-present Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { describe, expect, it } from 'vitest';
+// @ts-expect-error — sibling JS module without an adjacent .d.ts
+import {
+    make_claude_tools,
+    make_openai_tools,
+    normalize_json_schema,
+    normalize_tools_object,
+} from './FunctionCalling.js';
+
+// All four exports are pure data transforms — these tests just feed
+// inputs and check the normalized output, no service mocks involved.
+
+// ── normalize_json_schema ───────────────────────────────────────────
+
+describe('normalize_json_schema', () => {
+    it('returns the schema unchanged when falsy', () => {
+        expect(normalize_json_schema(undefined)).toBeUndefined();
+        expect(normalize_json_schema(null)).toBeNull();
+    });
+
+    it('returns object schemas without properties unchanged', () => {
+        const schema = { type: 'object' };
+        const out = normalize_json_schema(schema);
+        // Same reference is returned — no clone is made.
+        expect(out).toBe(schema);
+    });
+
+    it('recursively normalizes object property schemas', () => {
+        const schema = {
+            type: 'object',
+            properties: {
+                items: { type: 'array' },
+                nested: {
+                    type: 'object',
+                    properties: { inner: { type: 'array' } },
+                },
+            },
+        };
+        const out = normalize_json_schema(schema);
+        // Empty `items` is filled in for every array branch reachable
+        // from the root.
+        expect(out.properties.items.items).toEqual({});
+        expect(out.properties.nested.properties.inner.items).toEqual({});
+    });
+
+    it('fills in `items: {}` for arrays that omit it', () => {
+        expect(normalize_json_schema({ type: 'array' })).toEqual({
+            type: 'array',
+            items: {},
+        });
+    });
+
+    it('recursively normalizes the items schema of arrays', () => {
+        const schema = {
+            type: 'array',
+            items: {
+                type: 'object',
+                properties: { sub: { type: 'array' } },
+            },
+        };
+        const out = normalize_json_schema(schema);
+        expect(out.items.properties.sub.items).toEqual({});
+    });
+});
+
+// ── normalize_tools_object ──────────────────────────────────────────
+
+describe('normalize_tools_object', () => {
+    it('keeps OpenAI Responses web_search tools as-is', () => {
+        const tools = [{ type: 'web_search' }];
+        const out = normalize_tools_object(tools);
+        expect(out).toEqual([{ type: 'web_search' }]);
+    });
+
+    it('wraps a Claude-style {name, input_schema} tool into OpenAI shape', () => {
+        const out = normalize_tools_object([
+            {
+                name: 'lookup',
+                description: 'Search the docs',
+                input_schema: {
+                    type: 'object',
+                    properties: { q: { type: 'string' } },
+                },
+            },
+        ]);
+        expect(out).toEqual([
+            {
+                type: 'function',
+                function: {
+                    name: 'lookup',
+                    description: 'Search the docs',
+                    parameters: {
+                        type: 'object',
+                        properties: { q: { type: 'string' } },
+                    },
+                },
+            },
+        ]);
+    });
+
+    it('unwraps an OpenAI-style {type:"function", function:{...}} tool', () => {
+        const out = normalize_tools_object([
+            {
+                type: 'function',
+                function: {
+                    name: 'lookup',
+                    parameters: {
+                        type: 'object',
+                        properties: { q: { type: 'string' } },
+                    },
+                },
+            },
+        ]);
+        expect(out[0].type).toBe('function');
+        expect(out[0].function.name).toBe('lookup');
+        expect(out[0].function.parameters.properties.q).toEqual({
+            type: 'string',
+        });
+    });
+
+    it('defaults missing `parameters` to `{type: "object"}`', () => {
+        const out = normalize_tools_object([
+            { type: 'function', function: { name: 'noargs' } },
+        ]);
+        expect(out[0].function.parameters).toEqual({ type: 'object' });
+    });
+
+    it('infers `parameters.type = "object"` when missing', () => {
+        const out = normalize_tools_object([
+            {
+                type: 'function',
+                function: {
+                    name: 'lookup',
+                    parameters: { properties: { q: { type: 'string' } } },
+                },
+            },
+        ]);
+        expect(out[0].function.parameters.type).toBe('object');
+    });
+
+    it('falls back to wrapping `tool` itself for bare/unknown shapes', () => {
+        // No `input_schema`, no `type === "function"` — accepted as the
+        // function definition itself.
+        const out = normalize_tools_object([
+            {
+                name: 'bare',
+                parameters: { type: 'object', properties: {} },
+            },
+        ]);
+        expect(out[0].type).toBe('function');
+        expect(out[0].function.name).toBe('bare');
+    });
+
+    it('mutates the array in place and returns the same reference', () => {
+        const tools = [
+            { name: 'lookup', input_schema: { type: 'object' } },
+        ];
+        const out = normalize_tools_object(tools);
+        expect(out).toBe(tools);
+    });
+});
+
+// ── make_openai_tools ───────────────────────────────────────────────
+
+describe('make_openai_tools', () => {
+    it('is the identity function (normalized format already matches OpenAI)', () => {
+        const tools = [
+            {
+                type: 'function',
+                function: {
+                    name: 'lookup',
+                    parameters: { type: 'object' },
+                },
+            },
+        ];
+        expect(make_openai_tools(tools)).toBe(tools);
+    });
+});
+
+// ── make_claude_tools ───────────────────────────────────────────────
+
+describe('make_claude_tools', () => {
+    it('returns undefined when tools is undefined', () => {
+        expect(make_claude_tools(undefined)).toBeUndefined();
+    });
+
+    it('returns [] when tools is an empty array', () => {
+        expect(make_claude_tools([])).toEqual([]);
+    });
+
+    it('flattens the OpenAI {function:{...}} wrapper into Claude shape', () => {
+        const out = make_claude_tools([
+            {
+                type: 'function',
+                function: {
+                    name: 'lookup',
+                    description: 'Search the docs',
+                    parameters: {
+                        type: 'object',
+                        properties: { q: { type: 'string' } },
+                    },
+                },
+            },
+        ]);
+        expect(out).toEqual([
+            {
+                name: 'lookup',
+                description: 'Search the docs',
+                input_schema: {
+                    type: 'object',
+                    properties: { q: { type: 'string' } },
+                },
+            },
+        ]);
+    });
+});

--- a/src/backend/drivers/ai-chat/utils/Messages.test.ts
+++ b/src/backend/drivers/ai-chat/utils/Messages.test.ts
@@ -1,0 +1,360 @@
+/**
+ * Copyright (C) 2024-present Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { describe, expect, it } from 'vitest';
+// @ts-expect-error — sibling JS module without an adjacent .d.ts
+import {
+    extract_and_remove_system_messages,
+    extract_text,
+    normalize_messages,
+    normalize_single_message,
+} from './Messages.js';
+
+// All four exports are pure data transforms over arrays/objects, so
+// these tests just feed inputs and assert on the output shape — no
+// service mocks or method spies are needed.
+
+// ── normalize_single_message ────────────────────────────────────────
+
+describe('normalize_single_message', () => {
+    it('wraps a string into a single-content user message by default', () => {
+        const result = normalize_single_message('hello');
+        expect(result.role).toBe('user');
+        expect(result.content).toEqual([{ type: 'text', text: 'hello' }]);
+    });
+
+    it('honors a caller-supplied default role for string input', () => {
+        const result = normalize_single_message('greetings', {
+            role: 'system',
+        });
+        expect(result.role).toBe('system');
+    });
+
+    it('throws 400 when message is null/undefined/array', () => {
+        expect(() => normalize_single_message(null)).toThrow(
+            expect.objectContaining({ statusCode: 400 }),
+        );
+        expect(() => normalize_single_message(undefined)).toThrow(
+            expect.objectContaining({ statusCode: 400 }),
+        );
+        expect(() => normalize_single_message([])).toThrow(
+            expect.objectContaining({ statusCode: 400 }),
+        );
+    });
+
+    it('throws 400 when no content + no tool_calls (and not a tool message)', () => {
+        expect(() =>
+            normalize_single_message({ role: 'assistant' }),
+        ).toThrow(expect.objectContaining({ statusCode: 400 }));
+    });
+
+    it('synthesizes content from tool_calls when content is missing', () => {
+        const result = normalize_single_message({
+            role: 'assistant',
+            tool_calls: [
+                {
+                    id: 'call_1',
+                    function: { name: 'lookup', arguments: { q: 'puter' } },
+                },
+                {
+                    id: 'call_2',
+                    function: { name: 'lookup', arguments: { q: 'fs' } },
+                },
+            ],
+        });
+
+        expect(result.tool_calls).toBeUndefined();
+        expect(result.content).toEqual([
+            {
+                type: 'tool_use',
+                id: 'call_1',
+                name: 'lookup',
+                input: { q: 'puter' },
+            },
+            {
+                type: 'tool_use',
+                id: 'call_2',
+                name: 'lookup',
+                input: { q: 'fs' },
+            },
+        ]);
+    });
+
+    it('coerces string tool content into a tool_result block', () => {
+        const result = normalize_single_message({
+            role: 'tool',
+            tool_call_id: 'call_1',
+            content: 'tool said hi',
+        });
+        expect(result.tool_use_id).toBe('call_1');
+        expect(result.content).toEqual([
+            {
+                type: 'tool_result',
+                tool_use_id: 'call_1',
+                content: 'tool said hi',
+            },
+        ]);
+    });
+
+    it('JSON-serializes non-string tool content', () => {
+        const result = normalize_single_message({
+            role: 'tool',
+            tool_call_id: 'call_1',
+            content: { ok: true, data: [1, 2] },
+        });
+        expect(result.content[0].content).toBe(
+            JSON.stringify({ ok: true, data: [1, 2] }),
+        );
+    });
+
+    it('preserves the existing role when present', () => {
+        const result = normalize_single_message(
+            { role: 'assistant', content: 'hi' },
+            { role: 'system' },
+        );
+        expect(result.role).toBe('assistant');
+    });
+
+    it('upgrades string content blocks into typed text blocks', () => {
+        const result = normalize_single_message({
+            role: 'user',
+            content: ['hello', 'world'],
+        });
+        expect(result.content).toEqual([
+            { type: 'text', text: 'hello' },
+            { type: 'text', text: 'world' },
+        ]);
+    });
+
+    it('infers type=text when only a `text` field is present', () => {
+        const result = normalize_single_message({
+            role: 'user',
+            content: [{ text: 'untyped' }],
+        });
+        expect(result.content[0].type).toBe('text');
+    });
+
+    it('throws 400 when a content item is not a string or object', () => {
+        expect(() =>
+            normalize_single_message({
+                role: 'user',
+                content: [42],
+            }),
+        ).toThrow(expect.objectContaining({ statusCode: 400 }));
+    });
+
+    it('strips a stray `text` from tool_use blocks', () => {
+        const result = normalize_single_message({
+            role: 'assistant',
+            content: [
+                {
+                    type: 'tool_use',
+                    id: 'call_1',
+                    name: 'lookup',
+                    input: {},
+                    text: 'should be removed',
+                },
+            ],
+        });
+        expect(result.content[0].text).toBeUndefined();
+    });
+});
+
+// ── normalize_messages ──────────────────────────────────────────────
+
+describe('normalize_messages', () => {
+    it('normalizes each entry and merges consecutive same-role text messages', () => {
+        const result = normalize_messages([
+            'hi',
+            'there',
+            { role: 'assistant', content: 'hello back' },
+            { role: 'assistant', content: 'I can help' },
+        ]);
+
+        // Two user text blocks merge; two assistant text blocks merge.
+        expect(result).toHaveLength(2);
+        expect(result[0].role).toBe('user');
+        expect(result[0].content).toEqual([
+            { type: 'text', text: 'hi' },
+            { type: 'text', text: 'there' },
+        ]);
+        expect(result[1].role).toBe('assistant');
+        expect(result[1].content).toEqual([
+            { type: 'text', text: 'hello back' },
+            { type: 'text', text: 'I can help' },
+        ]);
+    });
+
+    it('splits multi-block non-tool messages into one message per block', () => {
+        const result = normalize_messages([
+            {
+                role: 'user',
+                content: [
+                    { type: 'text', text: 'hello' },
+                    { type: 'image_url', image_url: 'https://x/a.png' },
+                ],
+            },
+        ]);
+        // After split the two user blocks collapse back into one merged
+        // message because both have role='user' and neither is a
+        // tool block.
+        expect(result).toHaveLength(1);
+        expect(result[0].content).toHaveLength(2);
+    });
+
+    it('keeps assistant tool_use blocks together (no per-block split)', () => {
+        const result = normalize_messages([
+            {
+                role: 'assistant',
+                content: [
+                    {
+                        type: 'tool_use',
+                        id: 'call_1',
+                        name: 'lookup',
+                        input: { q: 'a' },
+                    },
+                    {
+                        type: 'tool_use',
+                        id: 'call_2',
+                        name: 'lookup',
+                        input: { q: 'b' },
+                    },
+                ],
+            },
+        ]);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].content).toHaveLength(2);
+        // Both tool_use blocks live under the same assistant message
+        // so OpenAI's tool-call ordering is preserved on the wire.
+        expect(result[0].content[0].id).toBe('call_1');
+        expect(result[0].content[1].id).toBe('call_2');
+    });
+
+    it('does not merge across tool_use / tool_result boundaries', () => {
+        const result = normalize_messages([
+            {
+                role: 'assistant',
+                content: [
+                    {
+                        type: 'tool_use',
+                        id: 'call_1',
+                        name: 'lookup',
+                        input: {},
+                    },
+                ],
+            },
+            {
+                role: 'user',
+                content: [
+                    {
+                        type: 'tool_result',
+                        tool_use_id: 'call_1',
+                        content: 'ok',
+                    },
+                ],
+            },
+            { role: 'user', content: 'and another follow-up' },
+        ]);
+        // tool_use, tool_result, and the trailing user text must remain
+        // as separate messages — merging would clobber tool ordering.
+        expect(result).toHaveLength(3);
+        expect(result[0].content[0].type).toBe('tool_use');
+        expect(result[1].content[0].type).toBe('tool_result');
+        expect(result[2].content[0]).toEqual({
+            type: 'text',
+            text: 'and another follow-up',
+        });
+    });
+});
+
+// ── extract_and_remove_system_messages ─────────────────────────────
+
+describe('extract_and_remove_system_messages', () => {
+    it('returns [system, non-system] preserving relative order', () => {
+        const messages = [
+            { role: 'system', content: 'sys-1' },
+            { role: 'user', content: 'u-1' },
+            { role: 'system', content: 'sys-2' },
+            { role: 'assistant', content: 'a-1' },
+            { role: 'user', content: 'u-2' },
+        ];
+        const [systems, others] = extract_and_remove_system_messages(messages);
+        expect(systems.map((m: Record<string, unknown>) => m.content)).toEqual([
+            'sys-1',
+            'sys-2',
+        ]);
+        expect(others.map((m: Record<string, unknown>) => m.content)).toEqual([
+            'u-1',
+            'a-1',
+            'u-2',
+        ]);
+    });
+
+    it('returns empty arrays for an empty input', () => {
+        const [systems, others] = extract_and_remove_system_messages([]);
+        expect(systems).toEqual([]);
+        expect(others).toEqual([]);
+    });
+});
+
+// ── extract_text ────────────────────────────────────────────────────
+
+describe('extract_text', () => {
+    it('joins string messages with a single space', () => {
+        expect(extract_text(['hello', 'world'])).toBe('hello world');
+    });
+
+    it('skips falsy / non-object entries by emitting an empty string', () => {
+        // null / array entries collapse to '' and don't crash.
+        expect(extract_text([null, undefined, ['nope'], 'kept'])).toBe(
+            '   kept',
+        );
+    });
+
+    it('joins content arrays of {text} blocks with spaces, then space-joins messages', () => {
+        const result = extract_text([
+            { content: [{ text: 'a' }, { text: 'b' }] },
+            { content: [{ text: 'c' }] },
+        ]);
+        expect(result).toBe('a b c');
+    });
+
+    it('passes through messages whose content is a plain string', () => {
+        expect(extract_text([{ content: 'plain' }])).toBe('plain');
+    });
+
+    it('reads single-block content objects with type=text', () => {
+        expect(extract_text([{ content: { type: 'text', text: 'one' } }])).toBe(
+            'one',
+        );
+    });
+
+    it('returns "" for non-text typed single-block content', () => {
+        expect(
+            extract_text([{ content: { type: 'image_url', image_url: 'x' } }]),
+        ).toBe('');
+    });
+
+    it('throws 400 when a typed text block has a non-string text field', () => {
+        expect(() =>
+            extract_text([{ content: { type: 'text', text: 42 } }]),
+        ).toThrow(expect.objectContaining({ statusCode: 400 }));
+    });
+});

--- a/src/backend/drivers/ai-chat/utils/Streaming.test.ts
+++ b/src/backend/drivers/ai-chat/utils/Streaming.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Copyright (C) 2024-present Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { Writable } from 'node:stream';
+import { describe, expect, it } from 'vitest';
+// @ts-expect-error — sibling JS module without an adjacent .d.ts
+import Streaming, {
+    AIChatMessageStream,
+    AIChatStream,
+    AIChatTextStream,
+    AIChatToolUseStream,
+} from './Streaming.js';
+
+// AIChatStream + friends emit newline-delimited JSON to an underlying
+// Writable. Tests run them against a real buffering Writable and parse
+// the captured chunks back, so assertions read the live wire shape —
+// no method-level spies on the stream classes.
+
+const makeHarness = () => {
+    const chunks: string[] = [];
+    let ended = false;
+    const sink = new Writable({
+        write(chunk, _enc, cb) {
+            chunks.push(chunk.toString('utf8'));
+            cb();
+        },
+        final(cb) {
+            ended = true;
+            cb();
+        },
+    });
+    const chatStream = new AIChatStream({ stream: sink });
+    return {
+        chatStream,
+        sink,
+        rawChunks: () => chunks.slice(),
+        events: () =>
+            chunks
+                .join('')
+                .split('\n')
+                .filter(Boolean)
+                .map((line) => JSON.parse(line)),
+        isEnded: () => ended,
+    };
+};
+
+// ── AIChatStream ────────────────────────────────────────────────────
+
+describe('AIChatStream', () => {
+    it('exposes a Streaming default with AIChatStream attached', () => {
+        expect(Streaming.AIChatStream).toBe(AIChatStream);
+    });
+
+    it('writes a `usage` event and ends the underlying stream on .end()', () => {
+        const h = makeHarness();
+        h.chatStream.end({ tokens: 42 });
+        const events = h.events();
+        expect(events).toEqual([
+            { type: 'usage', usage: { tokens: 42 } },
+        ]);
+        expect(h.isEnded()).toBe(true);
+    });
+
+    it('forwards .write(...) calls straight to the underlying stream', () => {
+        const h = makeHarness();
+        h.chatStream.write('raw chunk\n');
+        // .write is a passthrough — the raw bytes hit the sink without
+        // being wrapped in an event envelope.
+        expect(h.rawChunks()).toEqual(['raw chunk\n']);
+    });
+
+    it('returns a fresh AIChatMessageStream from .message()', () => {
+        const h = makeHarness();
+        const m = h.chatStream.message();
+        expect(m).toBeInstanceOf(AIChatMessageStream);
+    });
+});
+
+// ── AIChatMessageStream / AIChatTextStream ─────────────────────────
+
+describe('AIChatTextStream (via message().contentBlock)', () => {
+    it('emits a text event for addText with no extra_content', () => {
+        const h = makeHarness();
+        const block = h.chatStream.message().contentBlock({ type: 'text' });
+        block.addText('hello');
+        expect(h.events()).toEqual([{ type: 'text', text: 'hello' }]);
+    });
+
+    it('attaches extra_content when provided', () => {
+        const h = makeHarness();
+        const block = h.chatStream.message().contentBlock({ type: 'text' });
+        block.addText('hello', { meta: 1 });
+        expect(h.events()).toEqual([
+            { type: 'text', text: 'hello', extra_content: { meta: 1 } },
+        ]);
+    });
+
+    it('emits a separate reasoning event from addReasoning', () => {
+        const h = makeHarness();
+        const block = h.chatStream.message().contentBlock({ type: 'text' });
+        block.addReasoning('thinking…');
+        expect(h.events()).toEqual([
+            { type: 'reasoning', reasoning: 'thinking…' },
+        ]);
+    });
+
+    it('emits an extra_content event from addExtraContent', () => {
+        const h = makeHarness();
+        const block = h.chatStream.message().contentBlock({ type: 'text' });
+        block.addExtraContent({ tag: 'gemini-meta' });
+        expect(h.events()).toEqual([
+            { type: 'extra_content', extra_content: { tag: 'gemini-meta' } },
+        ]);
+    });
+
+    it('exposes AIChatTextStream as the constructor for type=text', () => {
+        const h = makeHarness();
+        const block = h.chatStream.message().contentBlock({ type: 'text' });
+        expect(block).toBeInstanceOf(AIChatTextStream);
+    });
+});
+
+// ── AIChatToolUseStream ────────────────────────────────────────────
+
+describe('AIChatToolUseStream (via message().contentBlock)', () => {
+    it('exposes AIChatToolUseStream as the constructor for type=tool_use', () => {
+        const h = makeHarness();
+        const block = h.chatStream
+            .message()
+            .contentBlock({ type: 'tool_use', id: 'call_1', name: 'lookup' });
+        expect(block).toBeInstanceOf(AIChatToolUseStream);
+    });
+
+    it('parses buffered partial JSON arguments on .end()', () => {
+        const h = makeHarness();
+        const block = h.chatStream.message().contentBlock({
+            type: 'tool_use',
+            id: 'call_1',
+            name: 'lookup',
+        });
+        block.addPartialJSON('{"q":');
+        block.addPartialJSON('"puter"}');
+        block.end();
+
+        expect(h.events()).toEqual([
+            {
+                type: 'tool_use',
+                id: 'call_1',
+                name: 'lookup',
+                input: { q: 'puter' },
+                text: '',
+            },
+        ]);
+    });
+
+    it('forwards extra_content when supplied on the contentBlock spec', () => {
+        const h = makeHarness();
+        const block = h.chatStream.message().contentBlock({
+            type: 'tool_use',
+            id: 'call_2',
+            name: 'lookup',
+            extra_content: { hint: 'metadata' },
+        });
+        block.addPartialJSON('{}');
+        block.end();
+
+        const [event] = h.events();
+        expect(event.extra_content).toEqual({ hint: 'metadata' });
+    });
+
+    it('falls back to {} when nothing was buffered', () => {
+        const h = makeHarness();
+        const block = h.chatStream.message().contentBlock({
+            type: 'tool_use',
+            id: 'call_3',
+            name: 'lookup',
+        });
+        block.end();
+
+        const [event] = h.events();
+        expect(event.input).toEqual({});
+    });
+
+    it('omits the empty-text suffix when contentBlock already has text', () => {
+        const h = makeHarness();
+        const block = h.chatStream.message().contentBlock({
+            type: 'tool_use',
+            id: 'call_4',
+            name: 'lookup',
+            text: 'preserved',
+        });
+        block.addPartialJSON('{}');
+        block.end();
+
+        const [event] = h.events();
+        // The trailing-text empty-fill only happens when no `text` is
+        // already present on the spec.
+        expect(event.text).toBe('preserved');
+    });
+
+    it('throws when the buffered partial JSON is malformed', () => {
+        const h = makeHarness();
+        const block = h.chatStream.message().contentBlock({
+            type: 'tool_use',
+            id: 'call_5',
+            name: 'lookup',
+        });
+        block.addPartialJSON('not-json');
+        // .end() runs JSON.parse on the buffer — bad JSON surfaces here.
+        expect(() => block.end()).toThrow(SyntaxError);
+    });
+});
+
+// ── unknown content block type ──────────────────────────────────────
+
+describe('AIChatMessageStream.contentBlock', () => {
+    it('throws on an unknown content block type', () => {
+        const h = makeHarness();
+        expect(() =>
+            h.chatStream.message().contentBlock({ type: 'audio' }),
+        ).toThrow(/Unknown content block type/);
+    });
+});


### PR DESCRIPTION
Covers `Messages` (normalize_single_message / normalize_messages / extract_and_remove_system_messages / extract_text), `FunctionCalling` (normalize_json_schema / normalize_tools_object /
make_openai_tools / make_claude_tools), and `Streaming` (AIChatStream / AIChatMessageStream / AIChatTextStream / AIChatToolUseStream). All three are pure data transforms — Streaming is exercised against a real `AIChatStream` wired to a buffering Writable, so no method-level spies are needed.

Closes #2956