### PR TITLE
tests: XAIProvider uses setupTestServer + real metering: [#2982]

### DIFF
--- a/src/backend/drivers/ai-chat/providers/xai/XAIProvider.test.ts
+++ b/src/backend/drivers/ai-chat/providers/xai/XAIProvider.test.ts
@@ -20,16 +20,20 @@
 /**
  * Offline unit tests for XAIProvider.
  *
- * The OpenAI SDK is mocked so the provider never reaches the network —
- * we drive `chat.completions.create` directly to assert how XAIProvider
- * shapes requests, surfaces streamed/non-streamed responses, maps
- * errors, and reports metering. The companion integration test
- * (XAIProvider.integration.test.ts) exercises the real xAI endpoint.
+ * Boots a real PuterServer (in-memory sqlite + dynamo + s3 + mock
+ * redis) and constructs XAIProvider directly against the live wired
+ * `MeteringService` so the recording side is exercised end-to-end.
+ * xAI is OpenAI-compatible so the OpenAI SDK is mocked at the module
+ * boundary; that's the real network egress point. The companion
+ * integration test (XAIProvider.integration.test.ts) exercises the
+ * real xAI endpoint.
  */
 
 import { Writable } from 'node:stream';
 import {
+    afterAll,
     afterEach,
+    beforeAll,
     beforeEach,
     describe,
     expect,
@@ -40,10 +44,9 @@ import {
 
 import { SYSTEM_ACTOR } from '../../../../core/actor.js';
 import type { MeteringService } from '../../../../services/metering/MeteringService.js';
-import {
-    makeMeteringStub as makeBaseMeteringStub,
-    withTestActor,
-} from '../../../integrationTestUtil.js';
+import { PuterServer } from '../../../../server.js';
+import { setupTestServer } from '../../../../testUtil.js';
+import { withTestActor } from '../../../integrationTestUtil.js';
 import { AIChatStream } from '../../utils/Streaming.js';
 import { XAI_MODELS } from './models.js';
 import { XAIProvider } from './XAIProvider.js';
@@ -60,34 +63,40 @@ const { createMock, openAICtor } = vi.hoisted(() => {
     return { createMock, openAICtor };
 });
 
-vi.mock('openai', () => ({
-    OpenAI: vi.fn().mockImplementation(function (
+vi.mock('openai', () => {
+    const OpenAICtor = vi.fn().mockImplementation(function (
         this: Record<string, unknown>,
         opts: unknown,
     ) {
         openAICtor(opts);
         this.chat = { completions: { create: createMock } };
-    }),
-}));
+    });
+    // Some providers (e.g. OllamaChatProvider, GeminiChatProvider)
+    // import the default export and access `.OpenAI` on it, so expose
+    // the same constructor under both shapes — the test server boots
+    // every provider, not just xAI.
+    return { OpenAI: OpenAICtor, default: { OpenAI: OpenAICtor } };
+});
 
-// ── Test helpers ────────────────────────────────────────────────────
-//
-// We reuse the shared MeteringService stub from integrationTestUtil so
-// the metering shape stays identical to integration tests, then layer
-// a `vi.spyOn` over `utilRecordUsageObject` to assert the calls the
-// provider makes.
+// ── Test harness ────────────────────────────────────────────────────
 
-type SpiedMetering = MeteringService & {
-    utilRecordUsageObject: MockInstance<
-        MeteringService['utilRecordUsageObject']
-    >;
-};
+let server: PuterServer;
+let recordSpy: MockInstance<MeteringService['utilRecordUsageObject']>;
+
+beforeAll(async () => {
+    server = await setupTestServer();
+});
+
+afterAll(async () => {
+    await server?.shutdown();
+});
 
 const makeProvider = () => {
-    const metering = makeBaseMeteringStub() as SpiedMetering;
-    vi.spyOn(metering, 'utilRecordUsageObject');
-    const provider = new XAIProvider({ apiKey: 'test-key' }, metering);
-    return { provider, metering };
+    const provider = new XAIProvider(
+        { apiKey: 'test-key' },
+        server.services.metering,
+    );
+    return { provider };
 };
 
 const asAsyncIterable = <T>(items: T[]): AsyncIterable<T> => ({
@@ -121,6 +130,10 @@ const makeCapturingChatStream = () => {
 beforeEach(() => {
     createMock.mockReset();
     openAICtor.mockReset();
+    // Spy on the live MeteringService — keep the underlying impl so
+    // recording-side bugs surface here, but capture calls so per-test
+    // assertions can verify metering shape.
+    recordSpy = vi.spyOn(server.services.metering, 'utilRecordUsageObject');
 });
 
 afterEach(() => {
@@ -332,7 +345,7 @@ describe('XAIProvider model resolution', () => {
     };
 
     it('resolves an exact canonical id', async () => {
-        const { provider, metering } = makeProvider();
+        const { provider } = makeProvider();
         createMock.mockResolvedValueOnce(baseCompletion);
 
         await withTestActor(() =>
@@ -344,7 +357,7 @@ describe('XAIProvider model resolution', () => {
 
         expect(createMock.mock.calls[0]![0].model).toBe('grok-3-mini');
         // Metering namespace mirrors the resolved canonical id.
-        expect(metering.utilRecordUsageObject).toHaveBeenCalledWith(
+        expect(recordSpy).toHaveBeenCalledWith(
             expect.any(Object),
             expect.anything(),
             'xai:grok-3-mini',
@@ -353,7 +366,7 @@ describe('XAIProvider model resolution', () => {
     });
 
     it('resolves an alias to its canonical id (alias rewriting)', async () => {
-        const { provider, metering } = makeProvider();
+        const { provider } = makeProvider();
         createMock.mockResolvedValueOnce(baseCompletion);
 
         await withTestActor(() =>
@@ -366,7 +379,7 @@ describe('XAIProvider model resolution', () => {
 
         // The wire model should be the canonical id, not the alias.
         expect(createMock.mock.calls[0]![0].model).toBe('grok-3');
-        expect(metering.utilRecordUsageObject).toHaveBeenCalledWith(
+        expect(recordSpy).toHaveBeenCalledWith(
             expect.any(Object),
             expect.anything(),
             'xai:grok-3',
@@ -375,7 +388,7 @@ describe('XAIProvider model resolution', () => {
     });
 
     it('falls back to the default model when given an unknown id', async () => {
-        const { provider, metering } = makeProvider();
+        const { provider } = makeProvider();
         createMock.mockResolvedValueOnce(baseCompletion);
 
         await withTestActor(() =>
@@ -386,7 +399,7 @@ describe('XAIProvider model resolution', () => {
         );
 
         expect(createMock.mock.calls[0]![0].model).toBe('grok-beta');
-        expect(metering.utilRecordUsageObject).toHaveBeenCalledWith(
+        expect(recordSpy).toHaveBeenCalledWith(
             expect.any(Object),
             expect.anything(),
             'xai:grok-beta',
@@ -399,7 +412,7 @@ describe('XAIProvider model resolution', () => {
 
 describe('XAIProvider.complete non-stream output', () => {
     it('returns the first choice and runs the metered usage calculator', async () => {
-        const { provider, metering } = makeProvider();
+        const { provider } = makeProvider();
         createMock.mockResolvedValueOnce({
             choices: [
                 {
@@ -438,9 +451,9 @@ describe('XAIProvider.complete non-stream output', () => {
         // Metering: usage is recorded once, with the right model
         // namespace, actor, and a costsOverride priced from
         // models.ts (grok-3: prompt=300, completion=1500, cached=0.75).
-        expect(metering.utilRecordUsageObject).toHaveBeenCalledTimes(1);
+        expect(recordSpy).toHaveBeenCalledTimes(1);
         const [usage, actor, prefix, overrides] =
-            metering.utilRecordUsageObject.mock.calls[0]!;
+            recordSpy.mock.calls[0]!;
         expect(usage).toEqual({
             prompt_tokens: 100,
             completion_tokens: 50,
@@ -509,7 +522,7 @@ describe('XAIProvider.complete non-stream output', () => {
     });
 
     it('zeroes cached_tokens when prompt_tokens_details is missing', async () => {
-        const { provider, metering } = makeProvider();
+        const { provider } = makeProvider();
         createMock.mockResolvedValueOnce({
             choices: [
                 {
@@ -529,7 +542,7 @@ describe('XAIProvider.complete non-stream output', () => {
         );
 
         const [usage, , , overrides] =
-            metering.utilRecordUsageObject.mock.calls[0]!;
+            recordSpy.mock.calls[0]!;
         expect(usage.cached_tokens).toBe(0);
         // 0 cached tokens × any rate = 0 metered cost.
         expect(overrides).toMatchObject({ cached_tokens: 0 });
@@ -540,7 +553,7 @@ describe('XAIProvider.complete non-stream output', () => {
 
 describe('XAIProvider.complete streaming', () => {
     it('streams text deltas through to text events and meters final usage', async () => {
-        const { provider, metering } = makeProvider();
+        const { provider } = makeProvider();
         createMock.mockReturnValueOnce(
             asAsyncIterable([
                 { choices: [{ delta: { content: 'hel' } }] },
@@ -586,9 +599,9 @@ describe('XAIProvider.complete streaming', () => {
         });
 
         // grok-3-mini costs: prompt=30, completion=50, cached=0.075.
-        expect(metering.utilRecordUsageObject).toHaveBeenCalledTimes(1);
+        expect(recordSpy).toHaveBeenCalledTimes(1);
         const [, , prefix, overrides] =
-            metering.utilRecordUsageObject.mock.calls[0]!;
+            recordSpy.mock.calls[0]!;
         expect(prefix).toBe('xai:grok-3-mini');
         expect(overrides).toEqual({
             prompt_tokens: 4 * 30,
@@ -675,7 +688,7 @@ describe('XAIProvider.complete streaming', () => {
 
 describe('XAIProvider.complete error mapping', () => {
     it('rethrows errors raised by the OpenAI client unchanged', async () => {
-        const { provider, metering } = makeProvider();
+        const { provider } = makeProvider();
         const apiError = new Error('xAI exploded');
         createMock.mockRejectedValueOnce(apiError);
         // Provider logs the error before rethrowing — silence the noise.
@@ -691,7 +704,7 @@ describe('XAIProvider.complete error mapping', () => {
         ).rejects.toBe(apiError);
 
         // No metering should be recorded on a failed call.
-        expect(metering.utilRecordUsageObject).not.toHaveBeenCalled();
+        expect(recordSpy).not.toHaveBeenCalled();
         expect(logSpy).toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
Drops the local makeMeteringStub in favour of a live PuterServer-wired MeteringService. The OpenAI SDK is still mocked at the module boundary (the real network egress point); the mock now also exposes a default export so the test server can boot every chat provider (some import the default and read .OpenAI off it). Aligns with AGENTS.md: "Prefer test server over mocking deps."