### PR TITLE
feat(ai): add direct MiniMax provider integration

### DIFF
--- a/src/backend/drivers/ai-chat/providers/minimax/miniMaxProvider.ts
+++ b/src/backend/drivers/ai-chat/providers/minimax/miniMaxProvider.ts
@@ -1,0 +1,87 @@
+import axios, { AxiosInstance } from 'axios';
+
+type ChatMessage = {
+    role: 'system' | 'user' | 'assistant' | 'tool';
+    content: any;
+    name?: string;
+    tool_call_id?: string;
+};
+
+type MiniMaxProviderConfig = {
+    apiKey: string;
+    apiBaseUrl?: string;
+};
+
+type CompleteArgs = {
+    model: string;
+    messages: ChatMessage[];
+    temperature?: number;
+    max_tokens?: number;
+    stream?: boolean;
+    tools?: any[];
+};
+
+export class MiniMaxProvider {
+    private client: AxiosInstance;
+    private apiKey: string;
+    private baseURL: string;
+
+    constructor(config: MiniMaxProviderConfig) {
+        this.apiKey = config.apiKey;
+        this.baseURL = (
+            config.apiBaseUrl || 'https://api.minimax.io/v1'
+        ).replace(/\/$/, '');
+
+        this.client = axios.create({
+            baseURL: this.baseURL,
+            headers: {
+                Authorization: `Bearer ${this.apiKey}`,
+                'Content-Type': 'application/json',
+            },
+        });
+    }
+
+    getDefaultModel() {
+        return 'MiniMax-M2.7';
+    }
+
+    async complete({
+        model,
+        messages,
+        temperature,
+        max_tokens,
+        stream = false,
+        tools,
+    }: CompleteArgs) {
+        const payload: any = {
+            model: model || this.getDefaultModel(),
+            messages,
+            ...(typeof temperature === 'number' ? { temperature } : {}),
+            ...(typeof max_tokens === 'number' ? { max_tokens } : {}),
+            ...(Array.isArray(tools) ? { tools } : {}),
+            ...(stream ? { stream: true } : {}),
+            extra_body: {
+                reasoning_split: true,
+            },
+        };
+
+        const res = await this.client.post('/chat/completions', payload, {
+            responseType: stream ? 'stream' : 'json',
+        });
+
+        return res.data;
+    }
+
+    async listModels() {
+        return [
+            'MiniMax-M2.7',
+            'MiniMax-M2.7-highspeed',
+            'MiniMax-M2.5',
+            'MiniMax-M2.5-highspeed',
+            'MiniMax-M2.1',
+            'MiniMax-M2.1-highspeed',
+            'MiniMax-M2-her',
+            'MiniMax-M2',
+        ];
+    }
+}

--- a/src/backend/drivers/ai-chat/providers/minimax/models.ts
+++ b/src/backend/drivers/ai-chat/providers/minimax/models.ts
@@ -1,0 +1,102 @@
+import type { IChatModel } from '../../types.js';
+
+export type MiniMaxChatModel = IChatModel & {
+	upstreamModel: string;
+};
+
+type MiniMaxModelSpec = {
+	id: string;
+	upstreamModel: string;
+	puterId: string;
+	name: string;
+	context: number;
+	aliases?: string[];
+};
+
+const makeModel = (spec: MiniMaxModelSpec): MiniMaxChatModel => ({
+	id: spec.id,
+	puterId: spec.puterId,
+	name: spec.name,
+	aliases: spec.aliases ?? [],
+	modalities: { input: ['text'], output: ['text'] },
+	costs_currency: 'usd-cents',
+	input_cost_key: 'prompt_tokens',
+	output_cost_key: 'completion_tokens',
+	costs: {
+		tokens: 1_000_000,
+		prompt_tokens: 0,
+		completion_tokens: 0,
+		cached_tokens: 0,
+	},
+	context: spec.context,
+	max_tokens: spec.context,
+	tool_call: true,
+	upstreamModel: spec.upstreamModel,
+});
+
+export const MINIMAX_MODELS: MiniMaxChatModel[] = [
+	makeModel({
+		id: 'minimax-m2.7',
+		upstreamModel: 'MiniMax-M2.7',
+		puterId: 'minimax/m2.7',
+		name: 'MiniMax M2.7',
+		context: 204_800,
+		aliases: ['MiniMax-M2.7', 'mini-max-m2.7', 'm2.7'],
+	}),
+	makeModel({
+		id: 'minimax-m2.7-highspeed',
+		upstreamModel: 'MiniMax-M2.7-highspeed',
+		puterId: 'minimax/m2.7-highspeed',
+		name: 'MiniMax M2.7 Highspeed',
+		context: 204_800,
+		aliases: ['MiniMax-M2.7-highspeed', 'm2.7-highspeed'],
+	}),
+	makeModel({
+		id: 'minimax-m2.5',
+		upstreamModel: 'MiniMax-M2.5',
+		puterId: 'minimax/m2.5',
+		name: 'MiniMax M2.5',
+		context: 204_800,
+		aliases: ['MiniMax-M2.5', 'm2.5'],
+	}),
+	makeModel({
+		id: 'minimax-m2.5-highspeed',
+		upstreamModel: 'MiniMax-M2.5-highspeed',
+		puterId: 'minimax/m2.5-highspeed',
+		name: 'MiniMax M2.5 Highspeed',
+		context: 204_800,
+		aliases: ['MiniMax-M2.5-highspeed', 'm2.5-highspeed'],
+	}),
+	makeModel({
+		id: 'minimax-m2.1',
+		upstreamModel: 'MiniMax-M2.1',
+		puterId: 'minimax/m2.1',
+		name: 'MiniMax M2.1',
+		context: 204_800,
+		aliases: ['MiniMax-M2.1', 'm2.1'],
+	}),
+	makeModel({
+		id: 'minimax-m2.1-highspeed',
+		upstreamModel: 'MiniMax-M2.1-highspeed',
+		puterId: 'minimax/m2.1-highspeed',
+		name: 'MiniMax M2.1 Highspeed',
+		context: 204_800,
+		aliases: ['MiniMax-M2.1-highspeed', 'm2.1-highspeed'],
+	}),
+	makeModel({
+		id: 'minimax-m2-her',
+		upstreamModel: 'MiniMax-M2-her',
+		puterId: 'minimax/m2-her',
+		name: 'MiniMax M2-her',
+		context: 65_536,
+		aliases: ['MiniMax-M2-her', 'm2-her'],
+	}),
+	makeModel({
+		id: 'minimax-m2',
+		upstreamModel: 'MiniMax-M2',
+		puterId: 'minimax/m2',
+		name: 'MiniMax M2',
+		context: 204_800,
+		aliases: ['MiniMax-M2', 'm2'],
+	}),
+];


### PR DESCRIPTION
Adds direct MiniMax provider integration.

Includes:
- MiniMax provider implementation
- model registration
- provider registration
- config support
- chat completion support
- streaming-ready structure

Uses direct HTTP requests via axios instead of OpenAI SDK.