### PR TITLE
Add OpenRouter model release dates

### DIFF
--- a/src/backend/drivers/ai-chat/providers/openrouter/OpenRouterProvider.test.ts
+++ b/src/backend/drivers/ai-chat/providers/openrouter/OpenRouterProvider.test.ts
@@ -92,6 +92,7 @@ const SAMPLE_API_MODELS = [
     {
         id: 'openai/gpt-5-nano',
         name: 'GPT-5 Nano',
+        created: 1714564800,
         context_length: 128000,
         pricing: { prompt: 0.00001, completion: 0.00003 },
         top_provider: { max_completion_tokens: 16000 },
@@ -99,6 +100,7 @@ const SAMPLE_API_MODELS = [
     {
         id: 'anthropic/claude-haiku-4.5',
         name: 'Claude Haiku 4.5',
+        created: 1760529600,
         context_length: 200000,
         pricing: { prompt: 0.000002, completion: 0.00001 },
         top_provider: { max_completion_tokens: 8192 },
@@ -107,6 +109,7 @@ const SAMPLE_API_MODELS = [
         // 'openrouter/auto' is filtered out — disallowed.
         id: 'openrouter/auto',
         name: 'Auto',
+        created: 1704067200,
         context_length: 32768,
         pricing: { prompt: 0, completion: 0 },
         top_provider: { max_completion_tokens: 4096 },
@@ -223,6 +226,23 @@ describe('OpenRouterProvider model catalog', () => {
         await provider.models();
         // Second call should be a cache hit, not a second axios request.
         expect(axiosRequestMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('maps OpenRouter created timestamps to release_date metadata', async () => {
+        const { provider } = makeProvider();
+        const models = await provider.models();
+        expect(models).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    id: 'openrouter:openai/gpt-5-nano',
+                    release_date: '2024-05-01',
+                }),
+                expect.objectContaining({
+                    id: 'openrouter:anthropic/claude-haiku-4.5',
+                    release_date: '2025-10-15',
+                }),
+            ]),
+        );
     });
 });
 

--- a/src/backend/drivers/ai-chat/providers/openrouter/OpenRouterProvider.ts
+++ b/src/backend/drivers/ai-chat/providers/openrouter/OpenRouterProvider.ts
@@ -36,6 +36,21 @@ type OpenrouterUsage = OpenAI.Completions.CompletionUsage & {
     cost?: number;
 };
 
+const openRouterReleaseDate = (created: unknown) => {
+    const timestamp =
+        typeof created === 'number'
+            ? created
+            : typeof created === 'string'
+              ? Number(created)
+              : undefined;
+
+    if (!timestamp || !Number.isFinite(timestamp)) {
+        return undefined;
+    }
+
+    return new Date(timestamp * 1000).toISOString().slice(0, 10);
+};
+
 export class OpenRouterProvider implements IChatProvider {
     #meteringService: MeteringService;
 
@@ -275,6 +290,7 @@ export class OpenRouterProvider implements IChatProvider {
                     tokens: 1_000_000,
                     ...microcentCosts,
                 },
+                release_date: openRouterReleaseDate(model.created),
                 ...overridenModel,
             });
         }

--- a/src/backend/drivers/ai-chat/providers/openrouter/OpenRouterProvider.ts
+++ b/src/backend/drivers/ai-chat/providers/openrouter/OpenRouterProvider.ts
@@ -36,19 +36,16 @@ type OpenrouterUsage = OpenAI.Completions.CompletionUsage & {
     cost?: number;
 };
 
-const openRouterReleaseDate = (created: unknown) => {
-    const timestamp =
-        typeof created === 'number'
-            ? created
-            : typeof created === 'string'
-              ? Number(created)
-              : undefined;
-
-    if (!timestamp || !Number.isFinite(timestamp)) {
+const openRouterReleaseDate = (created: unknown): string | undefined => {
+    const seconds = Number(created);
+    if (!Number.isFinite(seconds) || seconds <= 0) {
         return undefined;
     }
-
-    return new Date(timestamp * 1000).toISOString().slice(0, 10);
+    const date = new Date(seconds * 1000);
+    const year = date.getUTCFullYear();
+    const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+    const day = String(date.getUTCDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
 };
 
 export class OpenRouterProvider implements IChatProvider {


### PR DESCRIPTION
Closes #3143

## Summary
- map OpenRouter model `created` timestamps into `release_date` metadata
- add coverage for OpenRouter model catalog release dates

## Impact
OpenRouter-backed models returned by `/puterai/chat/models/details` can now include the same `release_date` field that other providers expose, using the API-provided creation timestamp formatted as `YYYY-MM-DD`.

## Validation
- `npm run test:backend -- src/backend/drivers/ai-chat/providers/openrouter/OpenRouterProvider.test.ts` - 1 file passed, 15 tests passed
- `npm run build:ts` - passed
- `git diff --check` - passed