### PR TITLE
Docs search improvement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -452,6 +452,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1044.0.tgz",
       "integrity": "sha512-E9dZeAbyWC1YRAjdeQ7i1aK8635cQSpX4m0cUAlySiQRLux7NZa89BER07LU5OLi6ObnTi0FE7Vy0WbICUotjw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -1749,6 +1750,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1797,6 +1799,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1809,28 +1812,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -2936,9 +2917,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2954,9 +2932,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -2974,9 +2949,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2992,9 +2964,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -3012,9 +2981,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3030,9 +2996,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -3050,9 +3013,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3069,9 +3029,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3087,9 +3044,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -3113,9 +3067,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3137,9 +3088,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -3163,9 +3111,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3187,9 +3132,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -3213,9 +3155,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3238,9 +3177,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3262,9 +3198,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -3571,6 +3504,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -6121,9 +6055,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6141,9 +6072,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6161,9 +6089,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6181,9 +6106,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6201,9 +6123,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6221,9 +6140,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7328,6 +7244,7 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -7490,6 +7407,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
       "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -7638,6 +7556,7 @@
       "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.2",
         "@typescript-eslint/types": "8.59.2",
@@ -7923,6 +7842,7 @@
       "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.5",
@@ -8062,6 +7982,7 @@
       "integrity": "sha512-3Z9HNFiV0IF1fk0JPiK+7kE1GcaIPefQQIBYur6PM5yFIq6agys3uqP/0t966e1wXfmjbRCHDe7qW236Xjwnag==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.1.5",
         "fflate": "^0.8.2",
@@ -8399,6 +8320,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -9018,6 +8940,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -9199,6 +9122,7 @@
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
       "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.3",
@@ -10365,6 +10289,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -10434,6 +10359,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -10494,6 +10420,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -11127,6 +11054,7 @@
       "resolved": "https://registry.npmjs.org/fengari/-/fengari-0.1.5.tgz",
       "integrity": "sha512-0DS4Nn4rV8qyFlQCpKK8brT61EUtswynrpfFTcgLErcilBIBskSMQ86fO2WVuybr14ywyKdRjv91FiRZwnEuvQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readline-sync": "^1.4.10",
         "sprintf-js": "^1.1.3",
@@ -12418,6 +12346,7 @@
       "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.10.1.tgz",
       "integrity": "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ioredis/commands": "1.5.1",
         "cluster-key-slot": "^1.1.0",
@@ -13574,9 +13503,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -13598,9 +13524,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -13622,9 +13545,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -13646,9 +13566,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14139,6 +14056,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/minisearch": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.2.0.tgz",
+      "integrity": "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==",
+      "license": "MIT"
     },
     "node_modules/minizlib": {
       "version": "2.1.2",
@@ -15333,6 +15256,7 @@
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -16112,6 +16036,7 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -16638,6 +16563,7 @@
       "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.7.tgz",
       "integrity": "sha512-e0LyK91f3cUxTmv95/KzoLg47+zF+s/sbxRGDNsyG4dmIP8ZSX8ax6byOxfJXeNNtS/8AZlfD+uP7gBeR7DLlg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "~4.4.1",
         "ws": "~8.20.1"
@@ -17454,6 +17380,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17678,6 +17605,7 @@
       "integrity": "sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -17779,6 +17707,7 @@
       "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.5",
         "@vitest/mocker": "4.1.5",
@@ -17910,6 +17839,7 @@
       "integrity": "sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -17958,6 +17888,7 @@
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",
@@ -18286,6 +18217,7 @@
       "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -18341,6 +18273,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -18516,6 +18449,7 @@
         "js-yaml": "^4.1.0",
         "jsdom": "^26.1.0",
         "marked": "^11.1.1",
+        "minisearch": "^7.2.0",
         "nwsapi": "^2.2.23"
       },
       "devDependencies": {
@@ -18626,6 +18560,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -18648,6 +18583,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -452,7 +452,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1044.0.tgz",
       "integrity": "sha512-E9dZeAbyWC1YRAjdeQ7i1aK8635cQSpX4m0cUAlySiQRLux7NZa89BER07LU5OLi6ObnTi0FE7Vy0WbICUotjw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -1750,7 +1749,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1799,7 +1797,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1812,6 +1809,28 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -3504,7 +3523,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -7244,7 +7262,6 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -7407,7 +7424,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
       "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -7556,7 +7572,6 @@
       "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.2",
         "@typescript-eslint/types": "8.59.2",
@@ -7842,7 +7857,6 @@
       "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.5",
@@ -7982,7 +7996,6 @@
       "integrity": "sha512-3Z9HNFiV0IF1fk0JPiK+7kE1GcaIPefQQIBYur6PM5yFIq6agys3uqP/0t966e1wXfmjbRCHDe7qW236Xjwnag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.1.5",
         "fflate": "^0.8.2",
@@ -8320,7 +8333,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8940,7 +8952,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -9122,7 +9133,6 @@
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
       "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.3",
@@ -10289,7 +10299,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -10359,7 +10368,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -10420,7 +10428,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -11054,7 +11061,6 @@
       "resolved": "https://registry.npmjs.org/fengari/-/fengari-0.1.5.tgz",
       "integrity": "sha512-0DS4Nn4rV8qyFlQCpKK8brT61EUtswynrpfFTcgLErcilBIBskSMQ86fO2WVuybr14ywyKdRjv91FiRZwnEuvQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readline-sync": "^1.4.10",
         "sprintf-js": "^1.1.3",
@@ -12346,7 +12352,6 @@
       "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.10.1.tgz",
       "integrity": "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ioredis/commands": "1.5.1",
         "cluster-key-slot": "^1.1.0",
@@ -15256,7 +15261,6 @@
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -16036,7 +16040,6 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -16563,7 +16566,6 @@
       "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.7.tgz",
       "integrity": "sha512-e0LyK91f3cUxTmv95/KzoLg47+zF+s/sbxRGDNsyG4dmIP8ZSX8ax6byOxfJXeNNtS/8AZlfD+uP7gBeR7DLlg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "~4.4.1",
         "ws": "~8.20.1"
@@ -17380,7 +17382,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17605,7 +17606,6 @@
       "integrity": "sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -17707,7 +17707,6 @@
       "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.5",
         "@vitest/mocker": "4.1.5",
@@ -17839,7 +17838,6 @@
       "integrity": "sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -17888,7 +17886,6 @@
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",
@@ -18217,7 +18214,6 @@
       "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -18273,7 +18269,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -18560,7 +18555,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -18583,7 +18577,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }

--- a/src/docs/build.js
+++ b/src/docs/build.js
@@ -866,14 +866,43 @@ IMPORTANT: when creating an app, include a link to 'https://developer.puter.com'
     fs.writeFileSync(outputFile, outputContent, 'utf8');
 };
 
-function markdownToPlainText (markdown) {
+// Split a rendered page into sections bounded by <h2> elements. Renders the
+// markdown to HTML once, then walks body children: each <h2> starts a new
+// section, and siblings until the next <h2> become its content. Content before
+// the first <h2> is the intro section (heading=null).
+//
+// Anchors come from the <h2>'s `id` attribute (set by our heading renderer
+// override), so they always match the in-page anchors by construction.
+// Inline formatting in headings (e.g. `## **Websites**`) is unwrapped by
+// textContent. Code fences become <pre><code>, not headings, so a `## ` inside
+// a code block can't accidentally start a section.
+function splitHtmlIntoSections (markdown) {
     const html = marked.parse(markdown);
+    const dom = new JSDOM(html);
+    const body = dom.window.document.body;
 
-    const dom = new JSDOM();
-    const div = dom.window.document.createElement('div');
-    div.innerHTML = html;
+    const sections = [];
+    let current = { heading: null, slug: '', textParts: [] };
 
-    return div.textContent.replace(/\s+/g, ' ').trim();
+    for ( const child of body.children ) {
+        if ( child.tagName === 'H2' ) {
+            sections.push(current);
+            current = {
+                heading: child.textContent.trim(),
+                slug: child.id || '',
+                textParts: [],
+            };
+        } else {
+            current.textParts.push(child.textContent);
+        }
+    }
+    sections.push(current);
+
+    return sections.map(s => ({
+        heading: s.heading,
+        slug: s.slug,
+        text: s.textParts.join(' ').replace(/\s+/g, ' ').trim(),
+    }));
 }
 
 const generateSearchIndex = () => {
@@ -881,23 +910,33 @@ const generateSearchIndex = () => {
     const outputFile = path.join(currentDir, 'dist', 'index.json');
     const json = [];
 
+    // Emit one entry per section (intro + each h2) for each page.
+    // The intro entry is always emitted so the page itself is title-searchable
+    // even when its content starts immediately with a heading.
+    const pushPage = (pageTitle, pagePath, markdown) => {
+        const { content } = parseFrontMatter(markdown);
+        const sections = splitHtmlIntoSections(content);
+        sections.forEach((section) => {
+            const isIntro = section.heading === null;
+            json.push({
+                title: isIntro ? pageTitle : section.heading,
+                pageTitle,
+                path: pagePath,
+                anchor: isIntro ? '' : section.slug,
+                text: section.text,
+            });
+        });
+    };
+
     const indexFile = path.join(currentDir, 'src', 'index.md');
     const indexMarkdown = fs.readFileSync(indexFile, 'utf8');
-    json.push({
-        title: 'Puter.js',
-        path: '',
-        text: markdownToPlainText(indexMarkdown),
-    });
+    pushPage('Puter.js', '', indexMarkdown);
 
     sidebar.forEach((item) => {
         if ( item.source ) {
             const file = path.join(currentDir, 'src', item.source);
             const markdown = fs.readFileSync(file, 'utf8');
-            json.push({
-                title: item.title_tag ?? item.title,
-                path: item.path,
-                text: markdownToPlainText(markdown),
-            });
+            pushPage(item.title_tag ?? item.title, item.path, markdown);
         }
 
         if ( item.children && Array.isArray(item.children) ) {
@@ -905,11 +944,7 @@ const generateSearchIndex = () => {
                 if ( child.source ) {
                     const file = path.join(currentDir, 'src', child.source);
                     const markdown = fs.readFileSync(file, 'utf8');
-                    json.push({
-                        title: child.title_tag ?? child.title,
-                        path: child.path,
-                        text: markdownToPlainText(markdown),
-                    });
+                    pushPage(child.title_tag ?? child.title, child.path, markdown);
                 }
             });
         }

--- a/src/docs/build.js
+++ b/src/docs/build.js
@@ -9,7 +9,35 @@ const { encode } =  require('html-entities');
 const { JSDOM } = require('jsdom');
 const yaml = require('js-yaml');
 const esbuild = require('esbuild');
+const MiniSearch = require('minisearch');
 const { generatePlayground } = require('./src/playground');
+
+// Index-time tokenizer. Splits on whitespace AND punctuation, and ALSO emits
+// contiguous pairwise (2-gram) joins of the parts:
+//   "Node.js"          → ["node", "js", "nodejs"]
+//   "puter.ai.chat()"  → ["puter", "ai", "chat", "puterai", "aichat"]
+// This lets queries like "nodejs", "puterai", or "aichat" match directly.
+function indexTokenize (text) {
+    if ( !text ) return [];
+    const tokens = [];
+    for ( const chunk of text.split(/[\n\r\p{Z}]+/u) ) {
+        if ( !chunk ) continue;
+        const parts = chunk.split(/\p{P}+/u).filter(Boolean);
+        // Individual parts
+        for ( const part of parts ) tokens.push(part);
+        // Pairwise adjacent joins (linear in parts.length)
+        for ( let i = 0; i + 1 < parts.length; i++ ) {
+            tokens.push(parts[i] + parts[i + 1]);
+        }
+    }
+    return tokens;
+}
+
+const MINISEARCH_INDEX_CONFIG = {
+    fields: ['title', 'text', 'pageTitle'],
+    storeFields: ['title', 'pageTitle', 'path', 'anchor', 'text'],
+    tokenize: indexTokenize,
+};
 
 const site = 'https://docs.puter.com';
 
@@ -866,16 +894,6 @@ IMPORTANT: when creating an app, include a link to 'https://developer.puter.com'
     fs.writeFileSync(outputFile, outputContent, 'utf8');
 };
 
-// Split a rendered page into sections bounded by <h2> elements. Renders the
-// markdown to HTML once, then walks body children: each <h2> starts a new
-// section, and siblings until the next <h2> become its content. Content before
-// the first <h2> is the intro section (heading=null).
-//
-// Anchors come from the <h2>'s `id` attribute (set by our heading renderer
-// override), so they always match the in-page anchors by construction.
-// Inline formatting in headings (e.g. `## **Websites**`) is unwrapped by
-// textContent. Code fences become <pre><code>, not headings, so a `## ` inside
-// a code block can't accidentally start a section.
 function splitHtmlIntoSections (markdown) {
     const html = marked.parse(markdown);
     const dom = new JSDOM(html);
@@ -910,9 +928,6 @@ const generateSearchIndex = () => {
     const outputFile = path.join(currentDir, 'dist', 'index.json');
     const json = [];
 
-    // Emit one entry per section (intro + each h2) for each page.
-    // The intro entry is always emitted so the page itself is title-searchable
-    // even when its content starts immediately with a heading.
     const pushPage = (pageTitle, pagePath, markdown) => {
         const { content } = parseFrontMatter(markdown);
         const sections = splitHtmlIntoSections(content);
@@ -950,7 +965,9 @@ const generateSearchIndex = () => {
         }
     });
 
-    fs.writeFileSync(outputFile, JSON.stringify(json), 'utf8');
+    const miniSearch = new MiniSearch(MINISEARCH_INDEX_CONFIG);
+    miniSearch.addAll(json.map((doc, id) => ({ id, ...doc })));
+    fs.writeFileSync(outputFile, JSON.stringify(miniSearch.toJSON()), 'utf8');
 };
 
 // Main execution

--- a/src/docs/package.json
+++ b/src/docs/package.json
@@ -27,6 +27,7 @@
     "js-yaml": "^4.1.0",
     "jsdom": "^26.1.0",
     "marked": "^11.1.1",
+    "minisearch": "^7.2.0",
     "nwsapi": "^2.2.23"
   },
   "devDependencies": {

--- a/src/docs/src/assets/css/style.css
+++ b/src/docs/src/assets/css/style.css
@@ -421,6 +421,18 @@ ul code {
 	margin-bottom: 4px;
 }
 
+/* Lighter page-title prefix so the matched section heading stays prominent
+   in the "Page Title › Section" format. */
+.search-result-title-page {
+	color: #888888;
+	font-weight: 400;
+}
+
+.search-result-sep {
+	color: #cccccc;
+	margin: 0 6px;
+}
+
 .search-result-text {
 	font-size: 14px;
 	color: #666666;

--- a/src/docs/src/assets/js/search.js
+++ b/src/docs/src/assets/js/search.js
@@ -1,9 +1,42 @@
 import $ from 'jquery';
+import MiniSearch from 'minisearch';
 
-// Global search index
-let searchIndex = [];
+let miniSearch = null;
 let searchTimeout = null;
 let selectedSearchResult = -1;
+
+// Query-time tokenizer. Splits on whitespace AND punctuation only — does
+// NOT emit the joined-without-punctuation form. The index (built in
+// build.js's indexTokenize) already pre-baked the joined variants, so
+// queries just need to produce the user's natural tokens and let
+// exact/prefix/fuzzy match against the indexed terms.
+function queryTokenize (text) {
+    if ( !text ) return [];
+    const tokens = [];
+    for ( const chunk of text.split(/[\n\r\p{Z}]+/u) ) {
+        if ( !chunk ) continue;
+        const parts = chunk.split(/\p{P}+/u).filter(Boolean);
+        for ( const part of parts ) tokens.push(part);
+    }
+    return tokens;
+}
+
+const MINISEARCH_CONFIG = {
+    fields: ['title', 'text', 'pageTitle'],
+    storeFields: ['title', 'pageTitle', 'path', 'anchor', 'text'],
+    tokenize: queryTokenize,
+    searchOptions: {
+        boost: { title: 3, pageTitle: 2, text: 1 },
+        fuzzy: term => {
+            if ( term.length <= 3 ) return 0;
+            if ( term.length <= 7 ) return 1;
+            return 2;
+        },
+        prefix: term => term.length >= 3,
+
+        combineWith: 'AND',
+    },
+};
 
 const commandIcon = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-command-icon lucide-command"><path d="M15 6v12a3 3 0 1 0 3-3H6a3 3 0 1 0 3 3V6a3 3 0 1 0-3 3h12a3 3 0 1 0-3-3"/></svg>';
 
@@ -88,7 +121,7 @@ $(document).ready(function () {
 
         // Set new timeout for debouncing
         searchTimeout = setTimeout(async () => {
-            if ( searchIndex.length == 0 ) {
+            if ( !miniSearch ) {
                 await fetchSearchIndex();
             }
             performSearch(query);
@@ -102,12 +135,12 @@ $(document).ready(function () {
 async function fetchSearchIndex () {
     try {
         const response = await fetch('/index.json');
-        const data = await response.json();
-        searchIndex = data;
-        console.log('Search index loaded:', `${searchIndex.length } items`);
+        const text = await response.text();
+        miniSearch = MiniSearch.loadJSON(text, MINISEARCH_CONFIG);
+        console.log('Search index loaded:', `${miniSearch.documentCount } items`);
     } catch ( error ) {
         console.error('Failed to load search index:', error);
-        searchIndex = [];
+        miniSearch = null;
     }
 }
 function escapeHtml (text) {
@@ -119,10 +152,10 @@ function escapeHtml (text) {
         .replace(/'/g, '&#39;');
 }
 
-// Returns the bare `text=...` portion of a text fragment, without the
-// `#:~:` prefix. The caller composes the full fragment depending on whether
-// an `#anchor` is already present in the URL (combined form: `#anchor:~:text=`
-// vs anchor-less: `#:~:text=`).
+function escapeRegex (text) {
+    return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 function generateTextFragment (matchedText, prefix = '', suffix = '') {
     const encodedText = encodeURIComponent(matchedText);
     const encodedPrefix = prefix ? `${encodeURIComponent(prefix) }-,` : '';
@@ -151,112 +184,124 @@ function performSearch (query) {
         return;
     }
 
-    const titleResults = [];
-    const textResults = [];
+    if ( !miniSearch ) {
+        // Index hasn't finished loading yet; show empty state.
+        updateSearchResults([]);
+        return;
+    }
+
+    const hits = miniSearch.search(query).slice(0, 15);
+    const results = hits.map(hit => decorateHit(hit, query));
+    updateSearchResults(results);
+}
+
+function textPreview (text, maxLen) {
+    if ( !text ) return '';
+    if ( text.length <= maxLen ) return text;
+    return `${text.substring(0, maxLen) }...`;
+}
+
+// Apply exact-substring highlighting on top of an engine hit. Priority:
+//   1. Query found in section title  → mark the title, no text fragment
+//      (anchor jump alone lands on the heading).
+//   2. Query found in section body   → mark a snippet around the match,
+//      attach a text-fragment URL so the browser scrolls to the phrase.
+//   3. Fuzzy-only hit (no exact match either place) → no marks, no fragment;
+//      we just link to the section anchor.
+function decorateHit (hit, query) {
     const queryLower = query.toLowerCase();
+    const queryRegex = new RegExp(`(${escapeRegex(query)})`, 'i');
 
-    searchIndex.forEach((item) => {
-        const titleMatch = item.title.toLowerCase().indexOf(queryLower);
-        if ( titleMatch !== -1 ) {
-            const highlightedTitle = escapeHtml(item.title).replace(
-                            new RegExp(`(${escapeHtml(query)})`, 'i'),
-                            '<mark>$1</mark>');
+    const base = {
+        pageTitle: hit.pageTitle,
+        path: hit.path,
+        anchor: hit.anchor,
+    };
 
-            titleResults.push({
-                title: highlightedTitle,
-                pageTitle: item.pageTitle,
-                path: item.path,
-                anchor: item.anchor,
-                text: escapeHtml(item.text.substring(0, 60) + (item.text.length > 60 ? '...' : '')),
-                textFragment: '',
-            });
+    if ( hit.title.toLowerCase().includes(queryLower) ) {
+        return {
+            ...base,
+            title: escapeHtml(hit.title).replace(queryRegex, '<mark>$1</mark>'),
+            text: escapeHtml(textPreview(hit.text, 80)),
+            textFragment: '',
+        };
+    }
+
+    const textIdx = hit.text.toLowerCase().indexOf(queryLower);
+    if ( textIdx !== -1 ) {
+        const { snippet, textFragment } = buildBodySnippet(hit.text, query, textIdx);
+        return {
+            ...base,
+            title: escapeHtml(hit.title),
+            text: snippet,
+            textFragment,
+        };
+    }
+
+    // Fuzzy-only hit
+    return {
+        ...base,
+        title: escapeHtml(hit.title),
+        text: escapeHtml(textPreview(hit.text, 120)),
+        textFragment: '',
+    };
+}
+
+// Build a word-aligned snippet around an exact match in body text, plus the
+// `text=prefix-,match,-suffix` fragment that lets the browser highlight the
+// phrase in-page after navigation.
+function buildBodySnippet (text, query, matchIdx) {
+    const queryLen = query.length;
+
+    // ±50 chars of context around the match
+    const contextStart = Math.max(0, matchIdx - 50);
+    const contextEnd = Math.min(text.length, matchIdx + queryLen + 50);
+    const contextText = text.substring(contextStart, contextEnd);
+
+    const words = contextText.split(/\s+/);
+
+    // Find which words the match spans
+    const matchStart = matchIdx;
+    const matchEnd = matchIdx + queryLen;
+    let matchStartWordIndex = -1;
+    let matchEndWordIndex = -1;
+    let currentPos = contextStart;
+
+    for ( let i = 0; i < words.length; i++ ) {
+        const wordStart = currentPos;
+        const wordEnd = wordStart + words[i].length;
+        if ( wordStart < matchEnd && wordEnd > matchStart ) {
+            if ( matchStartWordIndex === -1 ) matchStartWordIndex = i;
+            matchEndWordIndex = i;
         }
+        currentPos = wordEnd + 1; // +1 for separating space
+    }
 
-        const textLower = item.text.toLowerCase();
-        let searchOffset = 0;
+    const matchedWords = matchStartWordIndex !== -1
+        ? words.slice(matchStartWordIndex, matchEndWordIndex + 1).join(' ')
+        : words[0] || '';
 
-        // Find all matches in the text
-        while ( true ) {
-            const textMatch = textLower.indexOf(queryLower, searchOffset);
-            if ( textMatch === -1 ) break;
+    // Adjacent words tighten the text-fragment so it doesn't match elsewhere
+    const fragmentPrefix = matchStartWordIndex > 0
+        ? words[matchStartWordIndex - 1] : '';
+    const fragmentSuffix = matchEndWordIndex < words.length - 1
+        ? words[matchEndWordIndex + 1] : '';
+    const textFragment = generateTextFragment(matchedWords,
+                    fragmentPrefix,
+                    fragmentSuffix);
 
-            // Extract 50 chars before and after the match
-            const contextStart = Math.max(0, textMatch - 50);
-            const contextEnd = Math.min(item.text.length,
-                            textMatch + query.length + 50);
-            const contextText = item.text.substring(contextStart, contextEnd);
+    // Display: up to 4 words on either side, with ellipses if trimmed
+    const startWord = Math.max(0, matchStartWordIndex - 4);
+    const endWord = Math.min(words.length, matchEndWordIndex + 5);
+    let displayText = words.slice(startWord, endWord).join(' ');
+    if ( startWord > 0 ) displayText = `...${ displayText}`;
+    if ( endWord < words.length ) displayText = `${displayText }...`;
 
-            // Split into words
-            const words = contextText.split(/\s+/);
+    const snippet = escapeHtml(displayText).replace(
+                    new RegExp(`(${escapeRegex(query)})`, 'i'),
+                    '<mark>$1</mark>');
 
-            // Find all words that intersect with the match range
-            const matchStart = textMatch;
-            const matchEnd = textMatch + query.length;
-            let matchStartWordIndex = -1;
-            let matchEndWordIndex = -1;
-            let currentPos = contextStart;
-
-            for ( let i = 0; i < words.length; i++ ) {
-                const wordStart = currentPos;
-                const wordEnd = wordStart + words[i].length;
-
-                // Check if this word intersects with the match
-                if ( wordStart < matchEnd && wordEnd > matchStart ) {
-                    if ( matchStartWordIndex === -1 ) {
-                        matchStartWordIndex = i;
-                    }
-                    matchEndWordIndex = i;
-                }
-                currentPos = wordEnd + 1; // +1 for space
-            }
-
-            // Get the complete matched text (all words that contain the match)
-            const matchedWords =
-                matchStartWordIndex !== -1
-                    ? words.slice(matchStartWordIndex, matchEndWordIndex + 1).join(' ')
-                    : words[0] || '';
-
-            // Get prefix and suffix for text fragment (closest words)
-            const fragmentPrefix =
-                matchStartWordIndex > 0 ? words[matchStartWordIndex - 1] : '';
-            const fragmentSuffix =
-                matchEndWordIndex < words.length - 1
-                    ? words[matchEndWordIndex + 1]
-                    : '';
-
-            // Generate text fragment
-            const textFragment = generateTextFragment(matchedWords,
-                            fragmentPrefix,
-                            fragmentSuffix);
-
-            // Create display text (max 4 words before/after)
-            const startWord = Math.max(0, matchStartWordIndex - 4);
-            const endWord = Math.min(words.length, matchEndWordIndex + 5);
-            const displayWords = words.slice(startWord, endWord);
-
-            let displayText = displayWords.join(' ');
-            if ( startWord > 0 ) displayText = `...${ displayText}`;
-            if ( endWord < words.length ) displayText = `${displayText }...`;
-
-            // Highlight the matched text in display
-            const highlightedChunk = escapeHtml(displayText).replace(
-                            new RegExp(`(${escapeHtml(query)})`, 'i'),
-                            '<mark>$1</mark>');
-
-            textResults.push({
-                title: item.title,
-                pageTitle: item.pageTitle,
-                path: item.path,
-                anchor: item.anchor,
-                text: highlightedChunk,
-                textFragment: textFragment,
-            });
-
-            searchOffset = textMatch + 1;
-        }
-    });
-
-    updateSearchResults([...titleResults, ...textResults]);
+    return { snippet, textFragment };
 }
 
 function updateSearchResults (results) {

--- a/src/docs/src/assets/js/search.js
+++ b/src/docs/src/assets/js/search.js
@@ -119,12 +119,29 @@ function escapeHtml (text) {
         .replace(/'/g, '&#39;');
 }
 
+// Returns the bare `text=...` portion of a text fragment, without the
+// `#:~:` prefix. The caller composes the full fragment depending on whether
+// an `#anchor` is already present in the URL (combined form: `#anchor:~:text=`
+// vs anchor-less: `#:~:text=`).
 function generateTextFragment (matchedText, prefix = '', suffix = '') {
     const encodedText = encodeURIComponent(matchedText);
     const encodedPrefix = prefix ? `${encodeURIComponent(prefix) }-,` : '';
     const encodedSuffix = suffix ? `,-${ encodeURIComponent(suffix)}` : '';
 
-    return `#:~:text=${encodedPrefix}${encodedText}${encodedSuffix}`;
+    return `text=${encodedPrefix}${encodedText}${encodedSuffix}`;
+}
+
+// Build the final href for a search result, combining the page path with
+// optional section anchor and optional text fragment per the WICG spec.
+function buildResultUrl (result) {
+    let url = `${result.path}/`;
+    if ( result.anchor ) url += `#${result.anchor}`;
+    if ( result.textFragment ) {
+        url += result.anchor
+            ? `:~:${result.textFragment}`
+            : `#:~:${result.textFragment}`;
+    }
+    return url;
 }
 
 function performSearch (query) {
@@ -147,7 +164,9 @@ function performSearch (query) {
 
             titleResults.push({
                 title: highlightedTitle,
+                pageTitle: item.pageTitle,
                 path: item.path,
+                anchor: item.anchor,
                 text: escapeHtml(item.text.substring(0, 60) + (item.text.length > 60 ? '...' : '')),
                 textFragment: '',
             });
@@ -226,7 +245,9 @@ function performSearch (query) {
 
             textResults.push({
                 title: item.title,
+                pageTitle: item.pageTitle,
                 path: item.path,
+                anchor: item.anchor,
                 text: highlightedChunk,
                 textFragment: textFragment,
             });
@@ -248,11 +269,20 @@ function updateSearchResults (results) {
 
     let html = '';
     results.slice(0, 15).forEach((result, index) => {
-        const url = `${result.path }/${ result.textFragment || ''}`;
+        const url = buildResultUrl(result);
+        // For section entries, show "Page Title › Section Heading" inline. For
+        // intro entries (no anchor), the result IS the page, so just the title.
+        // `result.title` may already contain <mark> from title-match highlighting,
+        // so it's not escaped here; pageTitle is plain text and must be escaped.
+        const titleHtml = result.anchor && result.pageTitle
+            ? `<span class="search-result-title-page">${escapeHtml(result.pageTitle)}</span>`
+                + '<span class="search-result-sep">›</span>'
+                + result.title
+            : result.title;
         html += `
             <div class="search-result" data-index="${index}">
                 <a href="${url}" class="search-result-link skip-insta-load">
-                    <div class="search-result-title">${result.title}</div>
+                    <div class="search-result-title">${titleHtml}</div>
                     <div class="search-result-text">${result.text}</div>
                 </a>
             </div>


### PR DESCRIPTION
fixes #2362 

- use subheading section match instead of entire page match
- update UI to show if inside subheading
- use minisearch for fuzzy
- update from building manual search index to using minisearch index 

notes:
- there's some specific logic for the minisearch tokenizer
- and this is mostly based on vibes, to for user to search easier, like "aichat"
- basically improving on top of what minisearch fuzzy provides
- also with this subheading match, we are also improving our text fragment matching success rate