### PR TITLE
fix(docs/search): handle search index loading and failure states

### DIFF
--- a/src/docs/src/assets/js/search.js
+++ b/src/docs/src/assets/js/search.js
@@ -5,6 +5,15 @@ let miniSearch = null;
 let searchTimeout = null;
 let selectedSearchResult = -1;
 
+// Last query the user typed while the index was still loading; replayed by
+// fetchSearchIndex() once the index becomes available so the user doesn't
+// have to retype. Cleared on success, failure, or when the query falls
+// below the minimum length.
+let pendingQuery = null;
+// True after fetchSearchIndex() has thrown at least once; lets performSearch
+// distinguish "still loading" from "load failed" without waiting forever.
+let indexLoadFailed = false;
+
 // Query-time tokenizer. Splits on whitespace AND punctuation only — does
 // NOT emit the joined-without-punctuation form. The index (built in
 // build.js's indexTokenize) already pre-baked the joined variants, so
@@ -119,11 +128,9 @@ $(document).ready(function () {
             clearTimeout(searchTimeout);
         }
 
-        // Set new timeout for debouncing
-        searchTimeout = setTimeout(async () => {
-            if ( !miniSearch ) {
-                await fetchSearchIndex();
-            }
+        // Set new timeout for debouncing. performSearch handles the
+        // not-yet-loaded case itself, so the input handler stays sync.
+        searchTimeout = setTimeout(() => {
             performSearch(query);
         }, 300);
     });
@@ -133,14 +140,27 @@ $(document).ready(function () {
 });
 
 async function fetchSearchIndex () {
+    indexLoadFailed = false;
     try {
         const response = await fetch('/index.json');
         const text = await response.text();
         miniSearch = MiniSearch.loadJSON(text, MINISEARCH_CONFIG);
         console.log('Search index loaded:', `${miniSearch.documentCount } items`);
+        // Replay the query the user typed while we were still loading.
+        if ( pendingQuery !== null ) {
+            const q = pendingQuery;
+            pendingQuery = null;
+            performSearch(q);
+        }
     } catch ( error ) {
         console.error('Failed to load search index:', error);
         miniSearch = null;
+        indexLoadFailed = true;
+        if ( pendingQuery !== null ) {
+            pendingQuery = null;
+            $('.search-results').html(
+                            '<div class="search-no-results">Failed to load search index. Please refresh.</div>');
+        }
     }
 }
 function escapeHtml (text) {
@@ -179,14 +199,25 @@ function buildResultUrl (result) {
 
 function performSearch (query) {
     if ( !query || query.length < 2 ) {
+        // Drop any pending replay so the user isn't surprised by a stale
+        // search firing after they cleared the input.
+        pendingQuery = null;
         $('.search-results').html(
                         '<div class="search-no-results">Start typing to search...</div>');
         return;
     }
 
     if ( !miniSearch ) {
-        // Index hasn't finished loading yet; show empty state.
-        updateSearchResults([]);
+        if ( indexLoadFailed ) {
+            $('.search-results').html(
+                            '<div class="search-no-results">Failed to load search index. Please refresh.</div>');
+            return;
+        }
+        // Index still loading; remember the query so fetchSearchIndex
+        // can replay it on success.
+        pendingQuery = query;
+        $('.search-results').html(
+                        '<div class="search-no-results">Loading search index...</div>');
         return;
     }
 

--- a/src/docs/src/assets/js/search.js
+++ b/src/docs/src/assets/js/search.js
@@ -128,6 +128,13 @@ $(document).ready(function () {
             clearTimeout(searchTimeout);
         }
 
+        // Synchronously drop any pending replay when the input is too
+        // short, so a late index load can't resurrect stale results
+        // after the user clears the field within the debounce window.
+        if ( !query || query.length < 2 ) {
+            pendingQuery = null;
+        }
+
         // Set new timeout for debouncing. performSearch handles the
         // not-yet-loaded case itself, so the input handler stays sync.
         searchTimeout = setTimeout(() => {
@@ -158,8 +165,7 @@ async function fetchSearchIndex () {
         indexLoadFailed = true;
         if ( pendingQuery !== null ) {
             pendingQuery = null;
-            $('.search-results').html(
-                            '<div class="search-no-results">Failed to load search index. Please refresh.</div>');
+            renderSearchStatus('failed');
         }
     }
 }
@@ -197,27 +203,37 @@ function buildResultUrl (result) {
     return url;
 }
 
+// Single source of truth for the empty-state UI so the idle / loading /
+// failed copy can only drift in one place.
+function renderSearchStatus (kind) {
+    const messages = {
+        idle: 'Start typing to search...',
+        loading: 'Loading search index...',
+        failed: 'Failed to load search index. Please refresh.',
+    };
+    $('.search-results').html(
+        `<div class="search-no-results">${messages[kind]}</div>`
+    );
+}
+
 function performSearch (query) {
     if ( !query || query.length < 2 ) {
         // Drop any pending replay so the user isn't surprised by a stale
         // search firing after they cleared the input.
         pendingQuery = null;
-        $('.search-results').html(
-                        '<div class="search-no-results">Start typing to search...</div>');
+        renderSearchStatus('idle');
         return;
     }
 
     if ( !miniSearch ) {
         if ( indexLoadFailed ) {
-            $('.search-results').html(
-                            '<div class="search-no-results">Failed to load search index. Please refresh.</div>');
+            renderSearchStatus('failed');
             return;
         }
         // Index still loading; remember the query so fetchSearchIndex
         // can replay it on success.
         pendingQuery = query;
-        $('.search-results').html(
-                        '<div class="search-no-results">Loading search index...</div>');
+        renderSearchStatus('loading');
         return;
     }
 


### PR DESCRIPTION
## Summary
- Replaces the misleading "No results found" empty state shown when users searched before the MiniSearch index finished loading. The search now shows "Loading search index..." and replays the query automatically once the index is ready.
- Renders a distinct "Failed to load search index. Please refresh." message on fetch error so the loading state does not persist indefinitely.

Fixes #3180.

## Open question for review
The failure-state message is not in the issue description but is a necessary consequence of the loading-state change. Without it, a failed `fetchSearchIndex` would leave "Loading..." showing forever. Open to dropping or rephrasing if a different approach is preferred.

The pre-existing `openSearchUI()` call to `updateSearchResults([])` (which renders "No results found" on open before any typing) is out of scope and untouched.

## Test plan
`src/docs/src/assets/js/search.js` has no existing unit tests, so this change is verified manually. Built and served locally (`npm run build && npm run serve` in `src/docs`):
- [x] Normal speed: search results render as before, no flash of loading state.
- [x] 3G throttle, type before `/index.json` loads: "Loading search index..." appears, results auto-render when the index lands without retyping.
- [x] `/index.json` returning 404: brief "Loading..." then "Failed to load search index. Please refresh."
- [x] 3G throttle, type then backspace to empty input before the index loads: pending query is cleared, no stale results fire when the index arrives.