### PR TITLE
fix: remove unnecessary cache console.log statements 

### DIFF
--- a/src/puter-js/src/modules/FileSystem/index.js
+++ b/src/puter-js/src/modules/FileSystem/index.js
@@ -133,32 +133,26 @@ export class PuterJSFileSystemModule {
 
         this.socket.on('item.renamed', (item) => {
             puter._cache.flushall();
-            console.log('Flushed cache for item.renamed');
         });
 
         this.socket.on('item.removed', (item) => {
             // check original_client_socket_id and if it matches this.socket.id, don't invalidate cache
             puter._cache.flushall();
-            console.log('Flushed cache for item.removed');
         });
 
         this.socket.on('item.added', (item) => {
             // remove readdir cache for parent
             puter._cache.del(`readdir:${ path.dirname(item.path)}`);
-            console.log(`deleted cache for readdir:${ path.dirname(item.path)}`);
             // remove item cache for parent directory
             puter._cache.del(`item:${ path.dirname(item.path)}`);
-            console.log(`deleted cache for item:${ path.dirname(item.path)}`);
         });
 
         this.socket.on('item.updated', (item) => {
             puter._cache.flushall();
-            console.log('Flushed cache for item.updated');
         });
 
         this.socket.on('item.moved', (item) => {
             puter._cache.flushall();
-            console.log('Flushed cache for item.moved');
         });
 
         this.socket.on('connect', () => {
@@ -295,7 +289,6 @@ export class PuterJSFileSystemModule {
             const localValidTs = parseInt(localStorage.getItem(LAST_VALID_TS)) || 0;
 
             if ( serverTimestamp - localValidTs > 2000 ) {
-                console.log('Cache is not up to date, purging cache');
                 // Server has newer data, purge local cache
                 puter._cache.flushall();
                 localStorage.setItem(LAST_VALID_TS, '0');


### PR DESCRIPTION
# What kind of change does this PR introduce?
Bug fix / Cleanup

# Why was this change needed?
Fixes #3200

Hey team! 👋 This is one of my early open source PRs, so please bear with me! 🙏

Unnecessary `console.log` statements were left in 
`src/puter-js/src/modules/FileSystem/index.js` after cache-related 
socket events. These logs were showing up in CLI tools and polluting 
the console output for users.

Removed the following plain console logs:
- "Flushed cache for item.renamed"
- "Flushed cache for item.removed"  
- "deleted cache for readdir:..."
- "deleted cache for item:..."
- "Flushed cache for item.updated"
- "Flushed cache for item.moved"
- "Cache is not up to date, purging cache"

Note: The `debugMode`-gated logs were intentionally kept as they are 
useful for developers during debugging.

# How was this tested?
Visually verified that the console no longer outputs cache-related 
logs during normal file system operations. The `debugMode` logs remain 
unaffected and work as expected.

# Other information:
Small cleanup PR — no logic was changed, only console.log 
statements removed as requested in issue #3200.