### PR TITLE
skip github actions backend for docs only changes

### DIFF
--- a/.github/workflows/backend-tests.yaml
+++ b/.github/workflows/backend-tests.yaml
@@ -3,6 +3,8 @@ name: Backend Tests
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    paths-ignore:
+      - 'src/docs/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
Closes #3224

This PR adds `paths-ignore` to the `backend-tests.yaml` workflow. This ensures that the backend test suite isn't unnecessarily triggered when a PR only modifies files inside the `src/docs/` directory.