### PR TITLE
Add Claude Fable 5 model support with adaptive thinking

### DIFF
--- a/src/backend/drivers/ai-chat/providers/claude/ClaudeProvider.ts
+++ b/src/backend/drivers/ai-chat/providers/claude/ClaudeProvider.ts
@@ -229,9 +229,10 @@ export class ClaudeProvider implements IChatProvider {
             reasoningEffort: requestedReasoningEffort,
             maxTokens: max_tokens,
         });
-        // Opus 4.7 and 4.8 error on non-default sampling params; omit temperature entirely.
+        // Fable 5 and Opus 4.7/4.8 error on non-default sampling params; omit temperature entirely.
         // Other models require temperature=1 when thinking is enabled.
         const omitsTemperature = [
+            'claude-fable-5',
             'claude-opus-4-7',
             'claude-opus-4-8',
         ].includes(modelUsed.id);
@@ -241,6 +242,8 @@ export class ClaudeProvider implements IChatProvider {
               ? 1
               : (temperature ?? 0);
         const supportsEffort = [
+            'claude-fable-5',
+            'claude-opus-4-8',
             'claude-opus-4-7',
             'claude-opus-4-6',
             'claude-sonnet-4-6',
@@ -489,11 +492,16 @@ export class ClaudeProvider implements IChatProvider {
     }) {
         if (!reasoningEffort) return undefined;
 
-        // Opus 4.7, 4.6, and Sonnet 4.6 use adaptive thinking
-        // (`budget_tokens` is deprecated on 4.6/Sonnet 4.6, removed on 4.7).
-        // Opus 4.7 omits thinking content by default; `display: 'summarized'`
-        // restores visible reasoning in the stream.
-        if (modelId === 'claude-opus-4-7') {
+        // Fable 5, Opus 4.7/4.8, 4.6, and Sonnet 4.6 use adaptive thinking
+        // (`budget_tokens` is deprecated on 4.6/Sonnet 4.6, removed on
+        // Fable 5 and 4.7+). Fable 5 and Opus 4.7/4.8 omit thinking content
+        // by default; `display: 'summarized'` restores visible reasoning in
+        // the stream.
+        if (
+            modelId === 'claude-fable-5' ||
+            modelId === 'claude-opus-4-8' ||
+            modelId === 'claude-opus-4-7'
+        ) {
             return {
                 type: 'adaptive' as const,
                 display: 'summarized' as const,

--- a/src/backend/drivers/ai-chat/providers/claude/models.ts
+++ b/src/backend/drivers/ai-chat/providers/claude/models.ts
@@ -22,6 +22,35 @@ import type { IChatModel } from '../../types.js';
 // Hardcoded from https://models.dev/api.json
 export const CLAUDE_MODELS: IChatModel[] = [
     {
+        puterId: 'anthropic:anthropic/claude-fable-5',
+        id: 'claude-fable-5',
+        modalities: { input: ['text', 'image', 'pdf'], output: ['text'] },
+        open_weights: false,
+        tool_call: true,
+        release_date: '2026-06-09',
+        aliases: [
+            'claude-fable',
+            'claude-fable-latest',
+            'claude-fable-5-latest',
+            'claude-fable-5',
+            'anthropic/claude-fable-5',
+        ],
+        name: 'Claude Fable 5',
+        costs_currency: 'usd-cents',
+        input_cost_key: 'input_tokens',
+        output_cost_key: 'output_tokens',
+        costs: {
+            tokens: 1_000_000,
+            input_tokens: 1000,
+            ephemeral_5m_input_tokens: 1000 * 1.25,
+            ephemeral_1h_input_tokens: 1000 * 2,
+            cache_read_input_tokens: 1000 * 0.1,
+            output_tokens: 5000,
+        },
+        context: 1000000,
+        max_tokens: 128000,
+    },
+    {
         puterId: 'anthropic:anthropic/claude-opus-4-8',
         id: 'claude-opus-4-8',
         modalities: { input: ['text', 'image', 'pdf'], output: ['text'] },


### PR DESCRIPTION
## Summary
This PR adds support for the Claude Fable 5 model to the Claude provider, including proper configuration for its capabilities and adaptive thinking support.

## Key Changes
- **New Model Definition**: Added `claude-fable-5` to the CLAUDE_MODELS list with:
  - Support for text, image, and PDF inputs
  - Tool calling capabilities
  - Pricing configuration with cache and ephemeral token rates
  - 1M context window and 128K max output tokens
  - Multiple aliases for model identification

- **Temperature Handling**: Updated the temperature omission logic to include `claude-fable-5` alongside Opus 4.7/4.8, as these models error on non-default sampling parameters when thinking is enabled

- **Adaptive Thinking Support**: Extended adaptive thinking configuration to include `claude-fable-5` and `claude-opus-4-8`, with `display: 'summarized'` to restore visible reasoning in the stream

- **Effort Parameter Support**: Added `claude-fable-5` and `claude-opus-4-8` to the list of models that support the `reasoningEffort` parameter

## Implementation Details
The changes follow the existing pattern for newer Claude models that support extended thinking capabilities. Fable 5 is treated similarly to Opus 4.7/4.8 in terms of API parameter handling, indicating it shares the same advanced reasoning features and sampling parameter constraints.

https://claude.ai/code/session_01NhoV7PdEjYbYMxv4fyKwJw