### PR TITLE
fix: correct puter container healthcheck URL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -264,7 +264,7 @@ services:
       # Persistent runtime data (anything your config points at /var/puter).
       - ./puter/data/puter:/var/puter:z
     healthcheck:
-      test: wget --no-verbose --tries=1 --spider http://puter.localhost:4100/test || exit 1
+      test: wget --no-verbose --tries=1 --spider http://localhost:4100/ || exit 1
       interval: 30s
       timeout: 3s
       retries: 3


### PR DESCRIPTION
## Problem

The puter container healthcheck in `docker-compose.yml` was using `http://puter.localhost:4100/test`, which causes the container to be perpetually marked as **unhealthy**.

Two issues:
1. **`puter.localhost` does not resolve inside the container** — the service listens on `0.0.0.0:4100`, so `localhost` is the correct hostname from within the container.
2. **`/test` endpoint does not exist** — there is no `/test` route in the backend. The root path `/` serves the shell and can be used to verify the service is responding.

## Fix

Changed the healthcheck URL from:
```
http://puter.localhost:4100/test
```
to:
```
http://localhost:4100/
```

## Testing

Verified that:
- The backend serves the shell at `/` (`HomepageController.ts:77`)
- No `/test` route exists anywhere in the backend codebase
- `config.default.json` confirms the service runs on port 4100

Fixes #3191