### PR TITLE
fix(docs): highlight code blocks after client-side navigation (#3287)

### DIFF
--- a/src/docs/src/assets/js/example.js
+++ b/src/docs/src/assets/js/example.js
@@ -79,13 +79,15 @@ $(document).on('pathchange', function (e) {
     // uses on full page load — selecting only `code[class^="language"]` skips
     // fenced blocks written without a language tag, so they stayed unhighlighted
     // after client-side navigation while showing up correctly on a hard reload.
-    $('pre code').each(function () {
+    // Scope to `.docs-content` so we only re-highlight the swapped-in docs body
+    // and leave code blocks elsewhere on the page untouched.
+    hljs.configure({ ignoreUnescapedHTML: true });
+    $('.docs-content pre code').each(function () {
         // Skip blocks hljs has already processed so repeated pathchanges don't
         // log "Element previously highlighted" and re-run on unchanged nodes.
         if ( $(this).attr('data-highlighted') === 'yes' ) return;
 
         try {
-            hljs.configure({ ignoreUnescapedHTML: true });
             hljs.highlightElement(this);
         } catch (e) {
             console.error('Error: Failed to highlight.', e);

--- a/src/docs/src/assets/js/example.js
+++ b/src/docs/src/assets/js/example.js
@@ -75,21 +75,20 @@ $(document).on('pathchange', function (e) {
         $(this).find('.icon').html(icons[$(this).data('icon-active')]);
     });
 
-    // highlight code
-    $('code[class^=\'language\']').each(function () {
-        var $this = $(this);
-        if ( $this.attr('data-highlighted') === 'yes' ) {
-            // Remove the attribute or set it to 'no'
-            $this.removeAttr('data-highlighted');
-        }
-        // Now you can re-highlight
-        else {
-            try {
-                hljs.configure({ ignoreUnescapedHTML: true });
-                hljs.highlightElement(this);
-            } catch (e) {
-                console.error('Error: Failed to highlight.', e);
-            }
+    // Highlight code. Match the same `pre code` selector hljs.highlightAll()
+    // uses on full page load — selecting only `code[class^="language"]` skips
+    // fenced blocks written without a language tag, so they stayed unhighlighted
+    // after client-side navigation while showing up correctly on a hard reload.
+    $('pre code').each(function () {
+        // Skip blocks hljs has already processed so repeated pathchanges don't
+        // log "Element previously highlighted" and re-run on unchanged nodes.
+        if ( $(this).attr('data-highlighted') === 'yes' ) return;
+
+        try {
+            hljs.configure({ ignoreUnescapedHTML: true });
+            hljs.highlightElement(this);
+        } catch (e) {
+            console.error('Error: Failed to highlight.', e);
         }
     });
 });


### PR DESCRIPTION
## Summary

Fixes #3287 — code highlighting is missing on the docs site after client-side navigation (e.g. clicking **Deployments** in the sidebar). The code only gets styled after a hard refresh.

## Root cause

The docs use two different code paths to run highlight.js, and they target **different selectors**:

- **Full page load** runs an inline `hljs.highlightAll()` (injected in `build.js`). `highlightAll()` uses highlight.js's default `pre code` selector, so it highlights **every** fenced block — including blocks written without a language tag.
- **Client-side navigation** swaps `.docs-content` and fires a `pathchange` event. The `pathchange` handler in `example.js` highlighted only `code[class^="language"]`.

Markdown fenced blocks without a language hint render as bare `<pre><code>` (no `language-*` class), so they matched on full load but were skipped after in-app navigation — exactly the symptom in the issue.

On the **Deployments** page there are 3 `pre code` blocks but only 1 carries a `language-` class, so 2 of 3 blocks stayed unstyled after client-side nav.

## Fix

Align the `pathchange` handler with `highlightAll()` by selecting `pre code`, and skip blocks highlight.js has already processed (`data-highlighted="yes"`) so repeated `pathchange` events stay idempotent and don't log highlight.js's "Element previously highlighted" warning.

```diff
-    // highlight code
-    $('code[class^=\'language\']').each(function () {
-        var $this = $(this);
-        if ( $this.attr('data-highlighted') === 'yes' ) {
-            $this.removeAttr('data-highlighted');
-        }
-        else {
-            try {
-                hljs.configure({ ignoreUnescapedHTML: true });
-                hljs.highlightElement(this);
-            } catch (e) { console.error('Error: Failed to highlight.', e); }
-        }
-    });
+    $('pre code').each(function () {
+        if ( $(this).attr('data-highlighted') === 'yes' ) return;
+        try {
+            hljs.configure({ ignoreUnescapedHTML: true });
+            hljs.highlightElement(this);
+        } catch (e) { console.error('Error: Failed to highlight.', e); }
+    });
```

## Testing

- `npm run build` in `src/docs` succeeds.
- Reproduced the bug and verified the fix with a jsdom harness driving the built bundle: starting from a code-free page and simulating a `pathchange` navigation to the Deployments page, highlighted `pre code` blocks went from **0 → 3 of 3**. Pre-fix the same flow highlighted only **1 of 3**.
- Confirmed the pass is idempotent — triggering `pathchange` again leaves all 3 blocks highlighted with no re-processing.

Scoped to a single docs file; no behavior change for blocks that already carried a language class.