### PR TITLE
tweak context menu's text labels

### DIFF
--- a/src/gui/src/css/style.css
+++ b/src/gui/src/css/style.css
@@ -1710,13 +1710,17 @@ span.header-sort-icon img {
 }
 
 .submenu-arrow {
-    width: 15px;
-    height: 15px;
+    width: 10px;
+    height: 10px;
     float: right;
 }
 
 .submenu-arrow-active {
     display: none;
+}
+
+.context-menu-item .contextmenu-label {
+    height: 12px;
 }
 
 .context-menu-item-active .submenu-arrow {


### PR DESCRIPTION
Text label and submenu arrow needed some love.

Text label wasn't exactly in the middle and that submenu arrow was too big.