### PR TITLE
fix: unlink all OIDC providers when user updates email address

### DIFF
--- a/src/backend/controllers/auth/AuthController.ts
+++ b/src/backend/controllers/auth/AuthController.ts
@@ -2038,6 +2038,8 @@ export class AuthController extends PuterController {
             requires_email_confirmation: 0,
         });
 
+        await this.stores.oidc.unlinkAllByUserId(user.id);
+
         try {
             this.clients.event?.emit(
                 'user.email-changed' as never,

--- a/src/backend/stores/oidc/OIDCStore.js
+++ b/src/backend/stores/oidc/OIDCStore.js
@@ -87,4 +87,11 @@ export class OIDCStore extends PuterStore {
             [userId, provider],
         );
     }
+
+    async unlinkAllByUserId(userId) {
+        await this.clients.db.write(
+            'DELETE FROM `user_oidc_providers` WHERE `user_id` = ?',
+            [userId],
+        );
+    }
 }


### PR DESCRIPTION
Hey folks,

took a quick peek under the hood to patch that SSO backdoor we talked about. Since updating the primary email was leaving the old OIDC credentials hardwired to the user record i wired up a quick manual override on the database layer to cleanly sever the connection.

I've added a call to decouple all OIDC providers upon an email update
`await this.stores.oidc.unlinkAllByUserId(user.id);`

And implemented the corresponding query in the store to purge those old bindings from the table
```
async unlinkAllByUserId(userId: string): Promise<void> {
    await this.clients.db.write(
        'DELETE FROM `user_oidc_providers` WHERE `user_id` = ?',
        [userId],
    );
}
```

This properly cuts the cord on those old SSO keys and locks them out. Let me know if you need any calibration on this patch