### PR TITLE
feat: add Ideogram 4.0 Together AI image model

### DIFF
--- a/src/backend/drivers/ai-image/providers/together/models.ts
+++ b/src/backend/drivers/ai-image/providers/together/models.ts
@@ -489,6 +489,16 @@ export const TOGETHER_IMAGE_GENERATION_MODELS: IImageModel[] = [
         costs: { '1MP': 6 },
     },
     {
+        id: 'togetherai:ideogram/ideogram-4.0',
+        aliases: ['ideogram/ideogram-4.0', 'ideogram-4.0'],
+        costs_currency: 'usd-cents',
+        index_cost_key: '1MP',
+        name: 'ideogram/ideogram-4.0',
+        allowedQualityLevels: [''],
+        pricing_unit: 'per-MP',
+        costs: { '1MP': 6 },
+    },
+    {
         id: 'togetherai:openai/gpt-image-1.5',
         aliases: ['openai/gpt-image-1.5', 'gpt-image-1.5'],
         costs_currency: 'usd-cents',


### PR DESCRIPTION
Adds Ideogram 4.0 to the Together AI image provider. 

Closes #3283 

The entry follows the existing ideogram-3.0 model in together/models.ts. Together
lists 4.0 at $0.06, the same as 3.0, so I kept the 1MP: 6 cost. Left it as per-MP
to stay consistent with the 3.0 entry, but can switch to per-image if that's preferred.
