### PR TITLE
Add custom icon support for web links

### DIFF
--- a/src/gui/src/UI/UIItem.js
+++ b/src/gui/src/UI/UIItem.js
@@ -30,6 +30,7 @@ import truncate_filename from '../helpers/truncate_filename.js';
 import launch_app from '../helpers/launch_app.js';
 import open_item from '../helpers/open_item.js';
 import mime from '../lib/mime.js';
+import { changeWeblinkIcon } from '../helpers/weblink.js';
 
 const AI_APP_NAME = 'ai';
 
@@ -1143,6 +1144,7 @@ async function UIItem (options) {
         // -------------------------------------------------------
         else {
             const is_trash = $(el_item).attr('data-path') === window.trash_path || $(el_item).attr('data-shortcut_to_path') === window.trash_path;
+            const is_weblink = $(el_item).attr('data-name')?.toLowerCase().endsWith('.weblink');
             menu_items = [];
             // -------------------------------------------
             // Open
@@ -1566,6 +1568,21 @@ async function UIItem (options) {
                             options.shortcut_to === '' ? options.uid : options.shortcut_to,
                             options.shortcut_to_path === '' ? options.path : options.shortcut_to_path,
                         );
+                    },
+                });
+            }
+            // -------------------------------------------
+            // Change Web Link Icon
+            // -------------------------------------------
+            if ( !is_trashed && !is_trash && is_weblink ) {
+                menu_items.push({
+                    html: 'Change Icon',
+                    onClick: async function () {
+                        try {
+                            await changeWeblinkIcon(el_item);
+                        } catch (error) {
+                            UIAlert(error.message ?? 'Could not change the web link icon.');
+                        }
                     },
                 });
             }

--- a/src/gui/src/UI/UIItem.js
+++ b/src/gui/src/UI/UIItem.js
@@ -30,7 +30,7 @@ import truncate_filename from '../helpers/truncate_filename.js';
 import launch_app from '../helpers/launch_app.js';
 import open_item from '../helpers/open_item.js';
 import mime from '../lib/mime.js';
-import { changeWeblinkIcon } from '../helpers/weblink.js';
+import { isWeblinkName, weblinkChangeIconMenuItem } from '../helpers/weblink.js';
 
 const AI_APP_NAME = 'ai';
 
@@ -1144,7 +1144,8 @@ async function UIItem (options) {
         // -------------------------------------------------------
         else {
             const is_trash = $(el_item).attr('data-path') === window.trash_path || $(el_item).attr('data-shortcut_to_path') === window.trash_path;
-            const is_weblink = $(el_item).attr('data-name')?.toLowerCase().endsWith('.weblink');
+            const is_shortcut = !! $(el_item).attr('data-shortcut_to_path');
+            const is_weblink = isWeblinkName($(el_item).attr('data-name'));
             menu_items = [];
             // -------------------------------------------
             // Open
@@ -1574,17 +1575,8 @@ async function UIItem (options) {
             // -------------------------------------------
             // Change Web Link Icon
             // -------------------------------------------
-            if ( !is_trashed && !is_trash && is_weblink ) {
-                menu_items.push({
-                    html: 'Change Icon',
-                    onClick: async function () {
-                        try {
-                            await changeWeblinkIcon(el_item);
-                        } catch (error) {
-                            UIAlert(error.message ?? 'Could not change the web link icon.');
-                        }
-                    },
-                });
+            if ( !is_trashed && !is_trash && !is_shortcut && is_weblink ) {
+                menu_items.push(weblinkChangeIconMenuItem(el_item));
             }
             // -------------------------------------------
             // Delete

--- a/src/gui/src/UI/UIWindowSearch.js
+++ b/src/gui/src/UI/UIWindowSearch.js
@@ -138,7 +138,7 @@ async function UIWindowSearch (options) {
                         data-is_dir="${html_encode(result.is_dir)}"
                     >`;
                 // icon
-                h += `<img src="${(await item_icon(result)).image}" style="width: 20px; height: 20px; margin-right: 6px;">`;
+                h += `<img src="${html_encode((await item_icon(result)).image)}" style="width: 20px; height: 20px; margin-right: 6px;">`;
                 h += html_encode(result.name);
                 h += '</div>';
             }

--- a/src/gui/src/helpers/generate_file_context_menu.js
+++ b/src/gui/src/helpers/generate_file_context_menu.js
@@ -28,6 +28,7 @@ import open_item from './open_item.js';
 import launch_app from './launch_app.js';
 import path from '../lib/path.js';
 import mime from '../lib/mime.js';
+import { changeWeblinkIcon } from './weblink.js';
 
 const AI_APP_NAME = 'ai';
 
@@ -144,6 +145,8 @@ const generate_file_context_menu = async function (options) {
     const is_trashed = options.is_trashed ?? false;
     const is_worker = options.is_worker ?? false;
     const onOpen = options.onOpen;
+    const is_weblink = fsentry.name?.toLowerCase().endsWith('.weblink') ||
+        $(el_item).attr('data-name')?.toLowerCase().endsWith('.weblink');
 
     let menu_items = [];
 
@@ -518,6 +521,22 @@ const generate_file_context_menu = async function (options) {
                     fsentry.shortcut_to === '' ? fsentry.uid : fsentry.shortcut_to,
                     fsentry.shortcut_to_path === '' ? fsentry.path : fsentry.shortcut_to_path,
                 );
+            },
+        });
+    }
+
+    // -------------------------------------------
+    // Change Web Link Icon
+    // -------------------------------------------
+    if ( !is_trashed && !is_trash && is_weblink ) {
+        menu_items.push({
+            html: 'Change Icon',
+            onClick: async function () {
+                try {
+                    await changeWeblinkIcon(el_item);
+                } catch (error) {
+                    UIAlert(error.message ?? 'Could not change the web link icon.');
+                }
             },
         });
     }

--- a/src/gui/src/helpers/generate_file_context_menu.js
+++ b/src/gui/src/helpers/generate_file_context_menu.js
@@ -28,7 +28,7 @@ import open_item from './open_item.js';
 import launch_app from './launch_app.js';
 import path from '../lib/path.js';
 import mime from '../lib/mime.js';
-import { changeWeblinkIcon } from './weblink.js';
+import { isWeblinkName, weblinkChangeIconMenuItem } from './weblink.js';
 
 const AI_APP_NAME = 'ai';
 
@@ -145,8 +145,8 @@ const generate_file_context_menu = async function (options) {
     const is_trashed = options.is_trashed ?? false;
     const is_worker = options.is_worker ?? false;
     const onOpen = options.onOpen;
-    const is_weblink = fsentry.name?.toLowerCase().endsWith('.weblink') ||
-        $(el_item).attr('data-name')?.toLowerCase().endsWith('.weblink');
+    const is_weblink = isWeblinkName(fsentry.name ?? $(el_item).attr('data-name'));
+    const is_shortcut = fsentry.is_shortcut || !! $(el_item).attr('data-shortcut_to_path');
 
     let menu_items = [];
 
@@ -528,17 +528,8 @@ const generate_file_context_menu = async function (options) {
     // -------------------------------------------
     // Change Web Link Icon
     // -------------------------------------------
-    if ( !is_trashed && !is_trash && is_weblink ) {
-        menu_items.push({
-            html: 'Change Icon',
-            onClick: async function () {
-                try {
-                    await changeWeblinkIcon(el_item);
-                } catch (error) {
-                    UIAlert(error.message ?? 'Could not change the web link icon.');
-                }
-            },
-        });
+    if ( !is_trashed && !is_trash && !is_shortcut && is_weblink ) {
+        menu_items.push(weblinkChangeIconMenuItem(el_item));
     }
 
     // -------------------------------------------

--- a/src/gui/src/helpers/item_icon.js
+++ b/src/gui/src/helpers/item_icon.js
@@ -19,6 +19,7 @@
 
 import mime from '../lib/mime.js';
 import content_type_to_icon from './content_type_to_icon.js';
+import { getWeblinkIcon } from './weblink.js';
 
 /**
  * Assigns an icon to a filesystem entry based on its properties such as name, type,
@@ -240,7 +241,7 @@ const item_icon = async (fsentry) => {
     }
     // *.weblink
     else if ( fsentry.name.toLowerCase().endsWith('.weblink') ) {
-        return { image: window.icons['link.svg'], type: 'icon' };
+        return { image: await getWeblinkIcon(fsentry), type: 'icon' };
     }
     // *.tar
     else if ( fsentry.name.toLowerCase().endsWith('.tar') ) {

--- a/src/gui/src/helpers/new_context_menu_item.js
+++ b/src/gui/src/helpers/new_context_menu_item.js
@@ -19,6 +19,7 @@
 
 import UIPrompt from '../UI/UIPrompt.js';
 import UIAlert from '../UI/UIAlert.js';
+import { createWeblinkData, defaultWeblinkIcon } from './weblink.js';
 
 /**
  * Returns a context menu item to create a new folder and a variety of file types.
@@ -93,20 +94,14 @@ const new_context_menu_item = function (dirname, append_to_element) {
                         let linkName = siteName;
                         let fileName = `${linkName }.weblink`;
 
-                        // Store the URL in a simple JSON object
-                        const weblink_content = JSON.stringify({
+                        const icon = defaultWeblinkIcon();
+                        const weblink_content = JSON.stringify(createWeblinkData({
                             url: url,
-                            type: 'weblink',
                             domain: domain,
-                            created: Date.now(),
-                            modified: Date.now(),
-                            version: '2.0',
-                            metadata: {
-                                originalUrl: url,
-                                linkName: linkName,
-                                simpleName: siteName,
-                            },
-                        });
+                            linkName: linkName,
+                            simpleName: siteName,
+                            icon: icon,
+                        }));
 
                         // Create the file with standard link icon
                         const item = await window.create_file({
@@ -114,17 +109,18 @@ const new_context_menu_item = function (dirname, append_to_element) {
                             append_to_element: append_to_element,
                             name: fileName,
                             content: weblink_content,
-                            icon: window.icons['link.svg'],
+                            icon: icon,
                             type: 'weblink',
                             metadata: JSON.stringify({
                                 url: url,
                                 domain: domain,
+                                icon: icon,
                                 timestamp: Date.now(),
-                                version: '2.0',
+                                version: '2.1',
                             }),
                             html_attributes: {
                                 'data-weblink': 'true',
-                                'data-icon': window.icons['link.svg'],
+                                'data-icon': icon,
                                 'data-url': url,
                                 'data-domain': domain,
                                 'data-display-name': linkName,

--- a/src/gui/src/helpers/new_context_menu_item.js
+++ b/src/gui/src/helpers/new_context_menu_item.js
@@ -114,7 +114,6 @@ const new_context_menu_item = function (dirname, append_to_element) {
                             metadata: JSON.stringify({
                                 url: url,
                                 domain: domain,
-                                icon: icon,
                                 timestamp: Date.now(),
                                 version: '2.1',
                             }),

--- a/src/gui/src/helpers/weblink.js
+++ b/src/gui/src/helpers/weblink.js
@@ -31,9 +31,14 @@ const WEBLINK_ICON_ALLOWLIST = [
     'data:image/svg+xml;base64,',
 ];
 
-// Picked images are rasterized to a small PNG before storing so the icon stays
+// Raster icons are downscaled to a small PNG before storing so the icon stays
 // a few KB rather than embedding a full-resolution photo into the file/DOM.
 const WEBLINK_ICON_MAX_DIMENSION = 256;
+
+// SVG icons are kept as vectors, but capped so a pathological SVG (e.g. one
+// with an embedded base64 raster) can't bloat the file; oversized ones fall
+// back to rasterization.
+const WEBLINK_ICON_MAX_SVG_BYTES = 512 * 1024;
 
 const WEBLINK_VERSION = '2.1';
 
@@ -120,9 +125,22 @@ const readFileAsDataUrl = async (file) => await new Promise((resolve, reject) =>
     reader.readAsDataURL(file);
 });
 
-// Rasterize any browser-decodable image (PNG/JPEG/GIF/WebP/SVG) down to a small
-// PNG data URL. This both bounds the stored size and normalizes the output to a
-// single known-safe type, so no MIME sniffing of the source bytes is needed.
+// Read the first bytes of a blob as text so we can sniff SVG source. Returns ''
+// if the blob doesn't support slicing (nothing is treated as SVG in that case).
+const readHead = async (file) => {
+    if ( !file?.slice || !file?.arrayBuffer ) {
+        return '';
+    }
+    try {
+        return new TextDecoder('utf-8', { fatal: false }).decode(await file.slice(0, 512).arrayBuffer());
+    } catch (e) {
+        return '';
+    }
+};
+
+// Rasterize any browser-decodable image down to a small PNG data URL. Used for
+// raster formats (and as a size-capping fallback for oversized SVGs); it bounds
+// the stored size and yields a single known-safe type.
 const rasterizeToPngDataUrl = async (dataUrl) => await new Promise((resolve, reject) => {
     const img = new Image();
     img.onload = () => {
@@ -149,6 +167,21 @@ const rasterizeToPngDataUrl = async (dataUrl) => await new Promise((resolve, rej
 
 const readIconFromFsEntry = async (fsentry) => {
     const file = await puter.fs.read(fsentry.path);
+    const head = await readHead(file);
+
+    // Keep SVGs as vectors — they stay crisp at any size/DPI and render
+    // script-free in <img>. Rasterize everything else (and oversized SVGs) to a
+    // small PNG so the stored icon stays a few KB.
+    if ( head.toLowerCase().includes('<svg') && file.size <= WEBLINK_ICON_MAX_SVG_BYTES ) {
+        const dataUrl = await readFileAsDataUrl(file);
+        const base64 = dataUrl.slice(dataUrl.indexOf(',') + 1);
+        const svgIcon = `data:image/svg+xml;base64,${base64}`;
+
+        if ( isValidWeblinkIcon(svgIcon) ) {
+            return svgIcon;
+        }
+    }
+
     const icon = await rasterizeToPngDataUrl(await readFileAsDataUrl(file));
 
     if ( !isValidWeblinkIcon(icon) ) {

--- a/src/gui/src/helpers/weblink.js
+++ b/src/gui/src/helpers/weblink.js
@@ -1,23 +1,51 @@
-import UIWindow from '../UI/UIWindow.js';
-import mime from '../lib/mime.js';
+/**
+ * Copyright (C) 2024-present Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 
+import UIWindow from '../UI/UIWindow.js';
+import UIAlert from '../UI/UIAlert.js';
+
+// Icons are stored inline in the .weblink JSON as base64 data URLs. Because a
+// .weblink file can be shared or downloaded, its icon field is untrusted input
+// and is re-validated with isValidWeblinkIcon() every time it is read.
 const WEBLINK_ICON_ALLOWLIST = [
     'data:image/png;base64,',
     'data:image/jpeg;base64,',
-    'data:image/jpg;base64,',
     'data:image/gif;base64,',
     'data:image/webp;base64,',
     'data:image/svg+xml;base64,',
 ];
-const WEBLINK_ICON_MIME_ALLOWLIST = [
-    'image/png',
-    'image/jpeg',
-    'image/gif',
-    'image/webp',
-    'image/svg+xml',
-];
+
+// Picked images are rasterized to a small PNG before storing so the icon stays
+// a few KB rather than embedding a full-resolution photo into the file/DOM.
+const WEBLINK_ICON_MAX_DIMENSION = 256;
+
+const WEBLINK_VERSION = '2.1';
+
+// Cache the resolved icon per file so a folder full of weblinks doesn't fetch
+// every file's contents on each render/refresh. Keyed by path; entries are
+// refreshed when changeWeblinkIcon writes a new icon.
+const weblinkIconCache = new Map();
 
 export const defaultWeblinkIcon = () => window.icons['link.svg'];
+
+export const isWeblinkName = (name) =>
+    typeof name === 'string' && name.toLowerCase().endsWith('.weblink');
 
 export const isValidWeblinkIcon = (icon) => {
     if ( typeof icon !== 'string' || icon.length === 0 ) {
@@ -28,7 +56,17 @@ export const isValidWeblinkIcon = (icon) => {
         return true;
     }
 
-    return WEBLINK_ICON_ALLOWLIST.some(prefix => icon.toLowerCase().startsWith(prefix));
+    const lower = icon.toLowerCase();
+    const prefix = WEBLINK_ICON_ALLOWLIST.find(p => lower.startsWith(p));
+    if ( !prefix ) {
+        return false;
+    }
+
+    // The body must be pure base64. This rejects anything containing a quote,
+    // space or angle bracket, which is what stops a crafted icon value from
+    // breaking out of an `<img src="...">` attribute (DOM XSS).
+    const body = icon.slice(prefix.length);
+    return body.length > 0 && /^[a-z0-9+/]+={0,2}$/i.test(body);
 };
 
 export const createWeblinkData = ({ url, domain, linkName, simpleName, icon = defaultWeblinkIcon() }) => ({
@@ -38,7 +76,7 @@ export const createWeblinkData = ({ url, domain, linkName, simpleName, icon = de
     icon: isValidWeblinkIcon(icon) ? icon : defaultWeblinkIcon(),
     created: Date.now(),
     modified: Date.now(),
-    version: '2.1',
+    version: WEBLINK_VERSION,
     metadata: {
         originalUrl: url,
         linkName: linkName,
@@ -82,87 +120,36 @@ const readFileAsDataUrl = async (file) => await new Promise((resolve, reject) =>
     reader.readAsDataURL(file);
 });
 
-const inferImageMimeFromBlob = async (file) => {
-    if ( !file?.slice || !file?.arrayBuffer ) {
-        return null;
-    }
+// Rasterize any browser-decodable image (PNG/JPEG/GIF/WebP/SVG) down to a small
+// PNG data URL. This both bounds the stored size and normalizes the output to a
+// single known-safe type, so no MIME sniffing of the source bytes is needed.
+const rasterizeToPngDataUrl = async (dataUrl) => await new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => {
+        try {
+            const srcW = img.naturalWidth || img.width || WEBLINK_ICON_MAX_DIMENSION;
+            const srcH = img.naturalHeight || img.height || WEBLINK_ICON_MAX_DIMENSION;
+            const scale = Math.min(1, WEBLINK_ICON_MAX_DIMENSION / Math.max(srcW, srcH));
+            const w = Math.max(1, Math.round(srcW * scale));
+            const h = Math.max(1, Math.round(srcH * scale));
 
-    const bytes = new Uint8Array(await file.slice(0, 512).arrayBuffer());
+            const canvas = document.createElement('canvas');
+            canvas.width = w;
+            canvas.height = h;
+            canvas.getContext('2d').drawImage(img, 0, 0, w, h);
 
-    if (
-        bytes[0] === 0x89 &&
-        bytes[1] === 0x50 &&
-        bytes[2] === 0x4E &&
-        bytes[3] === 0x47
-    ) {
-        return 'image/png';
-    }
-
-    if ( bytes[0] === 0xFF && bytes[1] === 0xD8 && bytes[2] === 0xFF ) {
-        return 'image/jpeg';
-    }
-
-    if (
-        bytes[0] === 0x47 &&
-        bytes[1] === 0x49 &&
-        bytes[2] === 0x46
-    ) {
-        return 'image/gif';
-    }
-
-    if (
-        bytes[0] === 0x52 &&
-        bytes[1] === 0x49 &&
-        bytes[2] === 0x46 &&
-        bytes[3] === 0x46 &&
-        bytes[8] === 0x57 &&
-        bytes[9] === 0x45 &&
-        bytes[10] === 0x42 &&
-        bytes[11] === 0x50
-    ) {
-        return 'image/webp';
-    }
-
-    const text = new TextDecoder('utf-8', { fatal: false }).decode(bytes).trimStart();
-    if ( text.startsWith('<svg') || text.startsWith('<?xml') && text.includes('<svg') ) {
-        return 'image/svg+xml';
-    }
-
-    return null;
-};
-
-const normalizeImageDataUrl = async (dataUrl, fsentry, file) => {
-    if ( typeof dataUrl !== 'string' ) {
-        return dataUrl;
-    }
-
-    if ( isValidWeblinkIcon(dataUrl) ) {
-        return dataUrl;
-    }
-
-    const inferredMime = [
-        fsentry.type,
-        file?.type,
-        mime.getType(fsentry.name ?? fsentry.path ?? ''),
-    ]
-        .map(type => type?.toLowerCase())
-        .find(type => WEBLINK_ICON_MIME_ALLOWLIST.includes(type)) ??
-        await inferImageMimeFromBlob(file);
-
-    if ( !WEBLINK_ICON_MIME_ALLOWLIST.includes(inferredMime) ) {
-        return dataUrl;
-    }
-
-    return dataUrl.replace(/^data:[^,]*,/i, `data:${inferredMime};base64,`);
-};
+            resolve(canvas.toDataURL('image/png'));
+        } catch (e) {
+            reject(e);
+        }
+    };
+    img.onerror = () => reject(new Error('Please choose a PNG, JPG, GIF, WebP, or SVG image.'));
+    img.src = dataUrl;
+});
 
 const readIconFromFsEntry = async (fsentry) => {
     const file = await puter.fs.read(fsentry.path);
-    const icon = await normalizeImageDataUrl(
-        await readFileAsDataUrl(file),
-        fsentry,
-        file,
-    );
+    const icon = await rasterizeToPngDataUrl(await readFileAsDataUrl(file));
 
     if ( !isValidWeblinkIcon(icon) ) {
         throw new Error('Please choose a PNG, JPG, GIF, WebP, or SVG image.');
@@ -171,58 +158,70 @@ const readIconFromFsEntry = async (fsentry) => {
     return icon;
 };
 
-const centerDialog = (elDialog, elItem) => {
-    const $dialog = $(elDialog);
-    const $parentWindow = $(elItem).closest('.window');
-    const parentOffset = $parentWindow.length ? $parentWindow.offset() : null;
-    const parentWidth = $parentWindow.length ? $parentWindow.outerWidth() : window.innerWidth;
-    const parentHeight = $parentWindow.length ? $parentWindow.outerHeight() : window.innerHeight;
-    const parentLeft = parentOffset?.left ?? 0;
-    const parentTop = parentOffset?.top ?? 0;
-    const left = parentLeft + parentWidth / 2 - $dialog.outerWidth() / 2;
-    const top = parentTop + parentHeight / 2 - $dialog.outerHeight() / 2;
-
-    $dialog.css({
-        left: `${Math.max(0, left) }px`,
-        top: `${Math.max(window.toolbar_height ?? 0, top) }px`,
-    });
-};
-
+// Opens Puter's built-in file picker and resolves with a validated icon data
+// URL, or null if the user dismisses the dialog. The picker is parented to the
+// item's own window (or a lightweight receiver on the Desktop) and always tears
+// down via on_close, so no promise or DOM node is ever leaked on cancel.
 export const chooseWeblinkIcon = async (elItem) => await new Promise((resolve, reject) => {
-    const receiverUuid = `weblink-icon-picker-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-    const $receiver = $('<div>')
-        .addClass('window')
-        .attr('data-element_uuid', receiverUuid)
-        .css('display', 'none')
-        .appendTo('body');
+    const $parentWindow = $(elItem).closest('.window');
+    const hasParentWindow = $parentWindow.length > 0;
+
+    let $receiver;
+    let parentUuid;
+    if ( hasParentWindow ) {
+        $receiver = $parentWindow;
+        parentUuid = $parentWindow.attr('data-element_uuid');
+    } else {
+        parentUuid = `weblink-icon-picker-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+        $receiver = $('<div>')
+            .addClass('window')
+            .attr('data-element_uuid', parentUuid)
+            .css('display', 'none')
+            .appendTo('body');
+    }
+
+    let settled = false;
+    let filePicked = false;
 
     const cleanup = () => {
-        $receiver.off('file_opened');
-        $receiver.remove();
+        $receiver.off('file_opened', onFileOpened);
+        if ( !hasParentWindow ) {
+            $receiver.remove();
+        }
     };
 
-    $receiver.on('file_opened', async function (e) {
+    const finish = (fn, value) => {
+        if ( settled ) return;
+        settled = true;
+        cleanup();
+        fn(value);
+    };
+
+    async function onFileOpened (e) {
+        // Set synchronously (before the first await) so on_close, which fires
+        // right after selection, does not resolve null and discard the result.
+        filePicked = true;
         try {
             const selectedFile = Array.isArray(e.detail) ? e.detail[0] : e.detail;
 
             if ( !selectedFile?.path ) {
-                cleanup();
-                resolve(null);
+                finish(resolve, null);
                 return;
             }
 
-            const icon = await readIconFromFsEntry(selectedFile);
-            cleanup();
-            resolve(icon);
+            finish(resolve, await readIconFromFsEntry(selectedFile));
         } catch (error) {
-            cleanup();
-            reject(error);
+            finish(reject, error);
         }
-    });
+    }
+
+    $receiver.on('file_opened', onFileOpened);
 
     UIWindow({
         path: `/${window.user.username}/Desktop`,
-        parent_uuid: receiverUuid,
+        parent_uuid: parentUuid,
+        parent_center: hasParentWindow,
+        center: !hasParentWindow,
         allowed_file_types: 'image/*',
         show_maximize_button: false,
         show_minimize_button: false,
@@ -233,22 +232,18 @@ export const chooseWeblinkIcon = async (elItem) => await new Promise((resolve, r
         backdrop: true,
         close_on_backdrop_click: true,
         stay_on_top: true,
-    }).then((elDialog) => {
-        centerDialog(elDialog, elItem);
-    }).catch((error) => {
-        cleanup();
-        reject(error);
-    });
+        // Fires on any dismissal (cancel button, X, backdrop, Escape).
+        on_close: () => {
+            if ( !filePicked ) finish(resolve, null);
+        },
+    }).catch((error) => finish(reject, error));
 });
 
 export const updateWeblinkIcon = async ({ path, icon }) => {
     const data = await readWeblinkData(path);
-    const now = Date.now();
     data.icon = icon;
-    data.modified = now;
-    data.version = data.version ?? '2.1';
-    data.metadata = data.metadata ?? {};
-    data.metadata.icon = icon;
+    data.modified = Date.now();
+    data.version = WEBLINK_VERSION;
 
     await puter.fs.write(path, JSON.stringify(data), { overwrite: true });
     return data;
@@ -262,23 +257,40 @@ export const changeWeblinkIcon = async (elItem) => {
         return null;
     }
 
-    await updateWeblinkIcon({
-        path: $item.attr('data-path'),
-        icon: icon,
-    });
+    const path = $item.attr('data-path');
+    await updateWeblinkIcon({ path, icon });
 
-    $item.find('.item-icon > img').attr('src', icon);
-    $item.attr('data-icon', icon);
+    // Update every live view of this item (Desktop + any open folder windows),
+    // not just the clicked one, so the icon doesn't look stale elsewhere.
+    const uid = $item.attr('data-uid');
+    const $views = uid ? $(`.item[data-uid="${uid}"]`) : $item;
+    $views.find('.item-icon > img').attr('src', icon);
+    $views.attr('data-icon', icon);
+
+    weblinkIconCache.set(path, icon);
 
     return icon;
 };
 
 export const getWeblinkIcon = async (fsentry) => {
+    const path = fsentry.path;
+
+    if ( !path ) {
+        // Avoid a doomed puter.fs.read({ path: undefined }) for listing entries
+        // that don't carry a path.
+        return defaultWeblinkIcon();
+    }
+
+    if ( weblinkIconCache.has(path) ) {
+        return weblinkIconCache.get(path);
+    }
+
     try {
-        const data = await readWeblinkData(fsentry.path);
+        const data = await readWeblinkData(path);
         const icon = data.icon ?? data.metadata?.icon;
 
         if ( isValidWeblinkIcon(icon) ) {
+            weblinkIconCache.set(path, icon);
             return icon;
         }
     } catch (e) {
@@ -287,3 +299,16 @@ export const getWeblinkIcon = async (fsentry) => {
 
     return defaultWeblinkIcon();
 };
+
+// Shared "Change Icon" context-menu entry so UIItem and generate_file_context_menu
+// stay in sync instead of duplicating the block.
+export const weblinkChangeIconMenuItem = (elItem) => ({
+    html: i18n('change_icon'),
+    onClick: async function () {
+        try {
+            await changeWeblinkIcon(elItem);
+        } catch (error) {
+            UIAlert(error.message ?? 'Could not change the web link icon.');
+        }
+    },
+});

--- a/src/gui/src/helpers/weblink.js
+++ b/src/gui/src/helpers/weblink.js
@@ -1,0 +1,289 @@
+import UIWindow from '../UI/UIWindow.js';
+import mime from '../lib/mime.js';
+
+const WEBLINK_ICON_ALLOWLIST = [
+    'data:image/png;base64,',
+    'data:image/jpeg;base64,',
+    'data:image/jpg;base64,',
+    'data:image/gif;base64,',
+    'data:image/webp;base64,',
+    'data:image/svg+xml;base64,',
+];
+const WEBLINK_ICON_MIME_ALLOWLIST = [
+    'image/png',
+    'image/jpeg',
+    'image/gif',
+    'image/webp',
+    'image/svg+xml',
+];
+
+export const defaultWeblinkIcon = () => window.icons['link.svg'];
+
+export const isValidWeblinkIcon = (icon) => {
+    if ( typeof icon !== 'string' || icon.length === 0 ) {
+        return false;
+    }
+
+    if ( icon === defaultWeblinkIcon() ) {
+        return true;
+    }
+
+    return WEBLINK_ICON_ALLOWLIST.some(prefix => icon.toLowerCase().startsWith(prefix));
+};
+
+export const createWeblinkData = ({ url, domain, linkName, simpleName, icon = defaultWeblinkIcon() }) => ({
+    url: url,
+    type: 'weblink',
+    domain: domain,
+    icon: isValidWeblinkIcon(icon) ? icon : defaultWeblinkIcon(),
+    created: Date.now(),
+    modified: Date.now(),
+    version: '2.1',
+    metadata: {
+        originalUrl: url,
+        linkName: linkName,
+        simpleName: simpleName,
+    },
+});
+
+export const parseWeblinkData = async (content) => {
+    const text = typeof content === 'string' ? content : await content.text();
+
+    try {
+        return JSON.parse(text);
+    } catch (e) {
+        if ( text.startsWith('http://') || text.startsWith('https://') ) {
+            const url = new URL(text);
+            const domain = url.hostname;
+            const simpleName = domain.replace(/^www\./, '').split('.')[0];
+            const linkName = simpleName.charAt(0).toUpperCase() + simpleName.slice(1);
+
+            return createWeblinkData({
+                url: text,
+                domain: domain,
+                linkName: linkName,
+                simpleName: simpleName,
+            });
+        }
+
+        throw e;
+    }
+};
+
+export const readWeblinkData = async (path) => {
+    const content = await puter.fs.read({ path: path });
+    return parseWeblinkData(content);
+};
+
+const readFileAsDataUrl = async (file) => await new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result);
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(file);
+});
+
+const inferImageMimeFromBlob = async (file) => {
+    if ( !file?.slice || !file?.arrayBuffer ) {
+        return null;
+    }
+
+    const bytes = new Uint8Array(await file.slice(0, 512).arrayBuffer());
+
+    if (
+        bytes[0] === 0x89 &&
+        bytes[1] === 0x50 &&
+        bytes[2] === 0x4E &&
+        bytes[3] === 0x47
+    ) {
+        return 'image/png';
+    }
+
+    if ( bytes[0] === 0xFF && bytes[1] === 0xD8 && bytes[2] === 0xFF ) {
+        return 'image/jpeg';
+    }
+
+    if (
+        bytes[0] === 0x47 &&
+        bytes[1] === 0x49 &&
+        bytes[2] === 0x46
+    ) {
+        return 'image/gif';
+    }
+
+    if (
+        bytes[0] === 0x52 &&
+        bytes[1] === 0x49 &&
+        bytes[2] === 0x46 &&
+        bytes[3] === 0x46 &&
+        bytes[8] === 0x57 &&
+        bytes[9] === 0x45 &&
+        bytes[10] === 0x42 &&
+        bytes[11] === 0x50
+    ) {
+        return 'image/webp';
+    }
+
+    const text = new TextDecoder('utf-8', { fatal: false }).decode(bytes).trimStart();
+    if ( text.startsWith('<svg') || text.startsWith('<?xml') && text.includes('<svg') ) {
+        return 'image/svg+xml';
+    }
+
+    return null;
+};
+
+const normalizeImageDataUrl = async (dataUrl, fsentry, file) => {
+    if ( typeof dataUrl !== 'string' ) {
+        return dataUrl;
+    }
+
+    if ( isValidWeblinkIcon(dataUrl) ) {
+        return dataUrl;
+    }
+
+    const inferredMime = [
+        fsentry.type,
+        file?.type,
+        mime.getType(fsentry.name ?? fsentry.path ?? ''),
+    ]
+        .map(type => type?.toLowerCase())
+        .find(type => WEBLINK_ICON_MIME_ALLOWLIST.includes(type)) ??
+        await inferImageMimeFromBlob(file);
+
+    if ( !WEBLINK_ICON_MIME_ALLOWLIST.includes(inferredMime) ) {
+        return dataUrl;
+    }
+
+    return dataUrl.replace(/^data:[^,]*,/i, `data:${inferredMime};base64,`);
+};
+
+const readIconFromFsEntry = async (fsentry) => {
+    const file = await puter.fs.read(fsentry.path);
+    const icon = await normalizeImageDataUrl(
+        await readFileAsDataUrl(file),
+        fsentry,
+        file,
+    );
+
+    if ( !isValidWeblinkIcon(icon) ) {
+        throw new Error('Please choose a PNG, JPG, GIF, WebP, or SVG image.');
+    }
+
+    return icon;
+};
+
+const centerDialog = (elDialog, elItem) => {
+    const $dialog = $(elDialog);
+    const $parentWindow = $(elItem).closest('.window');
+    const parentOffset = $parentWindow.length ? $parentWindow.offset() : null;
+    const parentWidth = $parentWindow.length ? $parentWindow.outerWidth() : window.innerWidth;
+    const parentHeight = $parentWindow.length ? $parentWindow.outerHeight() : window.innerHeight;
+    const parentLeft = parentOffset?.left ?? 0;
+    const parentTop = parentOffset?.top ?? 0;
+    const left = parentLeft + parentWidth / 2 - $dialog.outerWidth() / 2;
+    const top = parentTop + parentHeight / 2 - $dialog.outerHeight() / 2;
+
+    $dialog.css({
+        left: `${Math.max(0, left) }px`,
+        top: `${Math.max(window.toolbar_height ?? 0, top) }px`,
+    });
+};
+
+export const chooseWeblinkIcon = async (elItem) => await new Promise((resolve, reject) => {
+    const receiverUuid = `weblink-icon-picker-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const $receiver = $('<div>')
+        .addClass('window')
+        .attr('data-element_uuid', receiverUuid)
+        .css('display', 'none')
+        .appendTo('body');
+
+    const cleanup = () => {
+        $receiver.off('file_opened');
+        $receiver.remove();
+    };
+
+    $receiver.on('file_opened', async function (e) {
+        try {
+            const selectedFile = Array.isArray(e.detail) ? e.detail[0] : e.detail;
+
+            if ( !selectedFile?.path ) {
+                cleanup();
+                resolve(null);
+                return;
+            }
+
+            const icon = await readIconFromFsEntry(selectedFile);
+            cleanup();
+            resolve(icon);
+        } catch (error) {
+            cleanup();
+            reject(error);
+        }
+    });
+
+    UIWindow({
+        path: `/${window.user.username}/Desktop`,
+        parent_uuid: receiverUuid,
+        allowed_file_types: 'image/*',
+        show_maximize_button: false,
+        show_minimize_button: false,
+        title: i18n('window_title_open'),
+        is_dir: true,
+        is_openFileDialog: true,
+        selectable_body: false,
+        backdrop: true,
+        close_on_backdrop_click: true,
+        stay_on_top: true,
+    }).then((elDialog) => {
+        centerDialog(elDialog, elItem);
+    }).catch((error) => {
+        cleanup();
+        reject(error);
+    });
+});
+
+export const updateWeblinkIcon = async ({ path, icon }) => {
+    const data = await readWeblinkData(path);
+    const now = Date.now();
+    data.icon = icon;
+    data.modified = now;
+    data.version = data.version ?? '2.1';
+    data.metadata = data.metadata ?? {};
+    data.metadata.icon = icon;
+
+    await puter.fs.write(path, JSON.stringify(data), { overwrite: true });
+    return data;
+};
+
+export const changeWeblinkIcon = async (elItem) => {
+    const $item = $(elItem);
+    const icon = await chooseWeblinkIcon(elItem);
+
+    if ( !icon ) {
+        return null;
+    }
+
+    await updateWeblinkIcon({
+        path: $item.attr('data-path'),
+        icon: icon,
+    });
+
+    $item.find('.item-icon > img').attr('src', icon);
+    $item.attr('data-icon', icon);
+
+    return icon;
+};
+
+export const getWeblinkIcon = async (fsentry) => {
+    try {
+        const data = await readWeblinkData(fsentry.path);
+        const icon = data.icon ?? data.metadata?.icon;
+
+        if ( isValidWeblinkIcon(icon) ) {
+            return icon;
+        }
+    } catch (e) {
+        // Older weblinks may contain only a URL or malformed legacy JSON.
+    }
+
+    return defaultWeblinkIcon();
+};

--- a/src/gui/src/i18n/translations/en.js
+++ b/src/gui/src/i18n/translations/en.js
@@ -96,6 +96,7 @@ const en = {
         cpu: 'CPU',
         create_account: 'Create Account',
         create_free_account: 'Create Free Account',
+        change_icon: 'Change Icon',
         create_desktop_shortcut: 'Create Shortcut (Desktop)',
         create_desktop_shortcut_s: 'Create Shortcuts (Desktop)',
         create_shortcut: 'Create Shortcut',


### PR DESCRIPTION
## Summary

- Add persistent custom icon support for `.weblink` files.
- Add a `Change Icon` context menu action that uses Puter's built-in file picker.
- Read selected icon files from Puter FS and store them as data URLs in the web link payload.
- Preserve legacy web links by falling back to the default link icon and upgrading plain-URL web links when edited.

## Details

Web link icons were previously hard-coded to `link.svg` in the item icon resolver. This change centralizes web link parsing and icon handling in `src/gui/src/helpers/weblink.js`, stores the selected icon in the `.weblink` JSON, and teaches `item_icon` to prefer that custom icon when rendering.

The icon picker accepts image files selected through Puter's file manager. Because files read from Puter FS may have a generic Blob MIME type, the helper normalizes data URLs using the selected file type, extension, and image byte signatures for PNG, JPEG, GIF, WebP, and SVG.

## Validation

- `npm run build --workspace src/gui`

The build passes with the existing webpack bundle size warnings.
