### PR TITLE
Return index_url from /installedApps for dashboard app titles

### DIFF
--- a/extensions/installedApps.test.ts
+++ b/extensions/installedApps.test.ts
@@ -132,6 +132,9 @@ describe('installedApps extension — handleInstalledApps', () => {
         expect(list[0].uid).toBe(app!.uid);
         expect(list[0].name).toBe(app!.name);
         expect(list[0].title).toBe(app!.title);
+        // index_url is required so the dashboard can derive a hostname title
+        // for anonymous (app-…) apps.
+        expect(list[0].index_url).toBe(app!.index_url);
         expect(Object.prototype.hasOwnProperty.call(list[0], 'iconUrl')).toBe(
             true,
         );

--- a/extensions/installedApps.ts
+++ b/extensions/installedApps.ts
@@ -49,6 +49,7 @@ export const handleInstalledApps = async (
             apps.title,
             apps.description,
             apps.icon,
+            apps.index_url,
             MIN(perm.dt) AS installed_at
         FROM apps
         LEFT JOIN user_to_app_permissions AS perm ON apps.id = perm.app_id


### PR DESCRIPTION
## What

Add `index_url` to the `/installedApps` response.

## Why

The dashboard shows a friendlier title for **anonymous apps** — those whose
`uuid`, `name`, and `title` are all identical and start with `app-`. Instead of
the opaque `app-…` id, it displays the hostname of the app's `index_url`.

This already worked for apps sourced from the launch-apps list (recent /
recommended), which carry `index_url`. But it did **not** work for apps that come
only from `/installedApps`, because that endpoint's `SELECT` didn't return
`index_url`, so the client's fallback could never fire.

## Change

- `extensions/installedApps.ts` — add `apps.index_url` to the query. It sits
  alongside `apps.icon` (also not in the `GROUP BY`), relying on the functional
  dependency on the `apps.id` primary key, so it's consistent with the existing
  query and safe across SQLite/Postgres/MySQL.
- `extensions/installedApps.test.ts` — assert `index_url` is present in the
  response so it can't be silently dropped again.

## Testing

`vitest run` on the extension suite — 5/5 passing, including the new assertion.
