### PR TITLE
Fix static hosting domain fallback for self-hosted custom domains

### DIFF
--- a/src/dev-center/js/dev-center.js
+++ b/src/dev-center/js/dev-center.js
@@ -45,9 +45,11 @@ if ( window.url_params.has('puter.domain') ) {
 
 // static hosting domain
 window.static_hosting_domain = 'puter.site';
-if ( window.domain === 'puter.localhost' ) {
-    window.static_hosting_domain = 'site.puter.localhost';
-}
+   if ( window.domain === 'puter.localhost' ) {
+       window.static_hosting_domain = 'site.puter.localhost';
+   } else if ( window.domain && window.domain !== 'puter.com' ) {
+       window.static_hosting_domain = `site.${window.domain}`;
+   }
 
 // add port to static_hosting_domain if provided
 if ( window.url_params.has('puter.port') && window.url_params.get('puter.port') ) {


### PR DESCRIPTION
Title: Fix static hosting domain fallback for self-hosted custom domains (#3380)

Description:

Fixes #3380

Root cause
dev-center.js only remaps window.static_hosting_domain away from the hardcoded public default (puter.site) when window.domain === 'puter.localhost'. Any self-hosted instance running on a real custom domain falls through to puter.site, which doesn't exist on that network — so the Dev Center's "Give it a try" flow 404s after deploying via Apps → Deploy → Use files.

I also investigated the middleware side, since the original issue included a hostRedirects.js patch. hostRedirects.ts already guards against this correctly — createUserSubdomainRedirect's hostingDomains.some(...) check passes through requests already on the target hosting domain, preventing the redirect loop. So no change was needed there; the gap was isolated to the frontend fallback logic.

Fix
Added an else if branch so any self-hosted instance with a real custom domain (not puter.localhost, not puter.com) derives its static hosting domain as site.<domain> instead of falling back to the public puter.site.

Testing

Reproduced the original 404 on a self-hosted instance with a custom domain following the exact steps in #3380.
Confirmed the fix resolves it — after the change, deployed apps load correctly via "Give it a try."
Verified file syntax with node --check src/dev-center/js/dev-center.js.
Wasn't able to run the full local npm run build, since this repo requires Node ≥24 and I'm on Node 22.14.0 locally — will rely on CI to validate the full build/test suite. Happy to upgrade and re-verify locally if maintainers would prefer that before merge.