### PR TITLE
fix: verified Dashboard bugs (10 separate fixes)

### DIFF
--- a/src/gui/src/UI/Dashboard/TabApps.js
+++ b/src/gui/src/UI/Dashboard/TabApps.js
@@ -129,17 +129,17 @@ function showUninstallModal ({ appName, appTitle, appUid, self, $el_window }) {
 
     $el_window.append($overlay);
 
-    const close = () => $overlay.remove();
+    const close = () => {
+        $overlay.remove();
+        $(document).off('keydown.uninstall-modal');
+    };
 
     $overlay.on('click', '.myapps-modal-cancel', close);
     $overlay.on('click', function (e) {
         if ( e.target === $overlay[0] ) close();
     });
     $(document).on('keydown.uninstall-modal', function (e) {
-        if ( e.key === 'Escape' ) {
-            close();
-            $(document).off('keydown.uninstall-modal');
-        }
+        if ( e.key === 'Escape' ) close();
     });
 
     $overlay.on('click', '.myapps-modal-confirm', async function () {
@@ -154,7 +154,6 @@ function showUninstallModal ({ appName, appTitle, appUid, self, $el_window }) {
             console.error('Failed to uninstall app:', err);
         }
         close();
-        $(document).off('keydown.uninstall-modal');
     });
 }
 

--- a/src/gui/src/UI/Dashboard/TabFiles.js
+++ b/src/gui/src/UI/Dashboard/TabFiles.js
@@ -1291,7 +1291,7 @@ const TabFiles = {
         // Download button
         $actions.find('.download-btn').on('click', function () {
             const selectedRows = document.querySelectorAll('.files-tab .row.selected');
-            if ( selectedRows.length >= 2 ) {
+            if ( selectedRows.length > 0 ) {
                 window.zipItems(Array.from(selectedRows), _this.currentPath, true);
             }
         });

--- a/src/gui/src/UI/Dashboard/TabFiles.js
+++ b/src/gui/src/UI/Dashboard/TabFiles.js
@@ -2050,9 +2050,9 @@ const TabFiles = {
                 ${icon}
             </div>
             <div class="item-badges">
-                <img class="item-badge item-has-website-badge long-hover" 
-                    style="${file.has_website && file.workers.length === 0 ? 'display:block;' : ''}" 
-                    src="${html_encode(window.icons['world.svg'])}" 
+                <img class="item-badge item-has-website-badge long-hover"
+                    style="${file.has_website && !is_worker ? 'display:block;' : ''}"
+                    src="${html_encode(window.icons['world.svg'])}"
                     data-item-id="${item_id}"
                 />
                 <img class="item-badge item-has-website-url-badge" 

--- a/src/gui/src/UI/Dashboard/TabFiles.js
+++ b/src/gui/src/UI/Dashboard/TabFiles.js
@@ -1456,7 +1456,7 @@ const TabFiles = {
                     const fullName = $(this).attr('data-name');
                     if ( fullName ) {
                         const textWidth = measureTextWidth(fullName) + padding;
-                        maxWidth = Math.max(maxWidth + 10, textWidth);
+                        maxWidth = Math.max(maxWidth, textWidth);
                     }
                 });
             } else if ( column === 'size' ) {
@@ -1464,7 +1464,7 @@ const TabFiles = {
                     const text = $(this).text();
                     if ( text ) {
                         const textWidth = measureTextWidth(text) + padding;
-                        maxWidth = Math.max(maxWidth + 10, textWidth);
+                        maxWidth = Math.max(maxWidth, textWidth);
                     }
                 });
             } else if ( column === 'modified' ) {
@@ -1472,7 +1472,7 @@ const TabFiles = {
                     const text = $(this).text();
                     if ( text ) {
                         const textWidth = measureTextWidth(text) + padding;
-                        maxWidth = Math.max(maxWidth + 10, textWidth);
+                        maxWidth = Math.max(maxWidth, textWidth);
                     }
                 });
             }

--- a/src/gui/src/UI/Dashboard/TabFiles.js
+++ b/src/gui/src/UI/Dashboard/TabFiles.js
@@ -194,6 +194,11 @@ const TabFiles = {
                 return;
             }
 
+            // If the directory was empty, drop the "No files in this directory."
+            // placeholder before inserting the first real row — otherwise it
+            // stays and overlaps the new item.
+            _this.$el_window.find('.files-tab .files > div:not(.item)').remove();
+
             await _this.renderItem(file);
 
             // Get the newly appended row (it's always last after renderItem)

--- a/src/gui/src/UI/Dashboard/TabHome.js
+++ b/src/gui/src/UI/Dashboard/TabHome.js
@@ -306,20 +306,21 @@ const TabHome = {
     },
 
     async loadRecentApps($el_window) {
-        if (!window.launch_apps?.recent?.length) {
-            try {
-                window.launch_apps = await $.ajax({
-                    url: `${window.api_origin}/get-launch-apps?icon_size=64`,
-                    type: 'GET',
-                    async: true,
-                    contentType: 'application/json',
-                    headers: {
-                        Authorization: `Bearer ${window.auth_token}`,
-                    },
-                });
-            } catch (e) {
-                console.error('Failed to load launch apps:', e);
-            }
+        // Always refetch: gating on an empty list froze "Recently used" for the
+        // whole session (apps launched after load never appeared). loadUsageData
+        // refreshes on the same activate/focus triggers, so this stays in step.
+        try {
+            window.launch_apps = await $.ajax({
+                url: `${window.api_origin}/get-launch-apps?icon_size=64`,
+                type: 'GET',
+                async: true,
+                contentType: 'application/json',
+                headers: {
+                    Authorization: `Bearer ${window.auth_token}`,
+                },
+            });
+        } catch (e) {
+            console.error('Failed to load launch apps:', e);
         }
         $el_window
             .find('.bento-recent-apps-container')

--- a/src/gui/src/UI/Dashboard/TabHome.js
+++ b/src/gui/src/UI/Dashboard/TabHome.js
@@ -433,12 +433,14 @@ const TabHome = {
         try {
             const res = await puter.auth.getMonthlyUsage();
             let monthlyAllowance = res.allowanceInfo?.monthUsageAllowance;
-            let remaining = res.allowanceInfo?.remaining;
-            let totalUsage = monthlyAllowance - remaining;
-            let totalUsagePercentage = (
-                (totalUsage / monthlyAllowance) *
-                100
-            ).toFixed(0);
+            // Actual month-to-date spend. `allowanceInfo.remaining` folds
+            // purchased credits into the remaining pool, so `allowance -
+            // remaining` turns negative once a user has credits. Use the
+            // reported usage total instead.
+            let totalUsage = res.usage?.total ?? 0;
+            let totalUsagePercentage = monthlyAllowance
+                ? Math.min(100, (totalUsage / monthlyAllowance) * 100).toFixed(0)
+                : '0';
 
             $el_window
                 .find('.bento-resources-used')

--- a/src/gui/src/UI/Dashboard/TabSecurity.js
+++ b/src/gui/src/UI/Dashboard/TabSecurity.js
@@ -155,6 +155,11 @@ const TabSecurity = {
                 return;
             }
 
+            // Keep the in-memory flag in sync so a later re-render reflects the
+            // real 2FA state. The disable dialog already clears window.user.otp;
+            // the enable path never set it, so the two directions disagreed.
+            if ( window.user ) window.user.otp = enabling;
+
             const $card = $el_window.find('.dashboard-section-security .dashboard-settings-card-2fa');
             if ( enabling ) {
                 $el_window.find('.dashboard-section-security .user-otp-state').text(i18n('two_factor_enabled'));

--- a/src/gui/src/UI/Dashboard/TabUsage.js
+++ b/src/gui/src/UI/Dashboard/TabUsage.js
@@ -231,9 +231,11 @@ async function update_usage_details ($el_window) {
 
     const monthlyUsagePromise = puter.auth.getMonthlyUsage().then(res => {
         let monthlyAllowance = res.allowanceInfo?.monthUsageAllowance;
-        let remaining = res.allowanceInfo?.remaining;
-        let totalUsage = monthlyAllowance - remaining;
-        let totalUsagePercentage = (totalUsage / monthlyAllowance * 100).toFixed(0);
+        // Actual month-to-date spend. `allowanceInfo.remaining` folds purchased
+        // credits into the remaining pool, so `allowance - remaining` turns
+        // negative as soon as a user has credits. Use the reported usage total.
+        let totalUsage = res.usage?.total ?? 0;
+        let totalUsagePercentage = monthlyAllowance ? Math.min(100, totalUsage / monthlyAllowance * 100).toFixed(0) : '0';
 
         $('#total-usage').html(window.number_format(totalUsage / 100_000_000, { decimals: 2, prefix: '$' }));
         $('#total-capacity').html(window.number_format(monthlyAllowance / 100_000_000, { decimals: 2, prefix: '$' }));

--- a/src/gui/src/UI/Dashboard/UIDashboard.js
+++ b/src/gui/src/UI/Dashboard/UIDashboard.js
@@ -396,6 +396,14 @@ async function UIDashboard (options) {
             document.querySelector('.dashboard-content').classList.add(tab);
         }
 
+        // Refresh the tab we just switched to, mirroring the sidebar-click
+        // handler — otherwise reaching a tab via browser back/forward leaves it
+        // showing stale data because its onActivate never runs.
+        const activeTab = tabs.find(t => t !== '-' && t.id === tab);
+        if ( activeTab?.onActivate ) {
+            activeTab.onActivate($el_window);
+        }
+
         // Scroll content area to top
         $el_window.find('.dashboard-content').scrollTop(0);
 

--- a/src/gui/src/UI/UIWindow2FASetup.js
+++ b/src/gui/src/UI/UIWindow2FASetup.js
@@ -751,7 +751,13 @@ const UIWindow2FASetup = async function UIWindow2FASetup () {
         is_draggable: false,
         backdrop: true,
         on_before_exit: async () => {
-            if ( ! setup_succeeded ) resolve_promise(false);
+            // Settle the promise on every close path. Clicking "Enable" sets
+            // setup_succeeded but does not resolve (only the Done button does),
+            // so closing the success screen via backdrop/Escape must resolve
+            // here too — otherwise the caller (Dashboard 2FA toggle) awaits a
+            // promise that never settles and leaves its control stuck disabled.
+            // resolve_promise is idempotent, so a prior Done-resolve is a no-op.
+            resolve_promise(setup_succeeded);
             return true;
         },
         window_class: 'window-tfa-setup',


### PR DESCRIPTION
Ten independently verified bugs in the Dashboard, each fixed in its own commit. Every fix was confirmed against the reference implementations (`UIItem.js`, `UIDesktop.js`), the metering backend, and global/dialog contracts before changing anything. No behavior change for the common/happy paths — see per-fix notes.

## Fixes (one commit each)

1. **Crash rendering website files without a `workers` array** — `TabFiles.renderItem` read `file.workers.length` unguarded when choosing the website badge. A published-website entry with no `workers` array threw `Cannot read properties of undefined`, so the row silently vanished (swallowed by `Promise.allSettled`) or was never added on socket updates. Reuse the already-guarded `is_worker` flag (matches `UIItem.js`).

2. **Usage showed negative spend for users with credits** — Usage tab + Home card derived spend as `monthUsageAllowance - allowanceInfo.remaining`, but the metering service folds purchased credits into `remaining`, so it went negative (e.g. `-$9.90 used`, `-3960%`). Use the reported `res.usage.total` and clamp to 100%. Identical to the old value for a free user with no credits/overage.

3. **Download button dead for a single selection** — In mobile select mode the action bar appears with one item and shows an enabled Download, but the handler required `>= 2` rows. Gate on `> 0` (`zipItems` already handles one item). Desktop unaffected — its bar only shows at 2+.

4. **Auto-fit column width scaled with row count** — Double-click-to-fit used `Math.max(maxWidth + 10, textWidth)`, forcing the width to grow ≥10px per row (a 60-file folder produced a ~660px column) and persisting it. Compare against the running max only.

5. **Empty-directory placeholder left overlapping a new row** — When a file appeared in an empty folder via the incremental path (`UIDashboardFileItem`), the "No files in this directory." placeholder wasn't removed, so it overlapped the item. Remove it before inserting, matching the in-app New Folder/File flows.

6. **Document keydown handler leaked per uninstall-modal dismissal** — `keydown.uninstall-modal` was only detached on the Escape/Confirm paths; Cancel and backdrop clicks left it bound to `document` (closing over a detached overlay), stacking one per open→cancel cycle. Detach inside `close()`.

7. **2FA setup promise could never resolve, freezing the toggle** — `UIWindow2FASetup` only resolved from Done, or from `on_before_exit` when setup had *not* succeeded. Closing the success screen via backdrop/Escape after clicking Enable left the promise unsettled; the Dashboard's sole caller `await`s it after disabling the toggle, so it stayed permanently disabled + pending. Resolve with `setup_succeeded` on any close (idempotent). The Dashboard is the only caller of this dialog.

8. **Back/forward didn't refresh tabs** — `handleRouteChange` (popstate/hashchange) swapped active classes but never called the tab's `onActivate`, unlike the sidebar-click and initial-route paths, so browser back/forward showed stale Home/Apps data. Call `onActivate` after switching.

9. **"Recently used" apps frozen for the session** — `loadRecentApps` only fetched when the list was empty, so apps launched after page load never appeared until a hard reload. Always refetch (in step with the usage-card refresh triggers).

10. **Enabling 2FA didn't sync `window.user.otp`** — The disable path clears `window.user.otp`; the enable path updated only the DOM. A re-render of the Security tab from cached `window.user` then showed 2FA as off for an account that had it on. Set `window.user.otp = enabling` on success.

## Verification
- Every file `node --check`-clean (ES module) and eslint-clean (0 errors).
- Numeric fixes (#2, #4) validated with a standalone harness: free-user output is byte-identical to before; credit/overage/auto-fit cases are corrected.
- DOM/handler fixes cross-checked against the desktop reference implementations and confirmed as the sole unguarded/inconsistent sites.

## Not changed (evaluated, deliberately left alone to avoid regression)
- Home `focus`+`visibilitychange` double-fire (redundant network only, no broken behavior; fix would touch refresh orchestration).
- Mobile `ContextMenu.positionModal` hardcoded desktop offset (touch-laptop-only positioning nit).
- `item.renamed`/`item.updated` using raw name for trashed items — the desktop reference behaves identically, so not Dashboard-specific.