### PR TITLE
feat: add defaultValue support for showFontPicker in puter app environment

### DIFF
--- a/src/gui/src/IPC.js
+++ b/src/gui/src/IPC.js
@@ -1349,6 +1349,11 @@ const ipc_listener = async (event, handled) => {
         // set options
         event.data.options = event.data.options ?? {};
 
+        // Map defaultValue to default for compatibility
+        if (event.data.options.defaultValue && !event.data.options.default) {
+            event.data.options.default = event.data.options.defaultValue;
+        }
+
         // clear window_options for security reasons
         event.data.options.window_options = {};
 
@@ -1381,6 +1386,11 @@ const ipc_listener = async (event, handled) => {
             event.data.options = { defaultColor: event.data.options };
         }
         event.data.options = event.data.options ?? {};
+
+        // Map defaultValue to default for compatibility
+        if (event.data.options.defaultValue && !event.data.options.default) {
+            event.data.options.default = event.data.options.defaultValue;
+        }
 
         // Clear window_options for security reasons
         event.data.options.window_options = {};

--- a/src/gui/src/UI/UIWindowFontPicker.js
+++ b/src/gui/src/UI/UIWindowFontPicker.js
@@ -55,7 +55,7 @@ async function UIWindowFontPicker (options) {
         h += '<div style="padding: 20px; border-bottom: 1px solid #ced7e1; width: 100%; box-sizing: border-box;">';
         h += '<div class="font-list" style="margin-bottom: 10px; height: 200px; overflow-y: scroll; background-color: white; padding: 0 10px;">';
         fontAvailable.forEach(element => {
-            h += `<p class="font-selector disable-user-select ${options.default === element ? 'font-selector-active' : ''}" style="font-family: '${html_encode(element)}';" data-font-family="${html_encode(element)}">${html_encode(element)}</p>`; // 👉️ one, two, three, four
+            h += `<p class="font-selector disable-user-select ${(options.default === element || options.defaultValue === element) ? 'font-selector-active' : ''}" style="font-family: '${html_encode(element)}';" data-font-family="${html_encode(element)}">${html_encode(element)}</p>`; // 👉️ one, two, three, four
         });
         h += '</div>';
 

--- a/src/puter-js/src/modules/UI.js
+++ b/src/puter-js/src/modules/UI.js
@@ -863,7 +863,7 @@ class UI extends EventListener {
         return new Promise((resolve) => {
             const opts = typeof options === 'string' ? { defaultFont: options } : (options ?? {});
             const el = document.createElement('puter-font-picker');
-            const defaultFont = opts.defaultFont || opts.default || 'System UI';
+            const defaultFont = opts.defaultValue || opts.defaultFont || opts.default || 'System UI';
             el.setAttribute('default-font', defaultFont);
             el.addEventListener('response', (e) => resolve(e.detail));
             document.body.appendChild(el);

--- a/src/puter-js/types/modules/ui.d.ts
+++ b/src/puter-js/types/modules/ui.d.ts
@@ -172,6 +172,9 @@ export interface ColorPickerOptions {
 export interface FontPickerOptions {
     /** The font initially selected when the picker opens. */
     defaultFont?: string;
+
+    /** The font initially selected when the picker opens (alias for defaultFont). */
+    defaultValue?: string;
 }
 
 /** Options that configure `showDirectoryPicker()`. */


### PR DESCRIPTION
## Description

This PR adds support for the `defaultValue` option in `puter.ui.showFontPicker()`, for consistency with `showColorPicker()` which already supports `defaultValue`.

When calling `showFontPicker` from a Puter app, passing `defaultValue` as an option would not pre-select the specified font because:
1. The IPC handler did not map `defaultValue` to `default` before passing to the desktop UI
2. The desktop UI window (`UIWindowFontPicker`) only checked `options.default`
3. The web fallback only checked `defaultFont` and `default`

## Changes

- **UI.js** (web fallback): Added `opts.defaultValue` to the font resolution chain
- **IPC.js** (app environment): Map `defaultValue` to `default` before calling `UIWindowFontPicker`
- **UIWindowFontPicker.js** (desktop UI): Check `defaultValue` alongside `default` when highlighting the active font
- **ui.d.ts** (types): Added `defaultValue` to `FontPickerOptions` interface

## Related Issue

Closes #2896