### PR TITLE
fix: verified Dashboard bug fixes (routing, files, apps, usage, mobile menu, CSS)

### DIFF
--- a/src/gui/src/UI/Dashboard/ContextMenu/ContextMenu.js
+++ b/src/gui/src/UI/Dashboard/ContextMenu/ContextMenu.js
@@ -42,6 +42,10 @@ export default class ContextMenuModal {
         if ( this.backdrop ) return; // Already showing
 
         this.menuItems = menuItems;
+        // Stack of parent menus for submenu drill-in, and the anchor rect so we
+        // can reposition when the menu height changes on navigation.
+        this._menuStack = [];
+        this._targetRect = targetRect;
 
         // Create backdrop
         this.backdrop = document.createElement('div');
@@ -62,7 +66,7 @@ export default class ContextMenuModal {
         this.modal.innerHTML = `
             ${titleHtml}
             <div class="context-menu-items">
-                ${this.renderMenuItems(menuItems)}
+                ${this.renderMenuItems(this.getVisibleItems())}
             </div>
         `;
 
@@ -102,39 +106,51 @@ export default class ContextMenuModal {
         const viewportWidth = window.innerWidth;
         const margin = 20; // Minimum margin from viewport edges
 
-        // Default: align with item left and top
-        let top = targetRect.top;
-        let left = targetRect.left;
+        const width = isMobile ? viewportWidth * 0.9 : modalWidth;
 
-        // Use target width as minimum, but allow modal to be wider if needed
-        const width = Math.max(targetRect.width, modalWidth);
-
-        // Horizontal positioning - center over item if possible
+        // Center over the target horizontally, clamped to the viewport. (The
+        // old code hardcoded left:300px on non-touch devices — which route here
+        // whenever maxTouchPoints > 0, e.g. touchscreen laptops — so the menu
+        // opened nowhere near the item on a wide screen.)
         const itemCenter = targetRect.left + (targetRect.width / 2);
-        const modalHalfWidth = width / 2;
+        let left = itemCenter - width / 2;
+        left = Math.max(margin, Math.min(left, viewportWidth - width - margin));
 
-        if ( itemCenter - modalHalfWidth >= margin &&
-            itemCenter + modalHalfWidth <= viewportWidth - margin ) {
-            left = itemCenter - modalHalfWidth;
-        } else {
-            // Align with item left, but ensure within viewport
-            left = 20; //Math.max(margin, Math.min(left, viewportWidth - width - margin));
-        }
-
-        // Vertical positioning - ensure modal stays within viewport
+        let top = targetRect.top;
         if ( top + modalHeight > viewportHeight - margin ) {
-            // Would go off bottom, shift up
             top = Math.max(margin, viewportHeight - modalHeight - margin);
         }
-
         if ( top < margin ) {
             top = margin;
         }
 
-        // Apply positioning
         this.modal.style.top = `${top}px`;
-        this.modal.style.left = isMobile ? `${left}px` : '300px';
+        this.modal.style.left = `${left}px`;
         this.modal.style.width = isMobile ? '90%' : 'auto';
+    }
+
+    /**
+     * The item list currently on screen: the active menu, prefixed with a Back
+     * row when we've drilled into a submenu.
+     * @returns {Array}
+     */
+    getVisibleItems () {
+        if ( this._menuStack && this._menuStack.length > 0 ) {
+            return [{ label: '‹ Back', _isBack: true }, '-', ...this.menuItems];
+        }
+        return this.menuItems;
+    }
+
+    /**
+     * Rebuild the item rows in place (after drilling in/out of a submenu) and
+     * reposition, since the height changed.
+     */
+    rerenderItems () {
+        const container = this.modal.querySelector('.context-menu-items');
+        if ( container ) {
+            container.innerHTML = this.renderMenuItems(this.getVisibleItems());
+        }
+        this.positionModal(this._targetRect);
     }
 
     /**
@@ -156,6 +172,8 @@ export default class ContextMenuModal {
             // Check for delete/danger styling
             const isDelete = label.toLowerCase().includes('delete');
             const deleteClass = isDelete ? 'context-menu-item--delete' : '';
+            const disabledClass = item.disabled ? 'context-menu-item--disabled' : '';
+            const hasSubmenu = Array.isArray(item.items) && item.items.length > 0;
 
             // Get icon - support both formats (HTML string or base64)
             let iconHtml = '';
@@ -169,12 +187,18 @@ export default class ContextMenuModal {
                 }
             }
 
+            // A submenu row gets a trailing chevron; a Back row a leading one.
+            const submenuChevron = hasSubmenu
+                ? '<span class="context-menu-item-chevron">›</span>'
+                : '';
+
             return `
-                <button class="context-menu-item ${deleteClass}" data-index="${index}">
+                <button class="context-menu-item ${deleteClass} ${disabledClass}" data-index="${index}"${item.disabled ? ' disabled' : ''}>
                     <div class="context-menu-item-icon">
                         ${iconHtml}
                     </div>
                     <span class="context-menu-item-label">${label}</span>
+                    ${submenuChevron}
                 </button>
             `;
         }).join('');
@@ -208,18 +232,36 @@ export default class ContextMenuModal {
             if ( ! itemBtn ) return;
 
             const index = parseInt(itemBtn.dataset.index, 10);
-            const menuItem = this.menuItems[index];
+            const menuItem = this.getVisibleItems()[index];
+            if ( ! menuItem || menuItem === '-' || menuItem.is_divider ) return;
 
-            if ( menuItem && menuItem !== '-' && !menuItem.is_divider ) {
-                // Support both action formats
-                const handler = menuItem.action || menuItem.onClick;
-                if ( handler ) {
-                    this.close();
-                    // Execute action after close animation starts
-                    setTimeout(() => {
-                        handler();
-                    }, 50);
-                }
+            // Back out of a submenu.
+            if ( menuItem._isBack ) {
+                this.menuItems = this._menuStack.pop();
+                this.rerenderItems();
+                return;
+            }
+
+            // Disabled items are inert (mirrors the desktop UIContextMenu).
+            if ( menuItem.disabled ) return;
+
+            // Drill into a submenu (e.g. "New", "Open With") instead of leaving
+            // it a dead button.
+            if ( Array.isArray(menuItem.items) && menuItem.items.length > 0 ) {
+                this._menuStack.push(this.menuItems);
+                this.menuItems = menuItem.items;
+                this.rerenderItems();
+                return;
+            }
+
+            // Support both action formats
+            const handler = menuItem.action || menuItem.onClick;
+            if ( handler ) {
+                this.close();
+                // Execute action after close animation starts
+                setTimeout(() => {
+                    handler();
+                }, 50);
             }
         };
         this.modal.addEventListener('click', this.itemClickHandler);

--- a/src/gui/src/UI/Dashboard/TabApps.js
+++ b/src/gui/src/UI/Dashboard/TabApps.js
@@ -269,9 +269,9 @@ const TabApps = {
             const appName = $(this).attr('data-app-name');
             const targetLink = $(this).attr('data-target-link');
             if ( targetLink && targetLink !== '' ) {
-                window.open(targetLink, '_blank');
+                window.open(targetLink, '_blank', 'noopener,noreferrer');
             } else if ( appName ) {
-                window.open(`/app/${appName}`, '_blank');
+                window.open(`/app/${appName}`, '_blank', 'noopener,noreferrer');
             }
         });
 

--- a/src/gui/src/UI/Dashboard/TabApps.js
+++ b/src/gui/src/UI/Dashboard/TabApps.js
@@ -73,7 +73,7 @@ function buildTileHtml (app) {
     const { title, targetLink } = resolveTileDisplay(app);
     const iconUrl = app.iconUrl || window.icons['app.svg'];
 
-    let h = `<div class="myapps-tile" data-app-name="${html_encode(app.name)}" data-app-title="${html_encode(title)}" data-app-uid="${html_encode(app.uid || '')}" data-target-link="${html_encode(targetLink)}" data-app-uninstallable="${app.uninstallable ? '1' : '0'}" title="${html_encode(title)}">`;
+    let h = `<div class="myapps-tile" data-app-name="${html_encode(app.name)}" data-app-title="${html_encode(title)}" data-app-uid="${html_encode(app.uid || '')}" data-target-link="${html_encode(targetLink)}" title="${html_encode(title)}">`;
     h += '<div class="myapps-tile-icon">';
     h += `<img src="${html_encode(iconUrl)}" alt="" draggable="false">`;
     h += '</div>';
@@ -127,21 +127,13 @@ function buildPagerHtml (apps, layout, instant) {
     return h;
 }
 
-function showUninstallModal ({ appName, appTitle, appUid, removesTile, self, $el_window }) {
+function showUninstallModal ({ appName, appTitle, appUid, self, $el_window }) {
     const displayName = (appTitle || appName || '').trim();
-    // A recommended/recent app's tile reappears on the next load even after a
-    // successful revoke; say so up front so the uninstall doesn't look like it
-    // silently failed. (Recommended apps stay indefinitely; recent ones until
-    // they age out of the open history — don't claim more than that.)
-    const note = removesTile
-        ? ''
-        : '<p>Its icon will stay in Apps for now, because this app is in your recommended or recently used list.</p>';
     const $overlay = $(`
         <div class="myapps-modal-overlay">
             <div class="myapps-modal">
                 <h3>Uninstall ${html_encode(displayName)}?</h3>
                 <p>This will revoke all permissions for this app.</p>
-                ${note}
                 <div class="myapps-modal-buttons">
                     <button class="myapps-modal-btn myapps-modal-cancel">Cancel</button>
                     <button class="myapps-modal-btn myapps-modal-confirm">Uninstall</button>
@@ -172,22 +164,15 @@ function showUninstallModal ({ appName, appTitle, appUid, removesTile, self, $el
         try {
             await puter.perms.revokeApp(appUid, '*');
             // A load fetched before the revoke must not apply — it would
-            // resurrect the pre-revoke grid.
+            // resurrect the pre-revoke grid. No refetch here either: the
+            // recommended/recent launch lists don't know about the revoke,
+            // so an immediate reload would just re-add the tile. The saved
+            // order intentionally keeps the app's name: reconcileAppOrder
+            // ignores it while the app is gone and restores its position if
+            // it comes back.
             self._invalidateInFlightLoads();
-            // Drop the tile right away when we expect the uninstall to stick
-            // (immediate feedback) — but whether it really disappears depends
-            // on server-side state (recommended/recent lists) that load-time
-            // flags can only guess at, so refetch either way and let the grid
-            // converge to the truth. The saved order intentionally keeps the
-            // app's name: reconcileAppOrder ignores it while the app is gone
-            // and restores its position if it comes back.
-            if ( removesTile ) {
-                self._apps = self._apps.filter(a => a.name !== appName);
-                self.renderApps($el_window, { preservePage: true, instant: true });
-            }
-            // Keep the user's page and skip the load fade — this is a
-            // background sync, not a fresh visit.
-            self.loadApps($el_window, { preservePage: true, instant: true });
+            self._apps = self._apps.filter(a => a.name !== appName);
+            self.renderApps($el_window, { preservePage: true, instant: true });
         } catch ( err ) {
             console.error('Failed to uninstall app:', err);
         }
@@ -316,12 +301,6 @@ const TabApps = {
             const appName = $(this).attr('data-app-name');
             const appTitle = $(this).attr('data-app-title');
             const appUid = $(this).attr('data-app-uid');
-            // Whether the tile disappears for good on uninstall (see
-            // _fetchAndRenderApps). Uninstall is still offered when it won't —
-            // it is the only UI path that revokes an app's permissions, and
-            // recommended/recent apps need that path too; the modal just sets
-            // the expectation that their tile stays.
-            const removesTile = $(this).attr('data-app-uninstallable') === '1';
             const noUninstall = APP_NAMES_NO_UNINSTALL.has((appName || '').toLowerCase());
 
             const items = noUninstall
@@ -334,7 +313,6 @@ const TabApps = {
                                 appName,
                                 appTitle,
                                 appUid,
-                                removesTile,
                                 self,
                                 $el_window,
                             });
@@ -982,7 +960,7 @@ const TabApps = {
         }
     },
 
-    loadApps ($el_window, renderOpts) {
+    loadApps ($el_window) {
         if ( this._drag ) {
             // Don't fetch/re-render on top of a live drag; cancel a pending
             // (not-yet-started) pickup so a rebuild can't strand it.
@@ -992,14 +970,14 @@ const TabApps = {
         // init and the initial-route onActivate both fire on open; join the
         // in-flight load instead of issuing a duplicate request trio.
         if ( this._loadPromise ) return this._loadPromise;
-        const p = this._fetchAndRenderApps($el_window, renderOpts).finally(() => {
+        const p = this._fetchAndRenderApps($el_window).finally(() => {
             if ( this._loadPromise === p ) this._loadPromise = null;
         });
         this._loadPromise = p;
         return p;
     },
 
-    async _fetchAndRenderApps ($el_window, renderOpts = {}) {
+    async _fetchAndRenderApps ($el_window) {
         // Give each load a monotonically increasing id. An older/slower
         // response must not clobber a newer one that already applied — or a
         // reorder the user saved while a stale fetch was in flight. We gate on
@@ -1082,29 +1060,6 @@ const TabApps = {
                 iconUrl: app.iconUrl || app.icon || null,
             }));
 
-            // Whether an uninstall makes the tile disappear for good: apps the
-            // user actually installed that are in NEITHER launch list.
-            // revokeApp still revokes permissions for the others, but
-            // get-launch-apps re-adds their tiles on the next load — the
-            // recommended list is hardcoded and the recent list is built from
-            // app-open history, which a revoke doesn't touch. The context menu
-            // uses this flag to set expectations in the modal (see
-            // showUninstallModal), not to withhold the action.
-            const recommendedNames = new Set(
-                (launchData.recommended || []).map(a => a.name),
-            );
-            const recentNames = new Set(
-                (launchData.recent || []).map(a => a.name),
-            );
-            const installedNames = new Set(
-                (Array.isArray(installedApps) ? installedApps : []).map(a => a.name),
-            );
-            const isUninstallable = name =>
-                installedNames.has(name)
-                && ! recommendedNames.has(name)
-                && ! recentNames.has(name)
-                && ! APP_NAMES_NO_UNINSTALL.has((name || '').toLowerCase());
-
             // Build seen set from launch apps
             const seen = new Set();
             const merged = [];
@@ -1112,22 +1067,22 @@ const TabApps = {
             for ( const app of launchApps ) {
                 if ( seen.has(app.name) ) continue;
                 seen.add(app.name);
-                merged.push({ ...app, uninstallable: isUninstallable(app.name) });
+                merged.push(app);
             }
 
             // Append installed apps that aren't already in the list
             for ( const app of installedApps ) {
                 if ( seen.has(app.name) ) continue;
                 seen.add(app.name);
-                merged.push({ ...app, uninstallable: isUninstallable(app.name) });
+                merged.push(app);
             }
 
             // A page beyond the first failed: fill the gap with apps we
-            // already know about (keeping their previous uninstallable flags)
-            // so one flaky request among N can't make apps vanish from the
-            // grid, from search, or from a subsequently saved order. Apps
-            // uninstalled remotely may linger until the next complete
-            // refresh — the same staleness any between-refresh window has.
+            // already know about so one flaky request among N can't make
+            // apps vanish from the grid, from search, or from a subsequently
+            // saved order. Apps uninstalled remotely may linger until the
+            // next complete refresh — the same staleness any between-refresh
+            // window has.
             if ( ! installedResult.complete && Array.isArray(this._apps) ) {
                 for ( const app of this._apps ) {
                     if ( seen.has(app.name) ) continue;
@@ -1170,7 +1125,7 @@ const TabApps = {
             this._hasCustomOrder = Array.isArray(effectiveOrder) && effectiveOrder.length > 0;
 
             this._apps = reconcileAppOrder(merged, effectiveOrder);
-            this.renderApps($el_window, renderOpts);
+            this.renderApps($el_window);
         } catch (e) {
             console.error('Failed to load installed apps:', e);
             // Only show the failure placeholder when nothing has loaded yet; a

--- a/src/gui/src/UI/Dashboard/TabApps.js
+++ b/src/gui/src/UI/Dashboard/TabApps.js
@@ -905,6 +905,15 @@ const TabApps = {
             this._endDrag(false);
         }
 
+        // Give each load a monotonically increasing id. Concurrent loads are
+        // routine (init + initial-route onActivate both fire on open); an
+        // older/slower response must not clobber a newer one that already
+        // applied — or a reorder the user saved while a stale fetch was in
+        // flight. We gate on "already applied", not "latest started", so the
+        // first load to resolve still populates _apps (the pager's
+        // ResizeObserver needs _apps set as soon as any load resolves).
+        const loadSeq = (this._loadSeq = (this._loadSeq || 0) + 1);
+
         const $container = $el_window.find('.myapps-container');
 
         try {
@@ -988,13 +997,24 @@ const TabApps = {
             } catch ( _e ) {
                 orderedNames = null;
             }
+            // Skip only if a strictly newer load already applied its result, or
+            // a drag began while we were awaiting (rendering would yank the grid
+            // out from under it).
+            if ( loadSeq < (this._appliedSeq || 0) ) return;
+            if ( this._drag?.started ) return;
+            this._appliedSeq = loadSeq;
+
             this._hasCustomOrder = Array.isArray(orderedNames) && orderedNames.length > 0;
 
             this._apps = reconcileAppOrder(merged, orderedNames);
             this.renderApps($el_window);
         } catch (e) {
             console.error('Failed to load installed apps:', e);
-            $container.html('<div class="myapps-empty"><p>Failed to load apps</p></div>');
+            // Only show the failure placeholder when nothing has loaded yet; a
+            // transient re-fetch error must not wipe a grid already on screen.
+            if ( ! this._apps ) {
+                $container.html('<div class="myapps-empty"><p>Failed to load apps</p></div>');
+            }
         }
     },
 

--- a/src/gui/src/UI/Dashboard/TabApps.js
+++ b/src/gui/src/UI/Dashboard/TabApps.js
@@ -243,6 +243,7 @@ const TabApps = {
     _loadPromise: null,
     _pendingLoad: null,
     _savedOrderNames: null,
+    _orderSavedAtSeq: 0,
 
     html () {
         let h = '<div class="dashboard-tab-content myapps-tab">';
@@ -916,9 +917,9 @@ const TabApps = {
     },
 
     // A load that resolved mid-drag was stashed rather than rendered (see
-    // _fetchAndRenderApps). Apply it now, reconciled against the on-screen
-    // order the drag just produced — re-fetching or replaying the fetched kv
-    // order here could undo a reorder whose save is still in flight.
+    // _fetchAndRenderApps). Apply it now; _resolveOrderNames picks between
+    // the canonical in-memory saved order and the kv snapshot this load
+    // fetched, based on which is fresher.
     _applyPendingLoad () {
         const pending = this._pendingLoad;
         if ( ! pending ) return;
@@ -926,19 +927,25 @@ const TabApps = {
         if ( pending.loadSeq < (this._appliedSeq || 0) ) return;
         this._appliedSeq = pending.loadSeq;
 
-        // The drag that deferred this load may have just saved a newer order;
-        // _savedOrderNames tracks the canonical saved list (saveOrder keeps
-        // it merged, with hidden apps at their ranks). Prefer it over the kv
-        // snapshot the stashed load fetched — that may predate the drag — and
-        // never reconcile against the visible-only on-screen order, which
-        // would tail-append any app returning to the grid.
-        const orderedNames = this._hasCustomOrder && Array.isArray(this._savedOrderNames)
-            ? this._savedOrderNames
-            : pending.orderedNames;
+        const orderedNames = this._resolveOrderNames(pending.loadSeq, pending.orderedNames);
         this._savedOrderNames = orderedNames;
         this._hasCustomOrder = Array.isArray(orderedNames) && orderedNames.length > 0;
         this._apps = reconcileAppOrder(pending.merged, orderedNames);
         this.renderApps(pending.$el_window, { preservePage: true, instant: true });
+    },
+
+    // Decide which saved-order snapshot a resolving load reconciles against.
+    // A fetch issued before the user's latest local order save carries a
+    // pre-save kv snapshot — replaying it would visibly revert the reorder,
+    // and permanently clobber it after the next save. A fetch issued after
+    // the save is at least as fresh and may carry a newer arrangement from
+    // another window, so it wins. Never resolve to the visible-only
+    // on-screen order: it would tail-append any app returning to the grid.
+    _resolveOrderNames (loadSeq, fetchedOrderNames) {
+        const fetchedBeforeSave = loadSeq <= (this._orderSavedAtSeq || 0);
+        return fetchedBeforeSave && Array.isArray(this._savedOrderNames)
+            ? this._savedOrderNames
+            : fetchedOrderNames;
     },
 
     // A local mutation of _apps (uninstall) must invalidate loads fetched
@@ -961,6 +968,10 @@ const TabApps = {
         // reconcileAppOrder ignores them.
         const names = mergeSavedOrder(serializeAppOrder(this._apps), this._savedOrderNames);
         this._savedOrderNames = names;
+        // Loads already in flight fetched kv before this save; mark the
+        // boundary so their stale snapshot can't replay over it (see
+        // _resolveOrderNames).
+        this._orderSavedAtSeq = this._loadSeq || 0;
         try {
             const p = puter.kv.set(APPS_ORDER_KV_KEY, JSON.stringify(names));
             if ( p && typeof p.catch === 'function' ) {
@@ -1150,11 +1161,15 @@ const TabApps = {
             }
             this._pendingLoad = null;
             this._appliedSeq = loadSeq;
-            this._savedOrderNames = orderedNames;
+            // A drag may have started AND committed while this load was in
+            // flight; _resolveOrderNames keeps its saved reorder from being
+            // replayed over by this load's pre-save kv snapshot.
+            const effectiveOrder = this._resolveOrderNames(loadSeq, orderedNames);
+            this._savedOrderNames = effectiveOrder;
 
-            this._hasCustomOrder = Array.isArray(orderedNames) && orderedNames.length > 0;
+            this._hasCustomOrder = Array.isArray(effectiveOrder) && effectiveOrder.length > 0;
 
-            this._apps = reconcileAppOrder(merged, orderedNames);
+            this._apps = reconcileAppOrder(merged, effectiveOrder);
             this.renderApps($el_window, renderOpts);
         } catch (e) {
             console.error('Failed to load installed apps:', e);

--- a/src/gui/src/UI/Dashboard/TabApps.js
+++ b/src/gui/src/UI/Dashboard/TabApps.js
@@ -165,11 +165,11 @@ function showUninstallModal ({ appName, appTitle, appUid, self, $el_window }) {
             await puter.perms.revokeApp(appUid, '*');
             // A load fetched before the revoke must not apply — it would
             // resurrect the pre-revoke grid. No refetch here either: the
-            // recommended/recent launch lists don't know about the revoke,
-            // so an immediate reload would just re-add the tile. The saved
-            // order intentionally keeps the app's name: reconcileAppOrder
-            // ignores it while the app is gone and restores its position if
-            // it comes back.
+            // recommended launch list doesn't know about the revoke, so an
+            // immediate reload would just re-add a recommended app's tile.
+            // The saved order intentionally keeps the app's name:
+            // reconcileAppOrder ignores it while the app is gone and
+            // restores its position if it comes back.
             self._invalidateInFlightLoads();
             self._apps = self._apps.filter(a => a.name !== appName);
             self.renderApps($el_window, { preservePage: true, instant: true });
@@ -1047,11 +1047,13 @@ const TabApps = {
             const installedApps = installedResult.apps;
             const launchData = await launchRes.json();
 
-            // Normalize launch apps (recommended + recent) to same shape
-            const launchApps = [
-                ...(launchData.recommended || []),
-                ...(launchData.recent || []),
-            ].map(app => ({
+            // Normalize recommended launch apps to the tile shape. The
+            // recent list is deliberately unused: recents are open history,
+            // not installs, so they resurrected uninstalled apps' tiles and
+            // showed merely-visited sites as if installed. Anything the user
+            // actually uses appears via installedApps (opening an app grants
+            // it a permission). Recents still power the Home tab.
+            const launchApps = (launchData.recommended || []).map(app => ({
                 name: app.name,
                 title: app.title,
                 uid: app.uuid || app.uid || null,

--- a/src/gui/src/UI/Dashboard/TabApps.js
+++ b/src/gui/src/UI/Dashboard/TabApps.js
@@ -171,19 +171,21 @@ function showUninstallModal ({ appName, appTitle, appUid, removesTile, self, $el
 
         try {
             await puter.perms.revokeApp(appUid, '*');
-            // Only drop the tile when the uninstall sticks — a recommended/
-            // recent app comes back on the next get-launch-apps load, so
-            // removing it here would just look like a broken flicker.
+            // A load fetched before the revoke must not apply — it would
+            // resurrect the pre-revoke grid.
+            self._invalidateInFlightLoads();
+            // Drop the tile right away when we expect the uninstall to stick
+            // (immediate feedback) — but whether it really disappears depends
+            // on server-side state (recommended/recent lists) that load-time
+            // flags can only guess at, so refetch either way and let the grid
+            // converge to the truth. The saved order intentionally keeps the
+            // app's name: reconcileAppOrder ignores it while the app is gone
+            // and restores its position if it comes back.
             if ( removesTile ) {
                 self._apps = self._apps.filter(a => a.name !== appName);
-                // Keep the persisted order free of the now-uninstalled app, but
-                // only if the user already has a custom order (don't create one).
-                if ( self._hasCustomOrder ) self.saveOrder();
-                // A load fetched before the revoke must not apply — it would
-                // pop the just-removed tile back in.
-                self._invalidateInFlightLoads();
                 self.renderApps($el_window, { preservePage: true });
             }
+            self.loadApps($el_window);
         } catch ( err ) {
             console.error('Failed to uninstall app:', err);
         }
@@ -238,7 +240,7 @@ const TabApps = {
     _reduceMotionMQL: undefined,
     _loadPromise: null,
     _pendingLoad: null,
-    _partialLoad: false,
+    _savedOrderNames: null,
 
     html () {
         let h = '<div class="dashboard-tab-content myapps-tab">';
@@ -291,15 +293,6 @@ const TabApps = {
                 window.open(targetLink, '_blank', 'noopener,noreferrer');
             } else if ( appName ) {
                 window.open(`/app/${appName}`, '_blank', 'noopener,noreferrer');
-                // Opening records an app-open, which puts this app in the
-                // server-side recent list — from now on a revoke leaves the
-                // tile in place (see isUninstallable in _fetchAndRenderApps).
-                // Flip the flag now so the uninstall modal doesn't act on a
-                // stale load-time snapshot and remove a tile that will
-                // silently reappear.
-                const app = (self._apps || []).find(a => a.name === appName);
-                if ( app ) app.uninstallable = false;
-                $(this).attr('data-app-uninstallable', '0');
             }
         });
 
@@ -930,7 +923,7 @@ const TabApps = {
         this._pendingLoad = null;
         if ( pending.loadSeq < (this._appliedSeq || 0) ) return;
         this._appliedSeq = pending.loadSeq;
-        this._partialLoad = pending.partial;
+        this._savedOrderNames = pending.orderedNames;
 
         const orderedNames = this._hasCustomOrder && Array.isArray(this._apps)
             ? serializeAppOrder(this._apps)
@@ -953,15 +946,19 @@ const TabApps = {
 
     saveOrder () {
         this._hasCustomOrder = true;
-        // Never persist an order backed by a partial app list — the saved
-        // order is the only record of the missing apps' positions, and
-        // overwriting it would drop them for good. The in-session order still
-        // applies; the next complete load can persist again.
-        if ( this._partialLoad ) {
-            console.warn('App order not saved: the installed-apps list is incomplete (a page failed to load).');
-            return;
-        }
         const names = serializeAppOrder(this._apps);
+        // Carry over saved names that aren't in the current list (e.g. apps
+        // whose installedApps page failed to load this session): the saved
+        // order is the only record of their positions, so dropping them would
+        // lose those for good, while stale names are harmless —
+        // reconcileAppOrder ignores them.
+        if ( Array.isArray(this._savedOrderNames) ) {
+            const have = new Set(names);
+            for ( const name of this._savedOrderNames ) {
+                if ( ! have.has(name) ) names.push(name);
+            }
+        }
+        this._savedOrderNames = names;
         try {
             const p = puter.kv.set(APPS_ORDER_KV_KEY, JSON.stringify(names));
             if ( p && typeof p.catch === 'function' ) {
@@ -1000,11 +997,6 @@ const TabApps = {
 
         const $container = $el_window.find('.myapps-container');
 
-        // Whether the installed-apps list came back incomplete (a page beyond
-        // the first failed). A partial list may render when the grid is empty,
-        // but must never be persisted (see saveOrder).
-        let installedAppsPartial = false;
-
         try {
             // Fetch the two app lists and the saved order together. The
             // installedApps endpoint caps `limit` at 100 and paginates, so page
@@ -1036,22 +1028,20 @@ const TabApps = {
                         if ( batch.length < PAGE_SIZE ) break;
                     } catch ( err ) {
                         // A first-page failure is a failed load. A later page
-                        // failing must not discard the pages already fetched —
-                        // that would turn one flaky request among N into an
-                        // empty grid — but a partial list is only better than
-                        // nothing: it must never REPLACE a complete grid
-                        // already on screen, so fail the refresh in that case
-                        // (the outer catch preserves what's showing).
-                        if ( page === 1 || this._apps ) throw err;
-                        console.error(`Failed to fetch installedApps page ${page}; showing the ${all.length} apps fetched so far:`, err);
-                        installedAppsPartial = true;
-                        break;
+                        // failing must not fail the refresh — that would turn
+                        // one flaky request among N into an empty (or frozen)
+                        // grid. Return what we have and flag it incomplete;
+                        // the merge below fills the gap from the previous
+                        // list so the grid and saved order can't shrink.
+                        if ( page === 1 ) throw err;
+                        console.error(`Failed to fetch installedApps page ${page}; got ${all.length} apps before the failure:`, err);
+                        return { apps: all, complete: false };
                     }
                 }
-                return all;
+                return { apps: all, complete: true };
             };
 
-            const [installedApps, launchRes, savedOrderRaw] = await Promise.all([
+            const [installedResult, launchRes, savedOrderRaw] = await Promise.all([
                 fetchAllInstalledApps(),
                 fetch(
                     `${window.api_origin}/get-launch-apps?icon_size=128`,
@@ -1063,6 +1053,7 @@ const TabApps = {
                 puter.kv.get(APPS_ORDER_KV_KEY).catch(() => null),
             ]);
 
+            const installedApps = installedResult.apps;
             const launchData = await launchRes.json();
 
             // Normalize launch apps (recommended + recent) to same shape
@@ -1118,6 +1109,20 @@ const TabApps = {
                 merged.push({ ...app, uninstallable: isUninstallable(app.name) });
             }
 
+            // A page beyond the first failed: fill the gap with apps we
+            // already know about (keeping their previous uninstallable flags)
+            // so one flaky request among N can't make apps vanish from the
+            // grid, from search, or from a subsequently saved order. Apps
+            // uninstalled remotely may linger until the next complete
+            // refresh — the same staleness any between-refresh window has.
+            if ( ! installedResult.complete && Array.isArray(this._apps) ) {
+                for ( const app of this._apps ) {
+                    if ( seen.has(app.name) ) continue;
+                    seen.add(app.name);
+                    merged.push({ ...app });
+                }
+            }
+
             // Overlay the user's saved ordering (if any). New apps are appended
             // in their default order; stale names are ignored.
             let orderedNames = null;
@@ -1137,13 +1142,13 @@ const TabApps = {
             // away either — stash it for _endDrag to apply.
             if ( this._drag?.started ) {
                 if ( ! this._pendingLoad || loadSeq > this._pendingLoad.loadSeq ) {
-                    this._pendingLoad = { $el_window, merged, orderedNames, loadSeq, partial: installedAppsPartial };
+                    this._pendingLoad = { $el_window, merged, orderedNames, loadSeq };
                 }
                 return;
             }
             this._pendingLoad = null;
             this._appliedSeq = loadSeq;
-            this._partialLoad = installedAppsPartial;
+            this._savedOrderNames = orderedNames;
 
             this._hasCustomOrder = Array.isArray(orderedNames) && orderedNames.length > 0;
 

--- a/src/gui/src/UI/Dashboard/TabApps.js
+++ b/src/gui/src/UI/Dashboard/TabApps.js
@@ -917,15 +917,33 @@ const TabApps = {
         const $container = $el_window.find('.myapps-container');
 
         try {
-            // Fetch the two app lists and the saved order together.
-            const [installedRes, launchRes, savedOrderRaw] = await Promise.all([
-                fetch(
-                    `${window.api_origin}/installedApps?orderBy=name&limit=100`,
-                    {
-                        headers: { 'Authorization': `Bearer ${puter.authToken}` },
-                        method: 'GET',
-                    },
-                ),
+            // Fetch the two app lists and the saved order together. The
+            // installedApps endpoint caps `limit` at 100 and paginates, so page
+            // through it — otherwise a user with >100 apps silently loses the
+            // rest from the grid and from search. Common case is a single page
+            // (a short page ends the loop before a second request).
+            const fetchAllInstalledApps = async () => {
+                const PAGE_SIZE = 100;
+                const MAX_PAGES = 50; // 5000 apps — a runaway backstop
+                const all = [];
+                for ( let page = 1; page <= MAX_PAGES; page++ ) {
+                    const res = await fetch(
+                        `${window.api_origin}/installedApps?orderBy=name&limit=${PAGE_SIZE}&page=${page}`,
+                        {
+                            headers: { 'Authorization': `Bearer ${puter.authToken}` },
+                            method: 'GET',
+                        },
+                    );
+                    const batch = await res.json();
+                    if ( ! Array.isArray(batch) || batch.length === 0 ) break;
+                    all.push(...batch);
+                    if ( batch.length < PAGE_SIZE ) break;
+                }
+                return all;
+            };
+
+            const [installedApps, launchRes, savedOrderRaw] = await Promise.all([
+                fetchAllInstalledApps(),
                 fetch(
                     `${window.api_origin}/get-launch-apps?icon_size=128`,
                     {
@@ -936,7 +954,6 @@ const TabApps = {
                 puter.kv.get(APPS_ORDER_KV_KEY).catch(() => null),
             ]);
 
-            const installedApps = await installedRes.json();
             const launchData = await launchRes.json();
 
             // Normalize launch apps (recommended + recent) to same shape

--- a/src/gui/src/UI/Dashboard/TabApps.js
+++ b/src/gui/src/UI/Dashboard/TabApps.js
@@ -73,7 +73,7 @@ function buildTileHtml (app) {
     const { title, targetLink } = resolveTileDisplay(app);
     const iconUrl = app.iconUrl || window.icons['app.svg'];
 
-    let h = `<div class="myapps-tile" data-app-name="${html_encode(app.name)}" data-app-title="${html_encode(title)}" data-app-uid="${html_encode(app.uid || '')}" data-target-link="${html_encode(targetLink)}" title="${html_encode(title)}">`;
+    let h = `<div class="myapps-tile" data-app-name="${html_encode(app.name)}" data-app-title="${html_encode(title)}" data-app-uid="${html_encode(app.uid || '')}" data-target-link="${html_encode(targetLink)}" data-app-uninstallable="${app.uninstallable ? '1' : '0'}" title="${html_encode(title)}">`;
     h += '<div class="myapps-tile-icon">';
     h += `<img src="${html_encode(iconUrl)}" alt="" draggable="false">`;
     h += '</div>';
@@ -292,10 +292,10 @@ const TabApps = {
             const appName = $(this).attr('data-app-name');
             const appTitle = $(this).attr('data-app-title');
             const appUid = $(this).attr('data-app-uid');
-            const nameLower = (appName || '').toLowerCase();
-            const noUninstall = APP_NAMES_NO_UNINSTALL.has(nameLower);
+            // Only offer Uninstall when it will actually stick (see loadApps).
+            const canUninstall = $(this).attr('data-app-uninstallable') === '1';
 
-            const items = noUninstall
+            const items = ! canUninstall
                 ? []
                 : [
                     {
@@ -943,6 +943,22 @@ const TabApps = {
                 iconUrl: app.iconUrl || app.icon || null,
             }));
 
+            // Uninstall only sticks for apps the user actually installed that
+            // are NOT in the hardcoded recommended list — revokeApp on a
+            // recommended app does nothing lasting because get-launch-apps
+            // re-adds it on the next load, so the tile "comes back" and the
+            // uninstall looks broken. Compute installability against both lists.
+            const recommendedNames = new Set(
+                (launchData.recommended || []).map(a => a.name),
+            );
+            const installedNames = new Set(
+                (Array.isArray(installedApps) ? installedApps : []).map(a => a.name),
+            );
+            const isUninstallable = name =>
+                installedNames.has(name)
+                && ! recommendedNames.has(name)
+                && ! APP_NAMES_NO_UNINSTALL.has((name || '').toLowerCase());
+
             // Build seen set from launch apps
             const seen = new Set();
             const merged = [];
@@ -950,14 +966,14 @@ const TabApps = {
             for ( const app of launchApps ) {
                 if ( seen.has(app.name) ) continue;
                 seen.add(app.name);
-                merged.push(app);
+                merged.push({ ...app, uninstallable: isUninstallable(app.name) });
             }
 
             // Append installed apps that aren't already in the list
             for ( const app of installedApps ) {
                 if ( seen.has(app.name) ) continue;
                 seen.add(app.name);
-                merged.push(app);
+                merged.push({ ...app, uninstallable: isUninstallable(app.name) });
             }
 
             // Overlay the user's saved ordering (if any). New apps are appended

--- a/src/gui/src/UI/Dashboard/TabApps.js
+++ b/src/gui/src/UI/Dashboard/TabApps.js
@@ -131,10 +131,11 @@ function showUninstallModal ({ appName, appTitle, appUid, removesTile, self, $el
     const displayName = (appTitle || appName || '').trim();
     // A recommended/recent app's tile reappears on the next load even after a
     // successful revoke; say so up front so the uninstall doesn't look like it
-    // silently failed.
+    // silently failed. (Recommended apps stay indefinitely; recent ones until
+    // they age out of the open history — don't claim more than that.)
     const note = removesTile
         ? ''
-        : '<p>This app is provided by Puter, so its icon will stay in Apps.</p>';
+        : '<p>Its icon will stay in Apps for now, because this app is in your recommended or recently used list.</p>';
     const $overlay = $(`
         <div class="myapps-modal-overlay">
             <div class="myapps-modal">
@@ -178,6 +179,13 @@ function showUninstallModal ({ appName, appTitle, appUid, removesTile, self, $el
                 // Keep the persisted order free of the now-uninstalled app, but
                 // only if the user already has a custom order (don't create one).
                 if ( self._hasCustomOrder ) self.saveOrder();
+                // Mark any in-flight load stale: it fetched before the revoke,
+                // and applying it would pop the just-removed tile back in.
+                // Also stop sharing its promise, so the next activation
+                // fetches fresh instead of joining the doomed load.
+                self._loadSeq = (self._loadSeq || 0) + 1;
+                self._appliedSeq = self._loadSeq;
+                self._loadPromise = null;
                 self.renderApps($el_window, { preservePage: true });
             }
         } catch ( err ) {
@@ -977,23 +985,33 @@ const TabApps = {
                 const MAX_PAGES = 50; // 5000 apps — a runaway backstop
                 const all = [];
                 for ( let page = 1; page <= MAX_PAGES; page++ ) {
-                    const res = await fetch(
-                        `${window.api_origin}/installedApps?orderBy=name&limit=${PAGE_SIZE}&page=${page}`,
-                        {
-                            headers: { 'Authorization': `Bearer ${puter.authToken}` },
-                            method: 'GET',
-                        },
-                    );
-                    const batch = await res.json();
-                    // An error payload (e.g. `{"error": ...}` on a 401/500) must
-                    // fail the whole load — reading it as end-of-pagination would
-                    // silently render the grid without any installed apps.
-                    if ( ! Array.isArray(batch) ) {
-                        throw new Error(`installedApps returned a non-array response (status ${res.status})`);
+                    try {
+                        const res = await fetch(
+                            `${window.api_origin}/installedApps?orderBy=name&limit=${PAGE_SIZE}&page=${page}`,
+                            {
+                                headers: { 'Authorization': `Bearer ${puter.authToken}` },
+                                method: 'GET',
+                            },
+                        );
+                        const batch = await res.json();
+                        // An error payload (e.g. `{"error": ...}` on a 401/500)
+                        // must fail the page — reading it as end-of-pagination
+                        // would silently drop every installed app.
+                        if ( ! Array.isArray(batch) ) {
+                            throw new Error(`installedApps returned a non-array response (status ${res.status})`);
+                        }
+                        if ( batch.length === 0 ) break;
+                        all.push(...batch);
+                        if ( batch.length < PAGE_SIZE ) break;
+                    } catch ( err ) {
+                        // A first-page failure is a failed load. A later page
+                        // failing must not discard the pages already fetched —
+                        // that would turn one flaky request among N into an
+                        // empty grid (the single-request load never had that).
+                        if ( page === 1 ) throw err;
+                        console.error(`Failed to fetch installedApps page ${page}; showing the ${all.length} apps fetched so far:`, err);
+                        break;
                     }
-                    if ( batch.length === 0 ) break;
-                    all.push(...batch);
-                    if ( batch.length < PAGE_SIZE ) break;
                 }
                 return all;
             };
@@ -1026,13 +1044,18 @@ const TabApps = {
             }));
 
             // Whether an uninstall makes the tile disappear for good: apps the
-            // user actually installed that are NOT in the hardcoded recommended
-            // list. revokeApp on a recommended app still revokes permissions,
-            // but get-launch-apps re-adds the tile on the next load — the
-            // context menu uses this flag to set expectations in the modal
-            // (see showUninstallModal), not to withhold the action.
+            // user actually installed that are in NEITHER launch list.
+            // revokeApp still revokes permissions for the others, but
+            // get-launch-apps re-adds their tiles on the next load — the
+            // recommended list is hardcoded and the recent list is built from
+            // app-open history, which a revoke doesn't touch. The context menu
+            // uses this flag to set expectations in the modal (see
+            // showUninstallModal), not to withhold the action.
             const recommendedNames = new Set(
                 (launchData.recommended || []).map(a => a.name),
+            );
+            const recentNames = new Set(
+                (launchData.recent || []).map(a => a.name),
             );
             const installedNames = new Set(
                 (Array.isArray(installedApps) ? installedApps : []).map(a => a.name),
@@ -1040,6 +1063,7 @@ const TabApps = {
             const isUninstallable = name =>
                 installedNames.has(name)
                 && ! recommendedNames.has(name)
+                && ! recentNames.has(name)
                 && ! APP_NAMES_NO_UNINSTALL.has((name || '').toLowerCase());
 
             // Build seen set from launch apps

--- a/src/gui/src/UI/Dashboard/TabApps.js
+++ b/src/gui/src/UI/Dashboard/TabApps.js
@@ -1,6 +1,6 @@
 import UIContextMenu from '../UIContextMenu.js';
 import { isTouchPrimaryDevice } from './ContextMenu/ContextMenu.js';
-import { reconcileAppOrder, serializeAppOrder, APPS_ORDER_KV_KEY } from './appOrder.js';
+import { reconcileAppOrder, serializeAppOrder, mergeSavedOrder, APPS_ORDER_KV_KEY } from './appOrder.js';
 
 /** Lowercase app names that must not offer Uninstall in the My Apps tile context menu. */
 const APP_NAMES_NO_UNINSTALL = new Set([
@@ -185,7 +185,9 @@ function showUninstallModal ({ appName, appTitle, appUid, removesTile, self, $el
                 self._apps = self._apps.filter(a => a.name !== appName);
                 self.renderApps($el_window, { preservePage: true });
             }
-            self.loadApps($el_window);
+            // Keep the user's page and skip the load fade — this is a
+            // background sync, not a fresh visit.
+            self.loadApps($el_window, { preservePage: true, instant: true });
         } catch ( err ) {
             console.error('Failed to uninstall app:', err);
         }
@@ -946,18 +948,12 @@ const TabApps = {
 
     saveOrder () {
         this._hasCustomOrder = true;
-        const names = serializeAppOrder(this._apps);
-        // Carry over saved names that aren't in the current list (e.g. apps
-        // whose installedApps page failed to load this session): the saved
-        // order is the only record of their positions, so dropping them would
-        // lose those for good, while stale names are harmless —
+        // Merge with the previously saved order so names absent from the
+        // current list (e.g. apps whose installedApps page failed to load
+        // this session) keep their saved positions — the saved order is the
+        // only record of them, and stale names are harmless because
         // reconcileAppOrder ignores them.
-        if ( Array.isArray(this._savedOrderNames) ) {
-            const have = new Set(names);
-            for ( const name of this._savedOrderNames ) {
-                if ( ! have.has(name) ) names.push(name);
-            }
-        }
+        const names = mergeSavedOrder(serializeAppOrder(this._apps), this._savedOrderNames);
         this._savedOrderNames = names;
         try {
             const p = puter.kv.set(APPS_ORDER_KV_KEY, JSON.stringify(names));
@@ -969,7 +965,7 @@ const TabApps = {
         }
     },
 
-    loadApps ($el_window) {
+    loadApps ($el_window, renderOpts) {
         if ( this._drag ) {
             // Don't fetch/re-render on top of a live drag; cancel a pending
             // (not-yet-started) pickup so a rebuild can't strand it.
@@ -979,14 +975,14 @@ const TabApps = {
         // init and the initial-route onActivate both fire on open; join the
         // in-flight load instead of issuing a duplicate request trio.
         if ( this._loadPromise ) return this._loadPromise;
-        const p = this._fetchAndRenderApps($el_window).finally(() => {
+        const p = this._fetchAndRenderApps($el_window, renderOpts).finally(() => {
             if ( this._loadPromise === p ) this._loadPromise = null;
         });
         this._loadPromise = p;
         return p;
     },
 
-    async _fetchAndRenderApps ($el_window) {
+    async _fetchAndRenderApps ($el_window, renderOpts = {}) {
         // Give each load a monotonically increasing id. An older/slower
         // response must not clobber a newer one that already applied — or a
         // reorder the user saved while a stale fetch was in flight. We gate on
@@ -1153,7 +1149,7 @@ const TabApps = {
             this._hasCustomOrder = Array.isArray(orderedNames) && orderedNames.length > 0;
 
             this._apps = reconcileAppOrder(merged, orderedNames);
-            this.renderApps($el_window);
+            this.renderApps($el_window, renderOpts);
         } catch (e) {
             console.error('Failed to load installed apps:', e);
             // Only show the failure placeholder when nothing has loaded yet; a

--- a/src/gui/src/UI/Dashboard/TabApps.js
+++ b/src/gui/src/UI/Dashboard/TabApps.js
@@ -127,13 +127,20 @@ function buildPagerHtml (apps, layout, instant) {
     return h;
 }
 
-function showUninstallModal ({ appName, appTitle, appUid, self, $el_window }) {
+function showUninstallModal ({ appName, appTitle, appUid, removesTile, self, $el_window }) {
     const displayName = (appTitle || appName || '').trim();
+    // A recommended/recent app's tile reappears on the next load even after a
+    // successful revoke; say so up front so the uninstall doesn't look like it
+    // silently failed.
+    const note = removesTile
+        ? ''
+        : '<p>This app is provided by Puter, so its icon will stay in Apps.</p>';
     const $overlay = $(`
         <div class="myapps-modal-overlay">
             <div class="myapps-modal">
                 <h3>Uninstall ${html_encode(displayName)}?</h3>
                 <p>This will revoke all permissions for this app.</p>
+                ${note}
                 <div class="myapps-modal-buttons">
                     <button class="myapps-modal-btn myapps-modal-cancel">Cancel</button>
                     <button class="myapps-modal-btn myapps-modal-confirm">Uninstall</button>
@@ -163,11 +170,16 @@ function showUninstallModal ({ appName, appTitle, appUid, self, $el_window }) {
 
         try {
             await puter.perms.revokeApp(appUid, '*');
-            self._apps = self._apps.filter(a => a.name !== appName);
-            // Keep the persisted order free of the now-uninstalled app, but
-            // only if the user already has a custom order (don't create one).
-            if ( self._hasCustomOrder ) self.saveOrder();
-            self.renderApps($el_window, { preservePage: true });
+            // Only drop the tile when the uninstall sticks — a recommended/
+            // recent app comes back on the next get-launch-apps load, so
+            // removing it here would just look like a broken flicker.
+            if ( removesTile ) {
+                self._apps = self._apps.filter(a => a.name !== appName);
+                // Keep the persisted order free of the now-uninstalled app, but
+                // only if the user already has a custom order (don't create one).
+                if ( self._hasCustomOrder ) self.saveOrder();
+                self.renderApps($el_window, { preservePage: true });
+            }
         } catch ( err ) {
             console.error('Failed to uninstall app:', err);
         }
@@ -220,6 +232,8 @@ const TabApps = {
     _drag: null,
     _justDragged: false,
     _reduceMotionMQL: undefined,
+    _loadPromise: null,
+    _pendingLoad: null,
 
     html () {
         let h = '<div class="dashboard-tab-content myapps-tab">';
@@ -292,10 +306,15 @@ const TabApps = {
             const appName = $(this).attr('data-app-name');
             const appTitle = $(this).attr('data-app-title');
             const appUid = $(this).attr('data-app-uid');
-            // Only offer Uninstall when it will actually stick (see loadApps).
-            const canUninstall = $(this).attr('data-app-uninstallable') === '1';
+            // Whether the tile disappears for good on uninstall (see
+            // _fetchAndRenderApps). Uninstall is still offered when it won't —
+            // it is the only UI path that revokes an app's permissions, and
+            // recommended/recent apps need that path too; the modal just sets
+            // the expectation that their tile stays.
+            const removesTile = $(this).attr('data-app-uninstallable') === '1';
+            const noUninstall = APP_NAMES_NO_UNINSTALL.has((appName || '').toLowerCase());
 
-            const items = ! canUninstall
+            const items = noUninstall
                 ? []
                 : [
                     {
@@ -305,6 +324,7 @@ const TabApps = {
                                 appName,
                                 appTitle,
                                 appUid,
+                                removesTile,
                                 self,
                                 $el_window,
                             });
@@ -882,6 +902,27 @@ const TabApps = {
 
         // Rebuild so pages rebalance to exactly perPage; skip the load fade.
         this.renderApps(d.$el_window, { preservePage: true, instant: true });
+
+        this._applyPendingLoad();
+    },
+
+    // A load that resolved mid-drag was stashed rather than rendered (see
+    // _fetchAndRenderApps). Apply it now, reconciled against the on-screen
+    // order the drag just produced — re-fetching or replaying the fetched kv
+    // order here could undo a reorder whose save is still in flight.
+    _applyPendingLoad () {
+        const pending = this._pendingLoad;
+        if ( ! pending ) return;
+        this._pendingLoad = null;
+        if ( pending.loadSeq < (this._appliedSeq || 0) ) return;
+        this._appliedSeq = pending.loadSeq;
+
+        const orderedNames = this._hasCustomOrder && Array.isArray(this._apps)
+            ? serializeAppOrder(this._apps)
+            : pending.orderedNames;
+        this._hasCustomOrder = Array.isArray(orderedNames) && orderedNames.length > 0;
+        this._apps = reconcileAppOrder(pending.merged, orderedNames);
+        this.renderApps(pending.$el_window, { preservePage: true, instant: true });
     },
 
     saveOrder () {
@@ -897,21 +938,30 @@ const TabApps = {
         }
     },
 
-    async loadApps ($el_window) {
+    loadApps ($el_window) {
         if ( this._drag ) {
             // Don't fetch/re-render on top of a live drag; cancel a pending
             // (not-yet-started) pickup so a rebuild can't strand it.
             if ( this._drag.started ) return;
             this._endDrag(false);
         }
+        // init and the initial-route onActivate both fire on open; join the
+        // in-flight load instead of issuing a duplicate request trio.
+        if ( this._loadPromise ) return this._loadPromise;
+        const p = this._fetchAndRenderApps($el_window).finally(() => {
+            if ( this._loadPromise === p ) this._loadPromise = null;
+        });
+        this._loadPromise = p;
+        return p;
+    },
 
-        // Give each load a monotonically increasing id. Concurrent loads are
-        // routine (init + initial-route onActivate both fire on open); an
-        // older/slower response must not clobber a newer one that already
-        // applied — or a reorder the user saved while a stale fetch was in
-        // flight. We gate on "already applied", not "latest started", so the
-        // first load to resolve still populates _apps (the pager's
-        // ResizeObserver needs _apps set as soon as any load resolves).
+    async _fetchAndRenderApps ($el_window) {
+        // Give each load a monotonically increasing id. An older/slower
+        // response must not clobber a newer one that already applied — or a
+        // reorder the user saved while a stale fetch was in flight. We gate on
+        // "already applied", not "latest started", so the first load to
+        // resolve still populates _apps (the pager's ResizeObserver needs
+        // _apps set as soon as any load resolves).
         const loadSeq = (this._loadSeq = (this._loadSeq || 0) + 1);
 
         const $container = $el_window.find('.myapps-container');
@@ -935,7 +985,13 @@ const TabApps = {
                         },
                     );
                     const batch = await res.json();
-                    if ( ! Array.isArray(batch) || batch.length === 0 ) break;
+                    // An error payload (e.g. `{"error": ...}` on a 401/500) must
+                    // fail the whole load — reading it as end-of-pagination would
+                    // silently render the grid without any installed apps.
+                    if ( ! Array.isArray(batch) ) {
+                        throw new Error(`installedApps returned a non-array response (status ${res.status})`);
+                    }
+                    if ( batch.length === 0 ) break;
                     all.push(...batch);
                     if ( batch.length < PAGE_SIZE ) break;
                 }
@@ -969,11 +1025,12 @@ const TabApps = {
                 iconUrl: app.iconUrl || app.icon || null,
             }));
 
-            // Uninstall only sticks for apps the user actually installed that
-            // are NOT in the hardcoded recommended list — revokeApp on a
-            // recommended app does nothing lasting because get-launch-apps
-            // re-adds it on the next load, so the tile "comes back" and the
-            // uninstall looks broken. Compute installability against both lists.
+            // Whether an uninstall makes the tile disappear for good: apps the
+            // user actually installed that are NOT in the hardcoded recommended
+            // list. revokeApp on a recommended app still revokes permissions,
+            // but get-launch-apps re-adds the tile on the next load — the
+            // context menu uses this flag to set expectations in the modal
+            // (see showUninstallModal), not to withhold the action.
             const recommendedNames = new Set(
                 (launchData.recommended || []).map(a => a.name),
             );
@@ -1014,11 +1071,18 @@ const TabApps = {
             } catch ( _e ) {
                 orderedNames = null;
             }
-            // Skip only if a strictly newer load already applied its result, or
-            // a drag began while we were awaiting (rendering would yank the grid
-            // out from under it).
+            // Skip only if a strictly newer load already applied its result.
             if ( loadSeq < (this._appliedSeq || 0) ) return;
-            if ( this._drag?.started ) return;
+            // A drag began while we were awaiting: rendering now would yank
+            // the grid out from under it, but the data must not be thrown
+            // away either — stash it for _endDrag to apply.
+            if ( this._drag?.started ) {
+                if ( ! this._pendingLoad || loadSeq > this._pendingLoad.loadSeq ) {
+                    this._pendingLoad = { $el_window, merged, orderedNames, loadSeq };
+                }
+                return;
+            }
+            this._pendingLoad = null;
             this._appliedSeq = loadSeq;
 
             this._hasCustomOrder = Array.isArray(orderedNames) && orderedNames.length > 0;

--- a/src/gui/src/UI/Dashboard/TabApps.js
+++ b/src/gui/src/UI/Dashboard/TabApps.js
@@ -179,13 +179,9 @@ function showUninstallModal ({ appName, appTitle, appUid, removesTile, self, $el
                 // Keep the persisted order free of the now-uninstalled app, but
                 // only if the user already has a custom order (don't create one).
                 if ( self._hasCustomOrder ) self.saveOrder();
-                // Mark any in-flight load stale: it fetched before the revoke,
-                // and applying it would pop the just-removed tile back in.
-                // Also stop sharing its promise, so the next activation
-                // fetches fresh instead of joining the doomed load.
-                self._loadSeq = (self._loadSeq || 0) + 1;
-                self._appliedSeq = self._loadSeq;
-                self._loadPromise = null;
+                // A load fetched before the revoke must not apply — it would
+                // pop the just-removed tile back in.
+                self._invalidateInFlightLoads();
                 self.renderApps($el_window, { preservePage: true });
             }
         } catch ( err ) {
@@ -242,6 +238,7 @@ const TabApps = {
     _reduceMotionMQL: undefined,
     _loadPromise: null,
     _pendingLoad: null,
+    _partialLoad: false,
 
     html () {
         let h = '<div class="dashboard-tab-content myapps-tab">';
@@ -294,6 +291,15 @@ const TabApps = {
                 window.open(targetLink, '_blank', 'noopener,noreferrer');
             } else if ( appName ) {
                 window.open(`/app/${appName}`, '_blank', 'noopener,noreferrer');
+                // Opening records an app-open, which puts this app in the
+                // server-side recent list — from now on a revoke leaves the
+                // tile in place (see isUninstallable in _fetchAndRenderApps).
+                // Flip the flag now so the uninstall modal doesn't act on a
+                // stale load-time snapshot and remove a tile that will
+                // silently reappear.
+                const app = (self._apps || []).find(a => a.name === appName);
+                if ( app ) app.uninstallable = false;
+                $(this).attr('data-app-uninstallable', '0');
             }
         });
 
@@ -924,6 +930,7 @@ const TabApps = {
         this._pendingLoad = null;
         if ( pending.loadSeq < (this._appliedSeq || 0) ) return;
         this._appliedSeq = pending.loadSeq;
+        this._partialLoad = pending.partial;
 
         const orderedNames = this._hasCustomOrder && Array.isArray(this._apps)
             ? serializeAppOrder(this._apps)
@@ -933,8 +940,27 @@ const TabApps = {
         this.renderApps(pending.$el_window, { preservePage: true, instant: true });
     },
 
+    // A local mutation of _apps (uninstall) must invalidate loads fetched
+    // before it — applying one would resurrect the pre-mutation state. Loads
+    // started after this call get a newer seq and still apply. Dropping the
+    // shared promise lets the next activation fetch fresh instead of joining
+    // the doomed load.
+    _invalidateInFlightLoads () {
+        this._loadSeq = (this._loadSeq || 0) + 1;
+        this._appliedSeq = this._loadSeq;
+        this._loadPromise = null;
+    },
+
     saveOrder () {
         this._hasCustomOrder = true;
+        // Never persist an order backed by a partial app list — the saved
+        // order is the only record of the missing apps' positions, and
+        // overwriting it would drop them for good. The in-session order still
+        // applies; the next complete load can persist again.
+        if ( this._partialLoad ) {
+            console.warn('App order not saved: the installed-apps list is incomplete (a page failed to load).');
+            return;
+        }
         const names = serializeAppOrder(this._apps);
         try {
             const p = puter.kv.set(APPS_ORDER_KV_KEY, JSON.stringify(names));
@@ -974,6 +1000,11 @@ const TabApps = {
 
         const $container = $el_window.find('.myapps-container');
 
+        // Whether the installed-apps list came back incomplete (a page beyond
+        // the first failed). A partial list may render when the grid is empty,
+        // but must never be persisted (see saveOrder).
+        let installedAppsPartial = false;
+
         try {
             // Fetch the two app lists and the saved order together. The
             // installedApps endpoint caps `limit` at 100 and paginates, so page
@@ -1007,9 +1038,13 @@ const TabApps = {
                         // A first-page failure is a failed load. A later page
                         // failing must not discard the pages already fetched —
                         // that would turn one flaky request among N into an
-                        // empty grid (the single-request load never had that).
-                        if ( page === 1 ) throw err;
+                        // empty grid — but a partial list is only better than
+                        // nothing: it must never REPLACE a complete grid
+                        // already on screen, so fail the refresh in that case
+                        // (the outer catch preserves what's showing).
+                        if ( page === 1 || this._apps ) throw err;
                         console.error(`Failed to fetch installedApps page ${page}; showing the ${all.length} apps fetched so far:`, err);
+                        installedAppsPartial = true;
                         break;
                     }
                 }
@@ -1102,12 +1137,13 @@ const TabApps = {
             // away either — stash it for _endDrag to apply.
             if ( this._drag?.started ) {
                 if ( ! this._pendingLoad || loadSeq > this._pendingLoad.loadSeq ) {
-                    this._pendingLoad = { $el_window, merged, orderedNames, loadSeq };
+                    this._pendingLoad = { $el_window, merged, orderedNames, loadSeq, partial: installedAppsPartial };
                 }
                 return;
             }
             this._pendingLoad = null;
             this._appliedSeq = loadSeq;
+            this._partialLoad = installedAppsPartial;
 
             this._hasCustomOrder = Array.isArray(orderedNames) && orderedNames.length > 0;
 

--- a/src/gui/src/UI/Dashboard/TabApps.js
+++ b/src/gui/src/UI/Dashboard/TabApps.js
@@ -183,7 +183,7 @@ function showUninstallModal ({ appName, appTitle, appUid, removesTile, self, $el
             // and restores its position if it comes back.
             if ( removesTile ) {
                 self._apps = self._apps.filter(a => a.name !== appName);
-                self.renderApps($el_window, { preservePage: true });
+                self.renderApps($el_window, { preservePage: true, instant: true });
             }
             // Keep the user's page and skip the load fade — this is a
             // background sync, not a fresh visit.
@@ -925,11 +925,17 @@ const TabApps = {
         this._pendingLoad = null;
         if ( pending.loadSeq < (this._appliedSeq || 0) ) return;
         this._appliedSeq = pending.loadSeq;
-        this._savedOrderNames = pending.orderedNames;
 
-        const orderedNames = this._hasCustomOrder && Array.isArray(this._apps)
-            ? serializeAppOrder(this._apps)
+        // The drag that deferred this load may have just saved a newer order;
+        // _savedOrderNames tracks the canonical saved list (saveOrder keeps
+        // it merged, with hidden apps at their ranks). Prefer it over the kv
+        // snapshot the stashed load fetched — that may predate the drag — and
+        // never reconcile against the visible-only on-screen order, which
+        // would tail-append any app returning to the grid.
+        const orderedNames = this._hasCustomOrder && Array.isArray(this._savedOrderNames)
+            ? this._savedOrderNames
             : pending.orderedNames;
+        this._savedOrderNames = orderedNames;
         this._hasCustomOrder = Array.isArray(orderedNames) && orderedNames.length > 0;
         this._apps = reconcileAppOrder(pending.merged, orderedNames);
         this.renderApps(pending.$el_window, { preservePage: true, instant: true });

--- a/src/gui/src/UI/Dashboard/TabFiles.js
+++ b/src/gui/src/UI/Dashboard/TabFiles.js
@@ -2035,21 +2035,24 @@ const TabFiles = {
         row.setAttribute("data-is_dir", file.is_dir ? "1" : "0");
         row.setAttribute("data-is_trash", file.is_trash ? "1" : "0");
         row.setAttribute("data-has_website", file.has_website ? "1" : "0");
-        row.setAttribute("data-website_url", website_url ? html_encode(website_url) : '');
+        // setAttribute stores values literally (no HTML parsing), so values must
+        // stay raw — encoding here would leave e.g. `&amp;` inside data-path and
+        // break every fs operation that reads the attribute back.
+        row.setAttribute("data-website_url", website_url || '');
         row.setAttribute("data-immutable", file.immutable ? "1" : "0");
         row.setAttribute("data-is_shortcut", is_shortcut);
-        row.setAttribute("data-shortcut_to", html_encode(file.shortcut_to));
-        row.setAttribute("data-shortcut_to_path", html_encode(file.shortcut_to_path));
+        row.setAttribute("data-shortcut_to", file.shortcut_to ?? '');
+        row.setAttribute("data-shortcut_to_path", file.shortcut_to_path ?? '');
         row.setAttribute("data-is_worker", is_worker ? "1" : "0");
         row.setAttribute("data-worker_url", is_worker ? worker_url : "0");
         row.setAttribute("data-sortable", file.sortable ?? 'true');
         row.setAttribute("data-metadata", JSON.stringify(metadata));
-        row.setAttribute("data-sort_by", html_encode(file.sort_by) ?? 'name');
+        row.setAttribute("data-sort_by", file.sort_by ?? 'name');
         row.setAttribute("data-size", file.size);
-        row.setAttribute("data-type", html_encode(file.type) ?? '');
+        row.setAttribute("data-type", file.type ?? '');
         row.setAttribute("data-modified", file.modified);
-        row.setAttribute("data-associated_app_name", html_encode(file.associated_app?.name) ?? '');
-        row.setAttribute("data-path", html_encode(file.path));
+        row.setAttribute("data-associated_app_name", file.associated_app?.name ?? '');
+        row.setAttribute("data-path", file.path);
         row.innerHTML = `
             <div class="item-checkbox"><span class="checkbox-icon"></span></div>
             <div class="item-icon">

--- a/src/gui/src/UI/Dashboard/TabFiles.js
+++ b/src/gui/src/UI/Dashboard/TabFiles.js
@@ -162,16 +162,21 @@ const TabFiles = {
         // drift — e.g. trashed items must show metadata.original_name, not
         // the UID that is their raw name (matching renderItem).
         window.UIDashboardFileItemUpdate = function ($row, file) {
-            let displayName = file.name || '';
-            try {
-                const meta = file.metadata ? JSON.parse(file.metadata) : null;
-                if ( meta && meta.original_name ) displayName = meta.original_name;
-            } catch { /* keep raw name */ }
-            $row.attr('data-name', displayName);
-            $row.attr('data-path', file.path || '');
-            $row.attr('data-type', file.type || '');
-            $row.find('.item-name').text(displayName);
-            $row.find('.item-name-editor').val(displayName);
+            // Minimal update payloads may omit fields — only write what the
+            // event actually carries, so it can't blank a correct name/path
+            // (or zero a size) that is already on screen.
+            if ( file.name || file.metadata ) {
+                let displayName = file.name || '';
+                try {
+                    const meta = file.metadata ? JSON.parse(file.metadata) : null;
+                    if ( meta && meta.original_name ) displayName = meta.original_name;
+                } catch { /* keep raw name */ }
+                $row.attr('data-name', displayName);
+                $row.find('.item-name').text(displayName);
+                $row.find('.item-name-editor').val(displayName);
+            }
+            if ( file.path ) $row.attr('data-path', file.path);
+            if ( typeof file.type !== 'undefined' ) $row.attr('data-type', file.type || '');
             // Refresh the visible Size/Modified cells too, not just the
             // hidden data attributes, so a remote overwrite is reflected.
             // Only when the payload actually carries the field — a minimal
@@ -2193,56 +2198,11 @@ const TabFiles = {
                 return;
             }
 
-            // Handle Shift+Click for range selection. Require the anchor to
-            // still be in this row list — a detached anchor (indexOf === -1)
-            // would otherwise set shift_clicked and then select nothing,
-            // leaving the click a no-op.
-            const allShiftRows = $(el_item).parent().find('.row').toArray();
-            const hasShiftAnchor = window.latest_selected_item
-                && allShiftRows.indexOf(window.latest_selected_item) !== -1;
-            if ( e.shiftKey && hasShiftAnchor && window.latest_selected_item !== el_item ) {
-                e.preventDefault();
-                shift_clicked = true;
-
-                const allRows = allShiftRows;
-                const clickedIndex = allRows.indexOf(el_item);
-                const lastSelectedIndex = allRows.indexOf(window.latest_selected_item);
-
-                if ( clickedIndex !== -1 && lastSelectedIndex !== -1 ) {
-                    const start = Math.min(clickedIndex, lastSelectedIndex);
-                    const end = Math.max(clickedIndex, lastSelectedIndex);
-
-                    // Clear selection if no Ctrl/Cmd held
-                    if ( !e.ctrlKey && !e.metaKey ) {
-                        el_item.parentElement.querySelectorAll('.row.selected').forEach(r => {
-                            r.classList.remove('selected');
-                        });
-                    }
-
-                    // Select all items in range
-                    for ( let i = start; i <= end; i++ ) {
-                        allRows[i].classList.add('selected');
-                    }
-
-                    // Update latest selected to the clicked item
-                    window.latest_selected_item = el_item;
-                    window.active_element = el_item;
-                    window.active_item_container = el_item.closest('.files');
-                    _this.updateFooterStats();
-                    return;
-                }
-            } else if ( e.shiftKey && ! hasShiftAnchor ) {
-                // Shift-click with no valid anchor (e.g. the first click after
-                // navigating to a new directory): select just this item and make
-                // it the anchor. onclick skips selection while Shift is held, so
-                // without this the click would select nothing. Shift-clicking
-                // the current anchor itself is NOT this case — that must fall
-                // through as a no-op so it can't collapse an existing
-                // multi-selection to one item.
-                e.preventDefault();
-                shift_clicked = true;
-                // Ctrl/Cmd+Shift extends: keep whatever is already selected.
-                if ( !e.ctrlKey && !e.metaKey ) {
+            // Select just el_item (or additionally to the current selection,
+            // when additive) and make it the anchor. Shared by the no-anchor
+            // shift-click and drag-handle paths so they can't drift apart.
+            const selectSingle = (additive = false) => {
+                if ( ! additive ) {
                     el_item.parentElement.querySelectorAll('.row.selected').forEach(r => {
                         r.classList.remove('selected');
                     });
@@ -2252,7 +2212,61 @@ const TabFiles = {
                 window.active_element = el_item;
                 window.active_item_container = el_item.closest('.files');
                 _this.updateFooterStats();
-                return;
+            };
+
+            // Handle Shift+Click for range selection. Require the anchor to
+            // still be in this row list — a detached anchor (indexOf === -1)
+            // would otherwise set shift_clicked and then select nothing,
+            // leaving the click a no-op. The row lookup happens only under
+            // Shift: this handler is the hot path for every click in the list.
+            if ( e.shiftKey ) {
+                const allRows = $(el_item).parent().find('.row').toArray();
+                const hasShiftAnchor = window.latest_selected_item
+                    && allRows.indexOf(window.latest_selected_item) !== -1;
+                if ( hasShiftAnchor && window.latest_selected_item !== el_item ) {
+                    e.preventDefault();
+                    shift_clicked = true;
+
+                    const clickedIndex = allRows.indexOf(el_item);
+                    const lastSelectedIndex = allRows.indexOf(window.latest_selected_item);
+
+                    if ( clickedIndex !== -1 && lastSelectedIndex !== -1 ) {
+                        const start = Math.min(clickedIndex, lastSelectedIndex);
+                        const end = Math.max(clickedIndex, lastSelectedIndex);
+
+                        // Clear selection if no Ctrl/Cmd held
+                        if ( !e.ctrlKey && !e.metaKey ) {
+                            el_item.parentElement.querySelectorAll('.row.selected').forEach(r => {
+                                r.classList.remove('selected');
+                            });
+                        }
+
+                        // Select all items in range
+                        for ( let i = start; i <= end; i++ ) {
+                            allRows[i].classList.add('selected');
+                        }
+
+                        // Update latest selected to the clicked item
+                        window.latest_selected_item = el_item;
+                        window.active_element = el_item;
+                        window.active_item_container = el_item.closest('.files');
+                        _this.updateFooterStats();
+                        return;
+                    }
+                } else if ( ! hasShiftAnchor ) {
+                    // Shift-click with no valid anchor (e.g. the first click
+                    // after navigating to a new directory): select just this
+                    // item and make it the anchor. onclick skips selection
+                    // while Shift is held, so without this the click would
+                    // select nothing. Ctrl/Cmd+Shift extends instead of
+                    // clearing.
+                    e.preventDefault();
+                    shift_clicked = true;
+                    selectSingle(e.ctrlKey || e.metaKey);
+                    return;
+                }
+                // Shift-click on the current anchor itself: deliberate no-op —
+                // it must not collapse an existing multi-selection.
             }
 
             // In select mode on mobile, treat taps like Ctrl+click (toggle selection)
@@ -2263,15 +2277,8 @@ const TabFiles = {
             // won't be reached — touches land on .row instead, deferring selection to onclick.
             const isDragHandle = e.target.closest('.item-name, .item-icon, .item-badges');
             if ( e.button === 0 && !e.ctrlKey && !e.metaKey && !e.shiftKey && !el_item.classList.contains('selected') && !isMobileSelectMode && isDragHandle ) {
-                el_item.parentElement.querySelectorAll('.row.selected').forEach(r => {
-                    r.classList.remove('selected');
-                });
-                el_item.classList.add('selected');
-                window.latest_selected_item = el_item;
-                window.active_element = el_item;
-                window.active_item_container = el_item.closest('.files');
+                selectSingle();
                 itemWasSelectedOnMousedown = true;
-                _this.updateFooterStats();
                 return;
             }
 

--- a/src/gui/src/UI/Dashboard/TabFiles.js
+++ b/src/gui/src/UI/Dashboard/TabFiles.js
@@ -185,6 +185,14 @@ const TabFiles = {
                 $existingRow.attr('data-type', file.type || '');
                 $existingRow.find('.item-name').text(displayName);
                 $existingRow.find('.item-name-editor').val(displayName);
+                // Refresh the visible Size/Modified cells too, not just the
+                // hidden data attributes, so a remote overwrite is reflected.
+                if ( $existingRow.attr('data-is_dir') !== '1' ) {
+                    $existingRow.find('.item-size').text(_this.formatFileSize(file.size));
+                }
+                if ( file.modified ) {
+                    $existingRow.find('.item-modified').text(window.timeago.format(file.modified * 1000));
+                }
                 if (
                     _this.currentView === 'grid' &&
                     typeof file.thumbnail === 'string' &&
@@ -214,6 +222,9 @@ const TabFiles = {
 
             // Highlight animation to indicate newly added item
             $newRow.addClass('item-newly-added');
+
+            // Reflect the new item in the footer item count / total size.
+            _this.updateFooterStats();
         };
 
         this.renderingDirectory = false;

--- a/src/gui/src/UI/Dashboard/TabFiles.js
+++ b/src/gui/src/UI/Dashboard/TabFiles.js
@@ -1046,7 +1046,7 @@ const TabFiles = {
                 const history_item = window.dashboard_nav_history[index];
 
                 items.push({
-                    html: `<span>${history_item === window.home_path ? i18n('home') : path.basename(history_item)}</span>`,
+                    html: `<span>${history_item === window.home_path ? i18n('home') : html_encode(path.basename(history_item))}</span>`,
                     val: index,
                     onClick: function (e) {
                         window.dashboard_nav_history_current_position = e.value;
@@ -1087,7 +1087,7 @@ const TabFiles = {
                 const history_item = window.dashboard_nav_history[index];
 
                 items.push({
-                    html: `<span>${history_item === window.home_path ? i18n('home') : path.basename(history_item)}</span>`,
+                    html: `<span>${history_item === window.home_path ? i18n('home') : html_encode(path.basename(history_item))}</span>`,
                     val: index,
                     onClick: function (e) {
                         window.dashboard_nav_history_current_position = e.value;

--- a/src/gui/src/UI/Dashboard/TabFiles.js
+++ b/src/gui/src/UI/Dashboard/TabFiles.js
@@ -164,13 +164,14 @@ const TabFiles = {
         window.UIDashboardFileItemUpdate = function ($row, file) {
             // Minimal update payloads may omit fields — only write what the
             // event actually carries, so it can't blank a correct name/path
-            // (or zero a size) that is already on screen.
-            if ( file.name || file.metadata ) {
-                let displayName = file.name || '';
-                try {
-                    const meta = file.metadata ? JSON.parse(file.metadata) : null;
-                    if ( meta && meta.original_name ) displayName = meta.original_name;
-                } catch { /* keep raw name */ }
+            // (or zero a size) that is already on screen. A metadata-only
+            // payload without original_name resolves to '' and is skipped too.
+            let displayName = file.name || '';
+            try {
+                const meta = file.metadata ? JSON.parse(file.metadata) : null;
+                if ( meta && meta.original_name ) displayName = meta.original_name;
+            } catch { /* keep raw name */ }
+            if ( displayName ) {
                 $row.attr('data-name', displayName);
                 $row.find('.item-name').text(displayName);
                 $row.find('.item-name-editor').val(displayName);
@@ -2198,16 +2199,17 @@ const TabFiles = {
                 return;
             }
 
-            // Select just el_item (or additionally to the current selection,
-            // when additive) and make it the anchor. Shared by the no-anchor
-            // shift-click and drag-handle paths so they can't drift apart.
-            const selectSingle = (additive = false) => {
+            // Select the given rows (replacing the current selection unless
+            // additive) and make el_item the anchor. Shared by the range,
+            // no-anchor shift-click, and drag-handle paths so their selection
+            // bookkeeping can't drift apart.
+            const applySelection = (rows, additive = false) => {
                 if ( ! additive ) {
                     el_item.parentElement.querySelectorAll('.row.selected').forEach(r => {
                         r.classList.remove('selected');
                     });
                 }
-                el_item.classList.add('selected');
+                for ( const row of rows ) row.classList.add('selected');
                 window.latest_selected_item = el_item;
                 window.active_element = el_item;
                 window.active_item_container = el_item.closest('.files');
@@ -2233,24 +2235,9 @@ const TabFiles = {
                     if ( clickedIndex !== -1 && lastSelectedIndex !== -1 ) {
                         const start = Math.min(clickedIndex, lastSelectedIndex);
                         const end = Math.max(clickedIndex, lastSelectedIndex);
-
-                        // Clear selection if no Ctrl/Cmd held
-                        if ( !e.ctrlKey && !e.metaKey ) {
-                            el_item.parentElement.querySelectorAll('.row.selected').forEach(r => {
-                                r.classList.remove('selected');
-                            });
-                        }
-
-                        // Select all items in range
-                        for ( let i = start; i <= end; i++ ) {
-                            allRows[i].classList.add('selected');
-                        }
-
-                        // Update latest selected to the clicked item
-                        window.latest_selected_item = el_item;
-                        window.active_element = el_item;
-                        window.active_item_container = el_item.closest('.files');
-                        _this.updateFooterStats();
+                        // Select the whole range; Ctrl/Cmd extends instead of
+                        // replacing.
+                        applySelection(allRows.slice(start, end + 1), e.ctrlKey || e.metaKey);
                         return;
                     }
                 } else if ( ! hasShiftAnchor ) {
@@ -2262,7 +2249,7 @@ const TabFiles = {
                     // clearing.
                     e.preventDefault();
                     shift_clicked = true;
-                    selectSingle(e.ctrlKey || e.metaKey);
+                    applySelection([el_item], e.ctrlKey || e.metaKey);
                     return;
                 }
                 // Shift-click on the current anchor itself: deliberate no-op —
@@ -2277,7 +2264,7 @@ const TabFiles = {
             // won't be reached — touches land on .row instead, deferring selection to onclick.
             const isDragHandle = e.target.closest('.item-name, .item-icon, .item-badges');
             if ( e.button === 0 && !e.ctrlKey && !e.metaKey && !e.shiftKey && !el_item.classList.contains('selected') && !isMobileSelectMode && isDragHandle ) {
-                selectSingle();
+                applySelection([el_item]);
                 itemWasSelectedOnMousedown = true;
                 return;
             }

--- a/src/gui/src/UI/Dashboard/TabFiles.js
+++ b/src/gui/src/UI/Dashboard/TabFiles.js
@@ -157,6 +157,40 @@ const TabFiles = {
         const _this = this;
         window.dashboard_object = _this;
 
+        // Refresh an existing row in place from an fs entry. Shared with
+        // UIDashboard's item.updated socket handler so the two paths can't
+        // drift — e.g. trashed items must show metadata.original_name, not
+        // the UID that is their raw name (matching renderItem).
+        window.UIDashboardFileItemUpdate = function ($row, file) {
+            let displayName = file.name || '';
+            try {
+                const meta = file.metadata ? JSON.parse(file.metadata) : null;
+                if ( meta && meta.original_name ) displayName = meta.original_name;
+            } catch { /* keep raw name */ }
+            $row.attr('data-name', displayName);
+            $row.attr('data-path', file.path || '');
+            $row.attr('data-size', file.size || 0);
+            $row.attr('data-modified', file.modified || 0);
+            $row.attr('data-type', file.type || '');
+            $row.find('.item-name').text(displayName);
+            $row.find('.item-name-editor').val(displayName);
+            // Refresh the visible Size/Modified cells too, not just the
+            // hidden data attributes, so a remote overwrite is reflected.
+            if ( $row.attr('data-is_dir') !== '1' ) {
+                $row.find('.item-size').text(_this.formatFileSize(file.size));
+            }
+            if ( file.modified ) {
+                $row.find('.item-modified').text(window.timeago.format(file.modified * 1000));
+            }
+            if (
+                _this.currentView === 'grid' &&
+                typeof file.thumbnail === 'string' &&
+                file.thumbnail.length > 0
+            ) {
+                $row.find('.item-icon img').attr('src', file.thumbnail);
+            }
+        };
+
         // Dashboard-compatible item creator for use by helpers.js and socket handlers.
         // Wraps renderItem() with a directory check so items are only added
         // when the user is viewing the relevant directory.
@@ -171,35 +205,7 @@ const TabFiles = {
             // If item already exists in view, update in-place.
             const $existingRow = $(`.files-tab .files .item[data-uid='${file.uid}']`);
             if ( $existingRow.length > 0 ) {
-                // Match renderItem's display name: trashed items show
-                // metadata.original_name, not the UID that is their raw name.
-                let displayName = file.name || '';
-                try {
-                    const meta = file.metadata ? JSON.parse(file.metadata) : null;
-                    if ( meta && meta.original_name ) displayName = meta.original_name;
-                } catch { /* keep raw name */ }
-                $existingRow.attr('data-name', displayName);
-                $existingRow.attr('data-path', file.path || '');
-                $existingRow.attr('data-size', file.size || 0);
-                $existingRow.attr('data-modified', file.modified || 0);
-                $existingRow.attr('data-type', file.type || '');
-                $existingRow.find('.item-name').text(displayName);
-                $existingRow.find('.item-name-editor').val(displayName);
-                // Refresh the visible Size/Modified cells too, not just the
-                // hidden data attributes, so a remote overwrite is reflected.
-                if ( $existingRow.attr('data-is_dir') !== '1' ) {
-                    $existingRow.find('.item-size').text(_this.formatFileSize(file.size));
-                }
-                if ( file.modified ) {
-                    $existingRow.find('.item-modified').text(window.timeago.format(file.modified * 1000));
-                }
-                if (
-                    _this.currentView === 'grid' &&
-                    typeof file.thumbnail === 'string' &&
-                    file.thumbnail.length > 0
-                ) {
-                    $existingRow.find('.item-icon img').attr('src', file.thumbnail);
-                }
+                window.UIDashboardFileItemUpdate($existingRow, file);
                 return;
             }
 
@@ -2182,8 +2188,9 @@ const TabFiles = {
             // would otherwise set shift_clicked and then select nothing,
             // leaving the click a no-op.
             const allShiftRows = $(el_item).parent().find('.row').toArray();
-            if ( e.shiftKey && window.latest_selected_item && window.latest_selected_item !== el_item
-                && allShiftRows.indexOf(window.latest_selected_item) !== -1 ) {
+            const hasShiftAnchor = window.latest_selected_item
+                && allShiftRows.indexOf(window.latest_selected_item) !== -1;
+            if ( e.shiftKey && hasShiftAnchor && window.latest_selected_item !== el_item ) {
                 e.preventDefault();
                 shift_clicked = true;
 
@@ -2214,16 +2221,22 @@ const TabFiles = {
                     _this.updateFooterStats();
                     return;
                 }
-            } else if ( e.shiftKey && e.pointerType !== 'touch' ) {
+            } else if ( e.shiftKey && ! hasShiftAnchor ) {
                 // Shift-click with no valid anchor (e.g. the first click after
                 // navigating to a new directory): select just this item and make
                 // it the anchor. onclick skips selection while Shift is held, so
-                // without this the click would select nothing.
+                // without this the click would select nothing. Shift-clicking
+                // the current anchor itself is NOT this case — that must fall
+                // through as a no-op so it can't collapse an existing
+                // multi-selection to one item.
                 e.preventDefault();
                 shift_clicked = true;
-                el_item.parentElement.querySelectorAll('.row.selected').forEach(r => {
-                    r.classList.remove('selected');
-                });
+                // Ctrl/Cmd+Shift extends: keep whatever is already selected.
+                if ( !e.ctrlKey && !e.metaKey ) {
+                    el_item.parentElement.querySelectorAll('.row.selected').forEach(r => {
+                        r.classList.remove('selected');
+                    });
+                }
                 el_item.classList.add('selected');
                 window.latest_selected_item = el_item;
                 window.active_element = el_item;

--- a/src/gui/src/UI/Dashboard/TabFiles.js
+++ b/src/gui/src/UI/Dashboard/TabFiles.js
@@ -1834,6 +1834,14 @@ const TabFiles = {
             r.classList.remove('selected');
         });
 
+        // Drop the shift-click anchor — it points at a row from the directory
+        // we're leaving, and a stale detached anchor makes the first shift-click
+        // in the new directory select nothing.
+        if ( window.latest_selected_item && ! document.body.contains(window.latest_selected_item) ) {
+            window.latest_selected_item = null;
+            window.active_element = null;
+        }
+
         // Determine whether target is a path or uid
         const isPath = typeof target === 'string' && target.startsWith('/');
         const readdirArg = isPath
@@ -2154,12 +2162,17 @@ const TabFiles = {
                 return;
             }
 
-            // Handle Shift+Click for range selection
-            if ( e.shiftKey && window.latest_selected_item && window.latest_selected_item !== el_item ) {
+            // Handle Shift+Click for range selection. Require the anchor to
+            // still be in this row list — a detached anchor (indexOf === -1)
+            // would otherwise set shift_clicked and then select nothing,
+            // leaving the click a no-op.
+            const allShiftRows = $(el_item).parent().find('.row').toArray();
+            if ( e.shiftKey && window.latest_selected_item && window.latest_selected_item !== el_item
+                && allShiftRows.indexOf(window.latest_selected_item) !== -1 ) {
                 e.preventDefault();
                 shift_clicked = true;
 
-                const allRows = $(el_item).parent().find('.row').toArray();
+                const allRows = allShiftRows;
                 const clickedIndex = allRows.indexOf(el_item);
                 const lastSelectedIndex = allRows.indexOf(window.latest_selected_item);
 
@@ -2186,6 +2199,22 @@ const TabFiles = {
                     _this.updateFooterStats();
                     return;
                 }
+            } else if ( e.shiftKey && e.pointerType !== 'touch' ) {
+                // Shift-click with no valid anchor (e.g. the first click after
+                // navigating to a new directory): select just this item and make
+                // it the anchor. onclick skips selection while Shift is held, so
+                // without this the click would select nothing.
+                e.preventDefault();
+                shift_clicked = true;
+                el_item.parentElement.querySelectorAll('.row.selected').forEach(r => {
+                    r.classList.remove('selected');
+                });
+                el_item.classList.add('selected');
+                window.latest_selected_item = el_item;
+                window.active_element = el_item;
+                window.active_item_container = el_item.closest('.files');
+                _this.updateFooterStats();
+                return;
             }
 
             // In select mode on mobile, treat taps like Ctrl+click (toggle selection)
@@ -2846,11 +2875,16 @@ const TabFiles = {
      * @returns {string} Formatted size string (e.g., "1.5 MB")
      */
     formatFileSize (bytes) {
-        if ( bytes === 0 ) return '0 B';
+        const num = Number(bytes);
+        // Missing/invalid sizes (undefined, null, NaN) and non-positive values
+        // shouldn't render as "NaN undefined".
+        if ( ! Number.isFinite(num) || num <= 0 ) return '0 B';
         const k = 1024;
-        const sizes = ['B', 'KB', 'MB', 'GB'];
-        const i = Math.floor(Math.log(bytes) / Math.log(k));
-        return `${Math.round((bytes / Math.pow(k, i)) * 100) / 100 } ${ sizes[i]}`;
+        const sizes = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'];
+        // Clamp the index so sizes beyond PB don't index past the array (which
+        // produced "1.5 undefined" for terabyte-plus files).
+        const i = Math.min(Math.floor(Math.log(num) / Math.log(k)), sizes.length - 1);
+        return `${Math.round((num / Math.pow(k, i)) * 100) / 100 } ${ sizes[i]}`;
     },
 
     /**

--- a/src/gui/src/UI/Dashboard/TabFiles.js
+++ b/src/gui/src/UI/Dashboard/TabFiles.js
@@ -1855,6 +1855,21 @@ const TabFiles = {
             // network). Without this, renderingDirectory would stay true and
             // the guard above would block all further navigation.
             console.error('Failed to read directory:', err);
+            // The container was already emptied above; show a message instead of
+            // leaving a blank pane with no explanation.
+            this.$el_window.find('.files-tab .files').html(`<div style="
+                display: flex;
+                justify-content: center;
+                align-items: center;
+                position: absolute;
+                top: 0;
+                left: 0;
+                right: 0;
+                bottom: 0;
+                pointer-events: none;
+                text-align: center;
+                padding: 0 16px;
+            ">This folder couldn't be opened.</div>`);
             this.hideSpinner();
             this.renderingDirectory = false;
             return;

--- a/src/gui/src/UI/Dashboard/TabFiles.js
+++ b/src/gui/src/UI/Dashboard/TabFiles.js
@@ -169,17 +169,21 @@ const TabFiles = {
             } catch { /* keep raw name */ }
             $row.attr('data-name', displayName);
             $row.attr('data-path', file.path || '');
-            $row.attr('data-size', file.size || 0);
-            $row.attr('data-modified', file.modified || 0);
             $row.attr('data-type', file.type || '');
             $row.find('.item-name').text(displayName);
             $row.find('.item-name-editor').val(displayName);
             // Refresh the visible Size/Modified cells too, not just the
             // hidden data attributes, so a remote overwrite is reflected.
-            if ( $row.attr('data-is_dir') !== '1' ) {
-                $row.find('.item-size').text(_this.formatFileSize(file.size));
+            // Only when the payload actually carries the field — a minimal
+            // update event must not zero out a correct value on screen.
+            if ( typeof file.size !== 'undefined' ) {
+                $row.attr('data-size', file.size || 0);
+                if ( $row.attr('data-is_dir') !== '1' ) {
+                    $row.find('.item-size').text(_this.formatFileSize(file.size));
+                }
             }
             if ( file.modified ) {
+                $row.attr('data-modified', file.modified);
                 $row.find('.item-modified').text(window.timeago.format(file.modified * 1000));
             }
             if (
@@ -189,6 +193,9 @@ const TabFiles = {
             ) {
                 $row.find('.item-icon img').attr('src', file.thumbnail);
             }
+            // The footer's item-count/total-size line is computed from the
+            // rows' data-size attributes — keep it in step with the cell.
+            _this.updateFooterStats();
         };
 
         // Dashboard-compatible item creator for use by helpers.js and socket handlers.
@@ -1876,6 +1883,9 @@ const TabFiles = {
                 text-align: center;
                 padding: 0 16px;
             ">This folder couldn't be opened.</div>`);
+            // The list was emptied above; without this the footer keeps the
+            // previous directory's item count over a pane with zero rows.
+            this.updateFooterStats();
             this.hideSpinner();
             this.renderingDirectory = false;
             return;

--- a/src/gui/src/UI/Dashboard/TabHome.js
+++ b/src/gui/src/UI/Dashboard/TabHome.js
@@ -73,7 +73,7 @@ function buildUsageHTML() {
     // Your Plan section
     h +=
         '<div class="bento-usage-section bento-usage-card bento-plan-section">';
-    h += '<a href="#" class="bento-usage-card-header bento-plan-header">';
+    h += '<a href="#" class="bento-usage-card-header bento-plan-header" data-target-tab="usage">';
     h += `<h3>${i18n('your_plan')}</h3>`;
     h += '<span class="bento-usage-card-arrow">›</span>';
     h += '</a>';
@@ -235,7 +235,9 @@ const TabHome = {
         //      bypass our dispatch, so we re-pull state + broadcast.
         const refresh = () => this.loadUsageData($el_window);
         const refreshAndBroadcast = async () => {
-            refresh();
+            // Pull fresh whoami, then broadcast. The dispatched event is handled
+            // by the `refresh` listener below, so we don't call refresh() here —
+            // doing both is what caused every focus to fire duplicate reloads.
             try {
                 await window.refresh_user_data?.(puter.authToken);
             } catch {}
@@ -246,11 +248,22 @@ const TabHome = {
             } catch {}
         };
         window.addEventListener('puter:subscription:changed', refresh);
+        // A single return-to-tab fires both `focus` and `visibilitychange`;
+        // coalesce them so we don't run the refresh (and refresh_user_data)
+        // twice in a row.
+        let refreshCoalesceTimer = null;
+        const scheduleRefreshAndBroadcast = () => {
+            if (refreshCoalesceTimer) return;
+            refreshCoalesceTimer = setTimeout(() => {
+                refreshCoalesceTimer = null;
+            }, 500);
+            refreshAndBroadcast();
+        };
         const onVisibility = () => {
-            if (document.visibilityState === 'visible') refreshAndBroadcast();
+            if (document.visibilityState === 'visible') scheduleRefreshAndBroadcast();
         };
         document.addEventListener('visibilitychange', onVisibility);
-        window.addEventListener('focus', refreshAndBroadcast);
+        window.addEventListener('focus', scheduleRefreshAndBroadcast);
 
         // Handle app clicks
         $el_window.on('click', '.bento-recent-app', function (e) {
@@ -259,9 +272,9 @@ const TabHome = {
             const appName = $(this).attr('data-app-name');
             const targetLink = $(this).attr('data-target-link');
             if (targetLink && targetLink !== '') {
-                window.open(targetLink, '_blank');
+                window.open(targetLink, '_blank', 'noopener,noreferrer');
             } else if (appName) {
-                window.open(`/app/${appName}`, '_blank');
+                window.open(`/app/${appName}`, '_blank', 'noopener,noreferrer');
             }
         });
 
@@ -386,7 +399,9 @@ const TabHome = {
                 $el_window.find('.bento-plan-upgrade').text('Manage →').show();
             } else {
                 $badge.text('Upgrade for more features').addClass('free');
-                $el_window.find('.bento-plan-upgrade').show();
+                // Reset the label too — otherwise it keeps saying "Manage →"
+                // after a subscription lapses/cancels.
+                $el_window.find('.bento-plan-upgrade').text('Upgrade →').show();
             }
 
             $el_window
@@ -405,7 +420,8 @@ const TabHome = {
         // Load storage data
         try {
             const res = await puter.fs.space();
-            let usage_percentage = ((res.used / res.capacity) * 100).toFixed(0);
+            // Guard capacity 0 — 0/0 would render literally as "NaN%".
+            let usage_percentage = res.capacity ? ((res.used / res.capacity) * 100).toFixed(0) : '0';
             usage_percentage = usage_percentage > 100 ? 100 : usage_percentage;
 
             let general_used = res.used;

--- a/src/gui/src/UI/Dashboard/TabHome.js
+++ b/src/gui/src/UI/Dashboard/TabHome.js
@@ -238,8 +238,14 @@ const TabHome = {
             // Pull fresh whoami, then broadcast. The dispatched event is handled
             // by the `refresh` listener below, so we don't call refresh() here —
             // doing both is what caused every focus to fire duplicate reloads.
+            // The broadcast is the only thing that triggers the refresh, so cap
+            // the wait: a whoami that never settles (hung connection) must not
+            // leave the cards stale for the rest of the session.
             try {
-                await window.refresh_user_data?.(puter.authToken);
+                await Promise.race([
+                    window.refresh_user_data?.(puter.authToken),
+                    new Promise(resolve => setTimeout(resolve, 8000)),
+                ]);
             } catch {}
             try {
                 window.dispatchEvent(

--- a/src/gui/src/UI/Dashboard/TabUsage.js
+++ b/src/gui/src/UI/Dashboard/TabUsage.js
@@ -76,23 +76,17 @@ const TabUsage = {
             </div>`;
     },
     init: ($el_window) => {
-        // Upgrade / Manage Plan button (same logic as billing tab)
-        const $planBtn = $($el_window).find('.usage-plan-btn');
-        const hasSubscription = window.user?.subscription?.active;
-        if ( hasSubscription ) {
-            $planBtn.text('Manage Plan').addClass('manage').show();
-        } else {
-            $planBtn.text('Upgrade').addClass('upgrade').show();
-        }
-        $planBtn.on('click', (e) => {
+        setupPlanButton($el_window);
+        // Guard the click: UIUpgradeAccount only exists on hosted puter.com, and
+        // without the guard clicking would throw a TypeError.
+        $($el_window).find('.usage-plan-btn').on('click', (e) => {
             e.preventDefault();
-            (new window.UIUpgradeAccount()).open_as_window();
+            if ( typeof window.UIUpgradeAccount === 'function' ) {
+                (new window.UIUpgradeAccount()).open_as_window();
+            }
         });
 
         update_usage_details($el_window);
-        $($el_window).find('.update-usage-details').on('click', function () {
-            update_usage_details($el_window);
-        });
 
         // Click handler for sortable table headers
         $($el_window).on('click', '.driver-usage-details-content-table th[data-sort]', function () {
@@ -121,7 +115,31 @@ const TabUsage = {
             renderUsageTable();
         });
     },
+    // Refresh whenever the tab is (re)activated — otherwise the usage numbers
+    // stay frozen at page-load time for the whole session (there is no other
+    // refresh path), diverging from the Home cards which do refresh.
+    onActivate: ($el_window) => {
+        setupPlanButton($el_window);
+        update_usage_details($el_window);
+    },
 };
+
+function setupPlanButton ($el_window) {
+    const $planBtn = $($el_window).find('.usage-plan-btn');
+    // UIUpgradeAccount is only present on hosted puter.com; on a self-hosted
+    // install the button has no working target, so hide it entirely rather
+    // than showing a dead control.
+    if ( typeof window.UIUpgradeAccount !== 'function' ) {
+        $planBtn.hide();
+        return;
+    }
+    const hasSubscription = window.user?.subscription?.active;
+    $planBtn
+        .text(hasSubscription ? 'Manage Plan' : 'Upgrade')
+        .toggleClass('manage', !!hasSubscription)
+        .toggleClass('upgrade', !hasSubscription)
+        .show();
+}
 
 function getSortIcon (column) {
     const isActive = usageTableSortState.column === column;
@@ -197,7 +215,7 @@ function renderUsageTable () {
     for ( const row of rowsToShow ) {
         h += `
         <tr>
-            <td>${row.resource}</td>
+            <td>${window.html_encode(row.resource.replaceAll('_dot_', '.'))}</td>
             <td>${row.formattedUnits}</td>
             <td>${row.formattedCost}</td>
         </tr>`;
@@ -274,10 +292,17 @@ async function update_usage_details ($el_window) {
         }
 
         renderUsageTable();
+    }).catch(err => {
+        console.error('Failed to load monthly usage:', err);
+        usageTableData = [];
+        $('.driver-usage-details-content').html(
+            '<p style="opacity:0.7; font-size:13px;">Usage details are unavailable right now.</p>',
+        );
     });
 
     const spacePromise = puter.fs.space().then(res => {
-        let usage_percentage = (res.used / res.capacity * 100).toFixed(0);
+        // Guard capacity 0 — otherwise 0/0 renders literally as "NaN%".
+        let usage_percentage = res.capacity ? (res.used / res.capacity * 100).toFixed(0) : '0';
         usage_percentage = usage_percentage > 100 ? 100 : usage_percentage;
 
         let general_used = res.used;
@@ -308,6 +333,8 @@ async function update_usage_details ($el_window) {
             width: `${host_usage_percentage }%`,
             'background-color': storageColor,
         });
+    }).catch(err => {
+        console.error('Failed to load storage usage:', err);
     });
 
     // Wait for both promises to complete

--- a/src/gui/src/UI/Dashboard/TabUsage.js
+++ b/src/gui/src/UI/Dashboard/TabUsage.js
@@ -86,7 +86,7 @@ const TabUsage = {
             }
         });
 
-        update_usage_details($el_window);
+        refreshUsageDetails($el_window);
 
         // Click handler for sortable table headers
         $($el_window).on('click', '.driver-usage-details-content-table th[data-sort]', function () {
@@ -120,17 +120,39 @@ const TabUsage = {
     // refresh path), diverging from the Home cards which do refresh.
     onActivate: ($el_window) => {
         setupPlanButton($el_window);
-        update_usage_details($el_window);
+        refreshUsageDetails($el_window);
     },
 };
 
-function setupPlanButton ($el_window) {
+// init and the initial-route onActivate both fire when the dashboard opens
+// directly on this tab; share the in-flight refresh instead of issuing
+// duplicate request pairs.
+let usageRefreshPromise = null;
+function refreshUsageDetails ($el_window) {
+    if ( ! usageRefreshPromise ) {
+        usageRefreshPromise = update_usage_details($el_window).finally(() => {
+            usageRefreshPromise = null;
+        });
+    }
+    return usageRefreshPromise;
+}
+
+let planBtnRetryTimer = null;
+
+function setupPlanButton ($el_window, attempts = 40) {
     const $planBtn = $($el_window).find('.usage-plan-btn');
+    clearTimeout(planBtnRetryTimer);
     // UIUpgradeAccount is only present on hosted puter.com; on a self-hosted
     // install the button has no working target, so hide it entirely rather
-    // than showing a dead control.
+    // than showing a dead control. Hosted deployments can attach it *after*
+    // the dashboard initializes, though — keep re-checking for a while so a
+    // load-order race can't leave a subscriber without the button for the
+    // whole session.
     if ( typeof window.UIUpgradeAccount !== 'function' ) {
         $planBtn.hide();
+        if ( attempts > 0 ) {
+            planBtnRetryTimer = setTimeout(() => setupPlanButton($el_window, attempts - 1), 250);
+        }
         return;
     }
     const hasSubscription = window.user?.subscription?.active;

--- a/src/gui/src/UI/Dashboard/TabUsage.js
+++ b/src/gui/src/UI/Dashboard/TabUsage.js
@@ -23,6 +23,7 @@ let usageTableSortState = {
     direction: 'desc', // default descending (highest cost first)
 };
 let usageTableData = []; // Store raw data for sorting
+let usageTableRendered = false; // A table (possibly empty) has rendered from a successful load
 let usageTableExpanded = false; // Track if table is showing all rows
 const USAGE_TABLE_INITIAL_ROWS = 10;
 
@@ -145,13 +146,15 @@ function setupPlanButton ($el_window, retryDelay = 250) {
     // UIUpgradeAccount is only present on hosted puter.com; on a self-hosted
     // install the button has no working target, so hide it entirely rather
     // than showing a dead control. Hosted deployments can attach it *after*
-    // the dashboard initializes, though — keep re-checking (backing off to a
-    // slow poll) so a load-order race can't leave a subscriber without the
-    // button for the whole session, no matter how late the script lands.
+    // the dashboard initializes, though — keep re-checking so a load-order
+    // race can't leave a subscriber without the button for the whole session,
+    // no matter how late the script lands. The backoff decays to a slow
+    // heartbeat so a self-hosted install (where it never appears) isn't left
+    // running a hot poll forever.
     if ( typeof window.UIUpgradeAccount !== 'function' ) {
         $planBtn.hide();
         planBtnRetryTimer = setTimeout(
-            () => setupPlanButton($el_window, Math.min(retryDelay * 1.5, 2000)),
+            () => setupPlanButton($el_window, Math.min(retryDelay * 1.5, 60000)),
             retryDelay,
         );
         return;
@@ -266,10 +269,6 @@ function renderUsageTable () {
 }
 
 async function update_usage_details ($el_window) {
-    // Add spinning animation and record start time
-    const startTime = Date.now();
-    $($el_window).find('.update-usage-details-icon').css('animation', 'spin 1s linear infinite');
-
     const monthlyUsagePromise = puter.auth.getMonthlyUsage().then(res => {
         let monthlyAllowance = res.allowanceInfo?.monthUsageAllowance;
         // Actual month-to-date spend. `allowanceInfo.remaining` folds purchased
@@ -315,12 +314,15 @@ async function update_usage_details ($el_window) {
         }
 
         renderUsageTable();
+        usageTableRendered = true;
     }).catch(err => {
         console.error('Failed to load monthly usage:', err);
         // Only show the failure note when nothing has rendered yet — a
         // transient refresh error must not wipe a table the user is already
-        // looking at (mirrors the Apps grid's error handling).
-        if ( usageTableData.length === 0 ) {
+        // looking at (mirrors the Apps grid's error handling). Track "has
+        // rendered", not data length: an account with zero usage renders a
+        // legitimately empty table.
+        if ( ! usageTableRendered ) {
             $('.driver-usage-details-content').html(
                 '<p style="opacity:0.7; font-size:13px;">Usage details are unavailable right now.</p>',
             );
@@ -366,16 +368,6 @@ async function update_usage_details ($el_window) {
 
     // Wait for both promises to complete
     await Promise.all([monthlyUsagePromise, spacePromise]);
-
-    // Ensure spinning continues for at least 1 second
-    const elapsed = Date.now() - startTime;
-    const minDuration = 1000; // 1 second
-    if ( elapsed < minDuration ) {
-        await new Promise(resolve => setTimeout(resolve, minDuration - elapsed));
-    }
-
-    // Remove spinning animation
-    $($el_window).find('.update-usage-details-icon').css('animation', '');
 }
 
 export default TabUsage;

--- a/src/gui/src/UI/Dashboard/TabUsage.js
+++ b/src/gui/src/UI/Dashboard/TabUsage.js
@@ -139,20 +139,21 @@ function refreshUsageDetails ($el_window) {
 
 let planBtnRetryTimer = null;
 
-function setupPlanButton ($el_window, attempts = 40) {
+function setupPlanButton ($el_window, retryDelay = 250) {
     const $planBtn = $($el_window).find('.usage-plan-btn');
     clearTimeout(planBtnRetryTimer);
     // UIUpgradeAccount is only present on hosted puter.com; on a self-hosted
     // install the button has no working target, so hide it entirely rather
     // than showing a dead control. Hosted deployments can attach it *after*
-    // the dashboard initializes, though — keep re-checking for a while so a
-    // load-order race can't leave a subscriber without the button for the
-    // whole session.
+    // the dashboard initializes, though — keep re-checking (backing off to a
+    // slow poll) so a load-order race can't leave a subscriber without the
+    // button for the whole session, no matter how late the script lands.
     if ( typeof window.UIUpgradeAccount !== 'function' ) {
         $planBtn.hide();
-        if ( attempts > 0 ) {
-            planBtnRetryTimer = setTimeout(() => setupPlanButton($el_window, attempts - 1), 250);
-        }
+        planBtnRetryTimer = setTimeout(
+            () => setupPlanButton($el_window, Math.min(retryDelay * 1.5, 2000)),
+            retryDelay,
+        );
         return;
     }
     const hasSubscription = window.user?.subscription?.active;
@@ -316,10 +317,14 @@ async function update_usage_details ($el_window) {
         renderUsageTable();
     }).catch(err => {
         console.error('Failed to load monthly usage:', err);
-        usageTableData = [];
-        $('.driver-usage-details-content').html(
-            '<p style="opacity:0.7; font-size:13px;">Usage details are unavailable right now.</p>',
-        );
+        // Only show the failure note when nothing has rendered yet — a
+        // transient refresh error must not wipe a table the user is already
+        // looking at (mirrors the Apps grid's error handling).
+        if ( usageTableData.length === 0 ) {
+            $('.driver-usage-details-content').html(
+                '<p style="opacity:0.7; font-size:13px;">Usage details are unavailable right now.</p>',
+            );
+        }
     });
 
     const spacePromise = puter.fs.space().then(res => {

--- a/src/gui/src/UI/Dashboard/TabUsage.js
+++ b/src/gui/src/UI/Dashboard/TabUsage.js
@@ -146,17 +146,19 @@ function setupPlanButton ($el_window, retryDelay = 250) {
     // UIUpgradeAccount is only present on hosted puter.com; on a self-hosted
     // install the button has no working target, so hide it entirely rather
     // than showing a dead control. Hosted deployments can attach it *after*
-    // the dashboard initializes, though — keep re-checking so a load-order
-    // race can't leave a subscriber without the button for the whole session,
-    // no matter how late the script lands. The backoff decays to a slow
-    // heartbeat so a self-hosted install (where it never appears) isn't left
-    // running a hot poll forever.
+    // the dashboard initializes, though — retry with decaying backoff so a
+    // load-order race can't hide the button from a subscriber. Give up after
+    // ~30s: a script that hasn't landed by then never will (self-hosted), and
+    // onActivate re-checks on every return to the tab anyway. The bound also
+    // releases the captured $el_window instead of pinning it forever.
     if ( typeof window.UIUpgradeAccount !== 'function' ) {
         $planBtn.hide();
-        planBtnRetryTimer = setTimeout(
-            () => setupPlanButton($el_window, Math.min(retryDelay * 1.5, 60000)),
-            retryDelay,
-        );
+        if ( retryDelay <= 10000 ) {
+            planBtnRetryTimer = setTimeout(
+                () => setupPlanButton($el_window, retryDelay * 1.5),
+                retryDelay,
+            );
+        }
         return;
     }
     const hasSubscription = window.user?.subscription?.active;

--- a/src/gui/src/UI/Dashboard/UIDashboard.js
+++ b/src/gui/src/UI/Dashboard/UIDashboard.js
@@ -349,13 +349,19 @@ async function UIDashboard (options) {
         }
     });
 
+    // Resolve an untrusted route tab id (from the URL hash) to a known tab id,
+    // falling back to Apps. This keeps a crafted hash (e.g. one containing a
+    // quote) from being interpolated into a jQuery selector, which throws and
+    // would otherwise leave the dashboard's event handlers unbound.
+    const knownTabId = tab => (tabs.some(t => t !== '-' && t.id === tab) ? tab : 'apps');
+
     // Apply initial route from URL - activate the correct tab
     if ( window.dashboard_initial_route ) {
         const route = window.dashboard_initial_route;
 
         // Activate the correct tab if not home
         if ( route.tab && route.tab !== 'home' ) {
-            const tabId = route.tab;
+            const tabId = knownTabId(route.tab);
             const $targetTab = $el_window.find(`.dashboard-sidebar-item[data-section="${tabId}"]`);
 
             // Only switch if the tab exists
@@ -386,7 +392,7 @@ async function UIDashboard (options) {
         if ( window.location.href === lastHandledHref ) return;
         lastHandledHref = window.location.href;
         const route = window.parseDashboardRoute();
-        const tab = route.tab;
+        const tab = knownTabId(route.tab);
         const filePath = route.path;
 
         // Switch to correct tab
@@ -456,9 +462,13 @@ async function UIDashboard (options) {
         document.querySelector('.dashboard-content').classList.add(section);
 
         // Reflect the current tab in the hash. Root (no hash) defaults to Apps,
-        // but selecting any tab — including Apps — shows its #tab.
-        history.pushState(null, '', `#${section}`);
-        lastHandledHref = window.location.href;
+        // but selecting any tab — including Apps — shows its #tab. Only push a
+        // new history entry when the hash actually changes, so re-clicking the
+        // current tab doesn't stack duplicate entries that make Back a no-op.
+        if ( window.location.hash !== `#${section}` ) {
+            history.pushState(null, '', `#${section}`);
+            lastHandledHref = window.location.href;
+        }
 
         // Scroll content area to top
         $el_window.find('.dashboard-content').scrollTop(0);

--- a/src/gui/src/UI/Dashboard/UIDashboard.js
+++ b/src/gui/src/UI/Dashboard/UIDashboard.js
@@ -373,7 +373,12 @@ async function UIDashboard (options) {
 
     // Handle browser back/forward navigation
     // This handler is called for both hashchange (manual hash changes) and popstate (back/forward)
+    // A single back/forward fires BOTH popstate and hashchange; track the last
+    // handled URL so the second event doesn't run onActivate (and its fetches) again.
+    let lastHandledHref = window.location.href;
     const handleRouteChange = () => {
+        if ( window.location.href === lastHandledHref ) return;
+        lastHandledHref = window.location.href;
         const route = window.parseDashboardRoute();
         const tab = route.tab;
         const filePath = route.path;
@@ -447,6 +452,7 @@ async function UIDashboard (options) {
         // Reflect the current tab in the hash. Root (no hash) defaults to Apps,
         // but selecting any tab — including Apps — shows its #tab.
         history.pushState(null, '', `#${section}`);
+        lastHandledHref = window.location.href;
 
         // Scroll content area to top
         $el_window.find('.dashboard-content').scrollTop(0);

--- a/src/gui/src/UI/Dashboard/UIDashboard.js
+++ b/src/gui/src/UI/Dashboard/UIDashboard.js
@@ -279,6 +279,7 @@ async function UIDashboard (options) {
                 return $(this).attr('data-path') === old_path;
             }).fadeOut(150, function () {
                 $(this).remove();
+                window.dashboard_object?.updateFooterStats?.();
             });
         }
 
@@ -296,6 +297,8 @@ async function UIDashboard (options) {
             return $(this).attr('data-path') === item.path;
         }).fadeOut(150, function () {
             $(this).remove();
+            // Keep the footer item count / total size in sync with the removal.
+            window.dashboard_object?.updateFooterStats?.();
         });
     });
 
@@ -331,8 +334,18 @@ async function UIDashboard (options) {
         $el.find('.item-name').text(item.name);
         $el.find('.item-name-editor').val(item.name);
 
+        // Refresh the visible Size/Modified cells, not just the data attributes,
+        // so a remote overwrite doesn't leave a stale size on screen.
+        const dashboard = window.dashboard_object;
+        if ( dashboard && $el.attr('data-is_dir') !== '1' && typeof item.size !== 'undefined' ) {
+            $el.find('.item-size').text(dashboard.formatFileSize(item.size));
+        }
+        if ( item.modified ) {
+            $el.find('.item-modified').text(window.timeago.format(item.modified * 1000));
+        }
+
         if (
-            window.dashboard_object?.currentView === 'grid'
+            dashboard?.currentView === 'grid'
             && typeof item.thumbnail === 'string'
             && item.thumbnail.length > 0
         ) {

--- a/src/gui/src/UI/Dashboard/UIDashboard.js
+++ b/src/gui/src/UI/Dashboard/UIDashboard.js
@@ -273,7 +273,11 @@ async function UIDashboard (options) {
         // the freshly-added row instead of the stale one.
         const old_path = resp.old_path ?? resp.from_path;
         if ( old_path ) {
-            $(`.item[data-path='${html_encode(old_path)}']`).fadeOut(150, function () {
+            // data-path holds the raw path; match by comparison rather than a
+            // selector so quotes/special characters in names can't break it.
+            $('.item').filter(function () {
+                return $(this).attr('data-path') === old_path;
+            }).fadeOut(150, function () {
                 $(this).remove();
             });
         }
@@ -288,7 +292,9 @@ async function UIDashboard (options) {
         if ( item.original_client_socket_id === window.socket.id ) return;
         if ( item.descendants_only ) return;
 
-        $(`.item[data-path='${html_encode(item.path)}']`).fadeOut(150, function () {
+        $('.item').filter(function () {
+            return $(this).attr('data-path') === item.path;
+        }).fadeOut(150, function () {
             $(this).remove();
         });
     });
@@ -299,9 +305,9 @@ async function UIDashboard (options) {
         const $el = $(`.item[data-uid='${item.uid}']`);
         if ( $el.length === 0 ) return;
 
-        // Update data attributes
-        $el.attr('data-name', html_encode(item.name));
-        $el.attr('data-path', html_encode(item.path));
+        // Update data attributes (raw values — .attr() stores literally)
+        $el.attr('data-name', item.name);
+        $el.attr('data-path', item.path);
 
         // Update displayed name
         $el.find('.item-name').text(item.name);
@@ -314,12 +320,12 @@ async function UIDashboard (options) {
         const $el = $(`.item[data-uid='${item.uid}']`);
         if ( $el.length === 0 ) return;
 
-        // Update data attributes
-        $el.attr('data-name', html_encode(item.name));
-        $el.attr('data-path', html_encode(item.path));
+        // Update data attributes (raw values — .attr() stores literally)
+        $el.attr('data-name', item.name);
+        $el.attr('data-path', item.path);
         $el.attr('data-size', item.size);
         $el.attr('data-modified', item.modified);
-        $el.attr('data-type', html_encode(item.type));
+        $el.attr('data-type', item.type ?? '');
 
         // Update displayed name
         $el.find('.item-name').text(item.name);

--- a/src/gui/src/UI/Dashboard/UIDashboard.js
+++ b/src/gui/src/UI/Dashboard/UIDashboard.js
@@ -71,12 +71,17 @@ async function UIDashboard (options) {
     // Dispatch 'dashboard-will-open' event to allow extensions to add tabs
     window.dispatchEvent(new CustomEvent('dashboard-will-open', { detail: { tabs } }));
 
+    // True if the untrusted route tab id (from the URL hash) names a real tab.
+    // The routing paths below ignore unknown ids outright — this also keeps a
+    // crafted hash (e.g. one containing a quote) from being interpolated into
+    // a jQuery selector, which throws and would otherwise leave the
+    // dashboard's event handlers unbound.
+    const isKnownTabId = tab => tabs.some(t => t !== '-' && t.id === tab);
+
     // Tab to render active on open. Apps is the default (root URL / no hash);
     // Home is reached via #home. Fall back to Apps for an unknown/absent route.
     const routeTab = window.dashboard_initial_route?.tab;
-    const initialTabId = tabs.some(t => t !== '-' && t.id === routeTab)
-        ? routeTab
-        : 'apps';
+    const initialTabId = isKnownTabId(routeTab) ? routeTab : 'apps';
 
     let h = '';
 
@@ -323,34 +328,11 @@ async function UIDashboard (options) {
         const $el = $(`.item[data-uid='${item.uid}']`);
         if ( $el.length === 0 ) return;
 
-        // Update data attributes (raw values — .attr() stores literally)
-        $el.attr('data-name', item.name);
-        $el.attr('data-path', item.path);
-        $el.attr('data-size', item.size);
-        $el.attr('data-modified', item.modified);
-        $el.attr('data-type', item.type ?? '');
-
-        // Update displayed name
-        $el.find('.item-name').text(item.name);
-        $el.find('.item-name-editor').val(item.name);
-
-        // Refresh the visible Size/Modified cells, not just the data attributes,
-        // so a remote overwrite doesn't leave a stale size on screen.
-        const dashboard = window.dashboard_object;
-        if ( dashboard && $el.attr('data-is_dir') !== '1' && typeof item.size !== 'undefined' ) {
-            $el.find('.item-size').text(dashboard.formatFileSize(item.size));
-        }
-        if ( item.modified ) {
-            $el.find('.item-modified').text(window.timeago.format(item.modified * 1000));
-        }
-
-        if (
-            dashboard?.currentView === 'grid'
-            && typeof item.thumbnail === 'string'
-            && item.thumbnail.length > 0
-        ) {
-            $el.find('.item-icon img').attr('src', item.thumbnail);
-        }
+        // Delegate to the shared row updater (defined in TabFiles.init) so
+        // this handler can't drift from renderItem's conventions — an inline
+        // copy here once showed trashed items' raw UID instead of their
+        // original name.
+        window.UIDashboardFileItemUpdate?.($el, item);
     });
 
     window.socket.on('item.added', async (item) => {
@@ -362,19 +344,14 @@ async function UIDashboard (options) {
         }
     });
 
-    // Resolve an untrusted route tab id (from the URL hash) to a known tab id,
-    // falling back to Apps. This keeps a crafted hash (e.g. one containing a
-    // quote) from being interpolated into a jQuery selector, which throws and
-    // would otherwise leave the dashboard's event handlers unbound.
-    const knownTabId = tab => (tabs.some(t => t !== '-' && t.id === tab) ? tab : 'apps');
-
     // Apply initial route from URL - activate the correct tab
     if ( window.dashboard_initial_route ) {
         const route = window.dashboard_initial_route;
 
-        // Activate the correct tab if not home
-        if ( route.tab && route.tab !== 'home' ) {
-            const tabId = knownTabId(route.tab);
+        // Activate the correct tab if not home. An unknown tab id stays on
+        // the Apps default rendered above rather than being redirected.
+        if ( route.tab && route.tab !== 'home' && isKnownTabId(route.tab) ) {
+            const tabId = route.tab;
             const $targetTab = $el_window.find(`.dashboard-sidebar-item[data-section="${tabId}"]`);
 
             // Only switch if the tab exists
@@ -405,7 +382,12 @@ async function UIDashboard (options) {
         if ( window.location.href === lastHandledHref ) return;
         lastHandledHref = window.location.href;
         const route = window.parseDashboardRoute();
-        const tab = knownTabId(route.tab);
+        // Ignore unknown tab ids entirely (a stale bookmark hash, an in-page
+        // anchor): switching the user to another tab out from under them was
+        // never the behavior, and the early return also keeps untrusted
+        // hashes out of the selectors below.
+        if ( ! isKnownTabId(route.tab) ) return;
+        const tab = route.tab;
         const filePath = route.path;
 
         // Switch to correct tab

--- a/src/gui/src/UI/Dashboard/UIDashboard.js
+++ b/src/gui/src/UI/Dashboard/UIDashboard.js
@@ -278,9 +278,14 @@ async function UIDashboard (options) {
         // the freshly-added row instead of the stale one.
         const old_path = resp.old_path ?? resp.from_path;
         if ( old_path ) {
-            // data-path holds the raw path; match by comparison rather than a
-            // selector so quotes/special characters in names can't break it.
-            $('.item').filter(function () {
+            // Narrow by uid first when the payload carries one (uids are
+            // UUIDs, safe to interpolate into a selector) — a full-DOM scan
+            // per socket event is O(rows) on the hot path. The uid matches
+            // both the old and new rows, so still compare data-path (raw
+            // value, compared rather than interpolated so quotes/special
+            // characters in names can't break it) to pick the stale one.
+            const $candidates = resp.uid ? $(`.item[data-uid='${resp.uid}']`) : $('.item');
+            $candidates.filter(function () {
                 return $(this).attr('data-path') === old_path;
             }).fadeOut(150, function () {
                 $(this).remove();
@@ -298,9 +303,15 @@ async function UIDashboard (options) {
         if ( item.original_client_socket_id === window.socket.id ) return;
         if ( item.descendants_only ) return;
 
-        $('.item').filter(function () {
-            return $(this).attr('data-path') === item.path;
-        }).fadeOut(150, function () {
+        // Match by uid when present (O(1) attribute selector; uids are UUIDs,
+        // safe to interpolate) and fall back to a path scan for minimal
+        // payloads — a removed item has exactly one row either way.
+        const $rows = item.uid
+            ? $(`.item[data-uid='${item.uid}']`)
+            : $('.item').filter(function () {
+                return $(this).attr('data-path') === item.path;
+            });
+        $rows.fadeOut(150, function () {
             $(this).remove();
             // Keep the footer item count / total size in sync with the removal.
             window.dashboard_object?.updateFooterStats?.();

--- a/src/gui/src/UI/Dashboard/appOrder.js
+++ b/src/gui/src/UI/Dashboard/appOrder.js
@@ -71,3 +71,58 @@ export function serializeAppOrder (apps) {
         .map(app => app && app.name)
         .filter(name => typeof name === 'string' && name.length > 0);
 }
+
+/**
+ * Merge the order being saved with the previously saved one so that names
+ * absent from `currentNames` (e.g. apps on an installedApps page that failed
+ * to load this session) keep their saved positions instead of being dropped
+ * or demoted to the tail. Each missing name keeps its RANK: if k survivors
+ * (names in both lists) preceded it in the saved order, it is re-inserted
+ * after the k-th survivor of the new order — so a drag of some visible tile
+ * neither drags hidden apps along nor pushes them off their slots. Present
+ * names appear exactly in `currentNames` order. Kept beside
+ * {@link serializeAppOrder} because it produces the same persisted shape.
+ *
+ * @param {string[]} currentNames - the on-screen order being saved
+ * @param {string[]|null|undefined} previousNames - the last saved order
+ * @returns {string[]}
+ */
+export function mergeSavedOrder (currentNames, previousNames) {
+    const result = Array.isArray(currentNames) ? currentNames.slice() : [];
+    if ( ! Array.isArray(previousNames) || previousNames.length === 0 ) return result;
+
+    const currentSet = new Set(result);
+    const prevSet = new Set(previousNames);
+    // A survivor is a name present in both lists; re-inserted missing names
+    // and brand-new names never count when locating the k-th survivor.
+    const isSurvivor = name => currentSet.has(name) && prevSet.has(name);
+
+    const seen = new Set();
+    let rank = 0;        // survivors encountered so far in the saved order
+    let lastInsert = -1; // keeps runs of missing names in their saved order
+    for ( const name of previousNames ) {
+        if ( typeof name !== 'string' || name.length === 0 ) continue;
+        if ( seen.has(name) ) continue;
+        seen.add(name);
+        if ( currentSet.has(name) ) {
+            rank++;
+            lastInsert = -1;
+            continue;
+        }
+        // Find the index just past the rank-th survivor in the result.
+        let at = 0;
+        if ( rank > 0 ) {
+            let survivors = 0;
+            for ( let i = 0; i < result.length; i++ ) {
+                if ( isSurvivor(result[i]) && ++survivors === rank ) {
+                    at = i + 1;
+                    break;
+                }
+            }
+        }
+        if ( lastInsert >= at ) at = lastInsert + 1;
+        result.splice(at, 0, name);
+        lastInsert = at;
+    }
+    return result;
+}

--- a/src/gui/src/UI/Dashboard/appOrder.js
+++ b/src/gui/src/UI/Dashboard/appOrder.js
@@ -94,35 +94,26 @@ export function mergeSavedOrder (currentNames, previousNames) {
     const currentSet = new Set(result);
     const prevSet = new Set(previousNames);
     // A survivor is a name present in both lists; re-inserted missing names
-    // and brand-new names never count when locating the k-th survivor.
+    // and brand-new names never count when advancing past a survivor.
     const isSurvivor = name => currentSet.has(name) && prevSet.has(name);
 
     const seen = new Set();
-    let rank = 0;        // survivors encountered so far in the saved order
-    let lastInsert = -1; // keeps runs of missing names in their saved order
+    // Single forward pointer over `result`: for each survivor in the saved
+    // order it advances just past the next survivor; each missing name is
+    // spliced in at the pointer, which puts it right after the same number
+    // of survivors that preceded it in the saved order — its rank.
+    let at = 0;
     for ( const name of previousNames ) {
         if ( typeof name !== 'string' || name.length === 0 ) continue;
         if ( seen.has(name) ) continue;
         seen.add(name);
         if ( currentSet.has(name) ) {
-            rank++;
-            lastInsert = -1;
+            while ( at < result.length && ! isSurvivor(result[at]) ) at++;
+            at++;
             continue;
         }
-        // Find the index just past the rank-th survivor in the result.
-        let at = 0;
-        if ( rank > 0 ) {
-            let survivors = 0;
-            for ( let i = 0; i < result.length; i++ ) {
-                if ( isSurvivor(result[i]) && ++survivors === rank ) {
-                    at = i + 1;
-                    break;
-                }
-            }
-        }
-        if ( lastInsert >= at ) at = lastInsert + 1;
         result.splice(at, 0, name);
-        lastInsert = at;
+        at++;
     }
     return result;
 }

--- a/src/gui/src/UI/Dashboard/appOrder.test.js
+++ b/src/gui/src/UI/Dashboard/appOrder.test.js
@@ -18,7 +18,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { reconcileAppOrder, serializeAppOrder } from './appOrder.js';
+import { reconcileAppOrder, serializeAppOrder, mergeSavedOrder } from './appOrder.js';
 
 const names = apps => apps.map(a => a.name);
 const mk = (...ns) => ns.map(n => ({ name: n }));
@@ -84,5 +84,60 @@ describe('serializeAppOrder', () => {
         const reordered = reconcileAppOrder(apps, ['d', 'c', 'b', 'a']);
         const saved = serializeAppOrder(reordered);
         expect(names(reconcileAppOrder(apps, saved))).toEqual(['d', 'c', 'b', 'a']);
+    });
+});
+
+describe('mergeSavedOrder', () => {
+    it('returns the current order when nothing was saved before', () => {
+        expect(mergeSavedOrder(['a', 'b'], null)).toEqual(['a', 'b']);
+        expect(mergeSavedOrder(['a', 'b'], [])).toEqual(['a', 'b']);
+    });
+
+    it('keeps present names exactly in the current order', () => {
+        expect(mergeSavedOrder(['c', 'a', 'b'], ['a', 'b', 'c'])).toEqual(['c', 'a', 'b']);
+    });
+
+    it('re-inserts a missing name after its surviving predecessor', () => {
+        // 'm' sat between 'b' and 'c' in the saved order; it must return to
+        // that slot, not be demoted to the tail.
+        expect(mergeSavedOrder(['a', 'b', 'c'], ['a', 'b', 'm', 'c'])).toEqual(['a', 'b', 'm', 'c']);
+    });
+
+    it('keeps a missing name at the front when it led the saved order', () => {
+        expect(mergeSavedOrder(['a', 'b'], ['m', 'a', 'b'])).toEqual(['m', 'a', 'b']);
+    });
+
+    it('keeps runs of missing names in their saved order', () => {
+        expect(mergeSavedOrder(['a', 'b'], ['a', 'm1', 'm2', 'b'])).toEqual(['a', 'm1', 'm2', 'b']);
+    });
+
+    it('keeps a missing name at its rank when visible tiles are rearranged', () => {
+        // 'm' was third; the user swapped 'a' and 'b'. 'm' stays third — it
+        // neither follows 'b' to the front nor gets demoted.
+        expect(mergeSavedOrder(['b', 'a', 'c'], ['a', 'b', 'm', 'c'])).toEqual(['b', 'a', 'm', 'c']);
+    });
+
+    it('preserves a truncated tail after a partial load and a drag', () => {
+        // Saved order covers 6 apps; only the first 4 loaded (page 2 failed)
+        // and the user dragged 'd' to the front. The unloaded tail must keep
+        // its saved position after the surviving 'c', not vanish.
+        const merged = mergeSavedOrder(['d', 'a', 'b', 'c'], ['a', 'b', 'c', 'd', 'e', 'f']);
+        expect(merged).toEqual(['d', 'a', 'b', 'c', 'e', 'f']);
+        // Round-trip: when the full list loads again, 'e' and 'f' come back
+        // in their saved slots.
+        expect(names(reconcileAppOrder(mk('a', 'b', 'c', 'd', 'e', 'f'), merged)))
+            .toEqual(['d', 'a', 'b', 'c', 'e', 'f']);
+    });
+
+    it('ignores unusable saved entries and duplicates', () => {
+        expect(mergeSavedOrder(['a'], ['', null, 'a', 'a', 'm'])).toEqual(['a', 'm']);
+    });
+
+    it('does not mutate its inputs', () => {
+        const current = ['a', 'b'];
+        const previous = ['b', 'm', 'a'];
+        mergeSavedOrder(current, previous);
+        expect(current).toEqual(['a', 'b']);
+        expect(previous).toEqual(['b', 'm', 'a']);
     });
 });

--- a/src/gui/src/css/dashboard.css
+++ b/src/gui/src/css/dashboard.css
@@ -3999,6 +3999,21 @@ body.myapps-reordering .myapps-tile {
     opacity: 0.8;
 }
 
+/* Disabled item - inert and dimmed (mirrors the desktop context menu) */
+.context-menu-modal-dialog .context-menu-item--disabled {
+    opacity: 0.4;
+    cursor: default;
+    pointer-events: none;
+}
+
+/* Submenu chevron, pushed to the trailing edge */
+.context-menu-modal-dialog .context-menu-item-chevron {
+    margin-left: auto;
+    padding-left: 0.5rem;
+    color: var(--dashboard-text-muted, #94a3b8);
+    font-size: 1rem;
+}
+
 /* Desktop - transparent backdrop. Use 769px so it doesn't overlap the mobile
    rules (all keyed to max-width: 768px) at exactly 768px, where a touch tablet
    would otherwise get a fully transparent, non-dimming modal backdrop. */

--- a/src/gui/src/css/dashboard.css
+++ b/src/gui/src/css/dashboard.css
@@ -2238,13 +2238,11 @@ body.myapps-reordering .myapps-tile {
     }
 }
 
-/* Hide .item-more on desktop (non-touch devices) - use right-click context menu instead */
-.dashboard-section-files .files-tab:not(.touch-device) .files.files-list-view .row .item-more,
-.dashboard-section-files .files-tab:not(.touch-device) .files.files-grid-view .row .item-more,
-.dashboard-section-files .files-tab:not(.touch-device) .files.files-grid-view .row:hover .item-more,
-.dashboard-section-files .files-tab:not(.touch-device) .header .columns .item-more {
-    display: none !important;
-}
+/* NOTE: a rule hiding .item-more on desktop (non-touch) used to sit here, but
+   it was malformed (selector list running into an @media block) and therefore
+   never in effect — desktop users have always had the visible '⋯' button, and
+   they use it, so repairing the rule into effect would remove a working
+   affordance. Intentionally removed instead. */
 
 .dashboard-section-files .files-tab .files.files-grid-view .row .item-name-editor {
     text-align: center;
@@ -4014,10 +4012,12 @@ body.myapps-reordering .myapps-tile {
     font-size: 1rem;
 }
 
-/* Desktop - transparent backdrop. Use 769px so it doesn't overlap the mobile
-   rules (all keyed to max-width: 768px) at exactly 768px, where a touch tablet
-   would otherwise get a fully transparent, non-dimming modal backdrop. */
-@media (min-width: 769px) {
+/* Desktop - transparent backdrop. Written as the exact complement of the
+   mobile rules (all keyed to max-width: 768px) so that no viewport width —
+   not even a fractional one from browser zoom / DPR scaling — gets desktop
+   styling with the mobile dimming, or vice versa. (min-width: 769px would
+   leave widths strictly between 768px and 769px uncovered.) */
+@media not all and (max-width: 768px) {
     .context-menu-modal-backdrop {
         background-color: transparent;
     }

--- a/src/gui/src/css/dashboard.css
+++ b/src/gui/src/css/dashboard.css
@@ -952,7 +952,6 @@ input.myapps-search::-webkit-search-decoration {
     -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
     word-break: break-word;
-    white-space: nowrap;
 }
 
 /* Uninstall confirmation modal */
@@ -1815,7 +1814,7 @@ body.myapps-reordering .myapps-tile {
 }
 
 .dashboard-section-files .row.folder.ui-droppable-hover,
-.dashboard-section-files .row.folder.selected.ui-droppable-over {
+.dashboard-section-files .row.folder.selected.ui-droppable-hover {
     color: var(--dashboard-text);
     background-color: rgba(59, 130, 246, 0.1);
     border: 2px dashed var(--select-color);
@@ -1901,14 +1900,16 @@ body.myapps-reordering .myapps-tile {
 }
 
 /* Dark mode support for native file drop */
-.window[data-color-scheme="dark"] .dashboard-section-files .files.native-drop-active {
-    background-color: rgba(100, 180, 255, 0.12);
-    outline-color: #4da3ff;
-}
+@media (prefers-color-scheme: dark) {
+    .dashboard-section-files .files.native-drop-active {
+        background-color: rgba(100, 180, 255, 0.12);
+        outline-color: #4da3ff;
+    }
 
-.window[data-color-scheme="dark"] .dashboard-section-files .directories li.native-drop-target,
-.window[data-color-scheme="dark"] .dashboard-section-files .files .row.folder.native-drop-target {
-    background-color: rgba(100, 180, 255, 0.2);
+    .dashboard-section-files .directories li.native-drop-target,
+    .dashboard-section-files .files .row.folder.native-drop-target {
+        background-color: rgba(100, 180, 255, 0.2);
+    }
 }
 
 .dashboard-section-files .files-footer {
@@ -1926,7 +1927,7 @@ body.myapps-reordering .myapps-tile {
     align-items: center;
     justify-content: center;
     gap: 8px;
-    color: #666;
+    color: var(--dashboard-text-secondary);
     z-index: 10;
 }
 
@@ -1936,7 +1937,7 @@ body.myapps-reordering .myapps-tile {
 }
 
 .dashboard-section-files .files-footer-separator {
-    color: #CCC;
+    color: var(--dashboard-text-muted);
 }
 
 /* Floating Selection Actions Bar */
@@ -2179,11 +2180,9 @@ body.myapps-reordering .myapps-tile {
     display: flex;
     align-items: center;
     justify-content: center;
-    /* background: #fafafa; */
+    background: var(--dashboard-background);
     border-radius: 8px;
     overflow: hidden;
-    background: white;
-    border-radius: 2px;
 }
 
 .dashboard-section-files .files-tab .files.files-grid-view .row .item-icon img {
@@ -2242,11 +2241,9 @@ body.myapps-reordering .myapps-tile {
 /* Hide .item-more on desktop (non-touch devices) - use right-click context menu instead */
 .dashboard-section-files .files-tab:not(.touch-device) .files.files-list-view .row .item-more,
 .dashboard-section-files .files-tab:not(.touch-device) .files.files-grid-view .row .item-more,
-@media (hover: hover) {
-    .dashboard-section-files .files-tab:not(.touch-device) .files.files-grid-view .row:hover .item-more,
-    .dashboard-section-files .files-tab:not(.touch-device) .header .columns .item-more {
-        display: none !important;
-    }
+.dashboard-section-files .files-tab:not(.touch-device) .files.files-grid-view .row:hover .item-more,
+.dashboard-section-files .files-tab:not(.touch-device) .header .columns .item-more {
+    display: none !important;
 }
 
 .dashboard-section-files .files-tab .files.files-grid-view .row .item-name-editor {
@@ -2444,12 +2441,6 @@ body.myapps-reordering .myapps-tile {
     transform: rotate(-45deg) translate(4px, -4px);
 }
 
-.dashboard-sidebar-separator {
-    height: 1px;
-    background: var(--dashboard-border);
-    margin: 15px 0;
-}
-
 /* Responsive: tablet and below */
 @media (max-width: 768px) {
     .dashboard-sidebar-header {
@@ -2484,6 +2475,15 @@ body.myapps-reordering .myapps-tile {
 
     .dashboard-content {
         padding: 64px 16px 24px;
+    }
+
+    /* The Files tab keeps its own `padding: 0 0 0 10px` (higher specificity)
+       so the rule above doesn't clear the fixed hamburger toggle for it. Push
+       the directories column down instead, so the toggle doesn't sit on top of
+       the first folder row (the column is hidden below 480px, so this only
+       affects the tablet range). */
+    .dashboard-section-files .directories {
+        padding-top: 52px;
     }
 
     .myapps-search-wrap {
@@ -3999,8 +3999,10 @@ body.myapps-reordering .myapps-tile {
     opacity: 0.8;
 }
 
-/* Desktop - transparent backdrop */
-@media (min-width: 768px) {
+/* Desktop - transparent backdrop. Use 769px so it doesn't overlap the mobile
+   rules (all keyed to max-width: 768px) at exactly 768px, where a touch tablet
+   would otherwise get a fully transparent, non-dimming modal backdrop. */
+@media (min-width: 769px) {
     .context-menu-modal-backdrop {
         background-color: transparent;
     }

--- a/src/gui/src/helpers.js
+++ b/src/gui/src/helpers.js
@@ -1814,15 +1814,24 @@ window.move_items = async function (el_items, dest_path, is_undo = false) {
                 // skip next loop iteration because this iteration was successful
                 item_with_same_name_already_exists = false;
 
-                // update all shortcut_to_path
-                $(`.item[data-shortcut_to_path="${html_encode($(el_item).attr('data-path'))}" i]`).attr('data-shortcut_to_path', fsentry.path);
+                // update all shortcut_to_path — compare raw attribute values
+                // (item rows store paths unencoded, so an html_encode()d
+                // selector misses names containing & < > " ')
+                const moved_from_path_lc = String($(el_item).attr('data-path') || '').toLowerCase();
+                $('.item[data-shortcut_to_path]').filter(function () {
+                    return String($(this).attr('data-shortcut_to_path')).toLowerCase() === moved_from_path_lc;
+                }).attr('data-shortcut_to_path', fsentry.path);
 
                 // Remove all items with matching uids from their OLD location(s).
                 // Exclude any row already at the item's new path: a concurrent
                 // item.moved socket handler may have just created a row at the
                 // destination (e.g. the dashboard file view showing the target
                 // directory), and removing by uid alone would delete it too.
-                $(`.item[data-uid='${$(el_item).attr('data-uid')}']`).not(`[data-path="${html_encode(fsentry.path)}" i]`).fadeOut(150, function () {
+                // Raw case-insensitive compare, for the same reason as above.
+                const dest_item_path_lc = fsentry.path.toLowerCase();
+                $(`.item[data-uid='${$(el_item).attr('data-uid')}']`).not(function () {
+                    return String($(this).attr('data-path') || '').toLowerCase() === dest_item_path_lc;
+                }).fadeOut(150, function () {
                     // find all parent windows that contain this item
                     let parent_windows = $(`.item[data-uid='${$(el_item).attr('data-uid')}']`).closest('.window');
                     // remove this item

--- a/src/gui/src/initgui.js
+++ b/src/gui/src/initgui.js
@@ -536,7 +536,16 @@ if (jQuery) {
  * @returns {{ tab: string, path: string|null }} Route object with tab name and optional file path
  */
 function parseDashboardRoute() {
-    const hash = decodeURIComponent(window.location.hash.slice(1)); // Remove '#' and decode URL encoding
+    // decodeURIComponent throws URIError on a malformed percent-sequence (e.g.
+    // `#100%`). This runs at module load, so an unguarded throw blanks the whole
+    // GUI — fall back to the raw hash instead.
+    const rawHash = window.location.hash.slice(1); // Remove '#'
+    let hash;
+    try {
+        hash = decodeURIComponent(rawHash);
+    } catch {
+        hash = rawHash;
+    }
     if (!hash) return { tab: 'apps', path: null };
 
     const parts = hash.split('/').filter(Boolean); // ['files', 'username', 'Documents']


### PR DESCRIPTION
## Summary

Fixes 20+ verified bugs across the GUI Dashboard (the default interface at the site root). Each fix was reproduced or traced to a concrete failure, then verified end-to-end in a running dashboard on a local backend. Grouped into one commit per concern.

## Fixes

**Routing & navigation**
- **Blank app on a shareable URL:** a malformed percent-sequence in the hash (e.g. `#100%`) threw `URIError` in `parseDashboardRoute` at module load, blanking the whole GUI; a hash with a quote (`#foo"bar`) was interpolated into a jQuery selector that throws, leaving all dashboard handlers unbound. Guard the decode and resolve the tab against the known set before it reaches a selector. *(Verified: `#100%` and `#foo"bar` now boot into Apps.)*
- **Double refresh on back/forward:** a single back/forward fires both `popstate` and `hashchange`, so each tab's `onActivate` (and its fetches) ran twice. Track the last-handled URL.
- **Back became a no-op:** re-clicking the active sidebar tab pushed duplicate history entries. Only `pushState` when the hash changes.

**Files**
- **Copy/cut/delete/drag broke on names with `& ' " < >`:** `renderItem` stored `html_encode`d values via `setAttribute`, so `data-path` held literal entities and every fs op hit the server with a mangled path ("Entry not found"). Store raw values; match socket-updated rows by comparison instead of selector interpolation. *(Verified: copy/paste of "Tom & Jerry.txt" now works.)*
- **Stored XSS:** folder names were interpolated unescaped into the back/forward history context menu. Escape them. *(Verified: payload renders inert.)*
- **Blank pane:** a failed `readdir` (permission/deleted/offline) left an empty file area with no message. Show a message and keep navigation working.
- **First shift-click after navigating selected nothing;** `formatFileSize` rendered "NaN undefined" for missing sizes and "1.5 undefined" for ≥1 TB. Fixed both.
- **Stale live updates:** incremental add/remove/move didn't update the footer count; `item.updated` didn't repaint the visible size/modified cells.

**Apps**
- **Uninstall silently reverted** for recommended apps (the protected-name list had drifted from the backend's recommended set). Offer Uninstall only when it will stick.
- **>100 installed apps were silently dropped** (endpoint caps `limit` at 100). Page through all of them.
- **Load races:** a slow, stale load could clobber a newer app list or a just-saved reorder; a drag could be rebuilt out from under; a transient error wiped a working grid. Sequence-guard, re-check drag after await, keep the grid on error.
- **Reverse tabnabbing:** external-app links opened without `noopener` (also on Home).

**Usage & Home**
- Usage "Upgrade" button threw on self-hosted (unguarded `UIUpgradeAccount`); the tab's data was frozen for the whole session (no `onActivate`); resource names showed the backend's `_dot_` escaping; a failed fetch left it blank; storage rendered "NaN%" at capacity 0.
- Home plan button stayed "Manage →" after a subscription lapsed; "Your Plan ›" was a dead link; returning to the tab fired up to 4 duplicate usage reloads; "NaN%" at capacity 0.

**Mobile context menu**
- Submenu items ("New", "Open With") were dead buttons on touch; `disabled` items were tappable and ran their action; the menu was pinned at a hardcoded `left: 300px` on touchscreen laptops. Drill into submenus with a Back row, render disabled items inert, position over the target. *(Verified with touch emulation.)*

**CSS**
- A malformed selector list (comma before `@media`) discarded the rule that hides the row ⋮ on desktop; dark-mode native-drop styles keyed off an attribute never set; a 2-line label clamp defeated by `white-space: nowrap`; a duplicate sidebar-separator rule (doubled divider); grid icons forced to white (dark-mode glare) with a self-overridden radius; hardcoded footer colors (dim/invisible per theme); a `ui-droppable-over` typo; a context-menu backdrop breakpoint overlapping at exactly 768px; the fixed hamburger overlapping the Files directories column at 481–768px.

## Testing

- Reproduced and verified each fix end-to-end against a local backend (`/` and `#tab` routes; Files/Apps/Usage/Home/Account/Security all smoke-tested for regressions).
- `appOrder` unit tests pass (11/11).

## Notes

- Deferred as out of scope / product decisions: broad i18n of hardcoded strings in TabApps (risks showing raw keys where translations are missing), and the shared `byte_format` helper's "5.00 Bytes" style.
- The Apps grid can appear empty on first paint in a **backgrounded** tab (`visibilityState: hidden` defers layout and the pager's ResizeObserver) — this reproduces on `main` and is not introduced here.
