### PR TITLE
fix(ai-chat): respect max_tokens parameter and model limit in MoonshotProvider

### DIFF
--- a/src/backend/drivers/ai-chat/providers/moonshot/MoonshotProvider.test.ts
+++ b/src/backend/drivers/ai-chat/providers/moonshot/MoonshotProvider.test.ts
@@ -202,7 +202,7 @@ describe('MoonshotProvider.complete request shape', () => {
         usage: { prompt_tokens: 1, completion_tokens: 1 },
     };
 
-    it('forwards model + messages and locks max_tokens=1000', async () => {
+    it('forwards model + messages and passes max_tokens or falls back to model max_tokens', async () => {
         const { provider } = makeProvider();
         createMock.mockResolvedValueOnce(baseCompletion);
 
@@ -216,9 +216,24 @@ describe('MoonshotProvider.complete request shape', () => {
         const [args] = createMock.mock.calls[0]!;
         expect(args.model).toBe('kimi-k2.6');
         expect(args.messages).toEqual([{ role: 'user', content: 'hello' }]);
-        // max_tokens is hardcoded by the provider — the call to Moonshot
-        // should always cap at 1000 tokens of completion.
-        expect(args.max_tokens).toBe(1000);
+        expect(args.max_tokens).toBe(262_144);
+    });
+
+    it('passes custom max_tokens when provided in arguments', async () => {
+        const { provider } = makeProvider();
+        createMock.mockResolvedValueOnce(baseCompletion);
+
+        await withTestActor(() =>
+            provider.complete({
+                model: 'kimi-k3',
+                messages: [{ role: 'user', content: 'hello' }],
+                max_tokens: 4096,
+            }),
+        );
+
+        const [args] = createMock.mock.calls[0]!;
+        expect(args.model).toBe('kimi-k3');
+        expect(args.max_tokens).toBe(4096);
     });
 
     it('omits the `tools` key entirely when no tools are supplied', async () => {

--- a/src/backend/drivers/ai-chat/providers/moonshot/MoonshotProvider.ts
+++ b/src/backend/drivers/ai-chat/providers/moonshot/MoonshotProvider.ts
@@ -68,6 +68,7 @@ export class MoonshotProvider implements IChatProvider {
         stream,
         model,
         tools,
+        max_tokens,
     }: ICompleteArguments): Promise<IChatCompleteResult> {
         const actor = Context.get('actor');
         const availableModels = this.models();
@@ -89,7 +90,7 @@ export class MoonshotProvider implements IChatProvider {
                 messages,
                 model: modelUsed.id,
                 ...(tools ? { tools } : {}),
-                max_tokens: 1000,
+                max_tokens: max_tokens || modelUsed.max_tokens || 1000,
                 stream,
                 ...(stream
                     ? {


### PR DESCRIPTION
Fixes #3408

### Summary
In `MoonshotProvider.ts`, `complete()` hardcoded `max_tokens: 1000` when invoking the Moonshot API and ignored the `max_tokens` argument in `ICompleteArguments`.

Because thinking models like **Kimi K3** perform internal reasoning steps before generating output text, they consume tokens during reasoning. With a hardcoded 1000-token limit, Kimi K3 exhausts its token budget during thinking and returns `finish_reason: "length"` with no output text.

### Changes
- Destructured `max_tokens` from `ICompleteArguments` in `MoonshotProvider.complete()`.
- Passed `max_tokens: max_tokens || modelUsed.max_tokens || 1000` to allow caller-specified `max_tokens` while defaulting to the model's configured max token limit (`modelUsed.max_tokens`).
- Updated unit tests in `MoonshotProvider.test.ts` to verify `max_tokens` pass-through and fallback behavior.

### Testing
Ran unit test suite via `npm run test:backend`:
`✓ src/backend/drivers/ai-chat/providers/moonshot/MoonshotProvider.test.ts (22 tests passed)`
