### PR TITLE
fix: showSaveFilePicker from external websites

### DIFF
--- a/src/backend/controllers/fs/LegacyFSController.ts
+++ b/src/backend/controllers/fs/LegacyFSController.ts
@@ -167,8 +167,7 @@ export class LegacyFSController extends PuterController {
 
         router.get('/get-launch-apps', apiOptions, async (req, res) => {
             const recommendedSvc = this.services.recommendedApps as unknown as
-                | { getRecommendedApps?: () => Promise<unknown[]> }
-                | undefined;
+                { getRecommendedApps?: () => Promise<unknown[]> } | undefined;
             const recommended = recommendedSvc?.getRecommendedApps
                 ? await recommendedSvc.getRecommendedApps()
                 : [];
@@ -640,9 +639,7 @@ export class LegacyFSController extends PuterController {
             // Trash, and `null`/`{}` when restoring. See
             // `src/gui/src/helpers.js` → `window.move_items`.
             newMetadata: (body.new_metadata ?? undefined) as
-                | Record<string, unknown>
-                | null
-                | undefined,
+                Record<string, unknown> | null | undefined,
         });
         const oldPath = source.path;
         await this.#emitGuiEvent('outer.gui.item.moved', moved, {
@@ -1071,8 +1068,7 @@ export class LegacyFSController extends PuterController {
         }
 
         type SignedOrEmpty =
-            | (SignedFile & { path?: string })
-            | Record<string, never>;
+            (SignedFile & { path?: string }) | Record<string, never>;
         const result: { signatures: SignedOrEmpty[]; token?: string } = {
             signatures: [],
         };
@@ -1612,10 +1608,7 @@ export class LegacyFSController extends PuterController {
         const subjectRef = body.subject;
         const appRef = body.app;
         const mode = (getString(body, 'mode') ?? 'read') as
-            | 'see'
-            | 'list'
-            | 'read'
-            | 'write';
+            'see' | 'list' | 'read' | 'write';
         if (!subjectRef || !appRef)
             throw new HttpError(400, '`subject` and `app` are required', {
                 legacyCode: 'bad_request',
@@ -2271,12 +2264,21 @@ export class LegacyFSController extends PuterController {
 
     #serializeBatchError(err: unknown): Record<string, unknown> {
         if (err instanceof HttpError) {
-            return {
+            const payload: Record<string, unknown> = {
                 error: true,
                 status: err.statusCode,
                 message: err.message,
                 code: err.legacyCode ?? err.code,
             };
+            // Same as the terminal errorHandler: extra fields (e.g.
+            // `entry_name` on item_with_same_name_exists) ride along
+            // without clobbering the canonical slots.
+            if (err.fields) {
+                for (const [k, v] of Object.entries(err.fields)) {
+                    if (!(k in payload)) payload[k] = v;
+                }
+            }
+            return payload;
         }
         if (err instanceof Error) {
             return { error: true, status: 500, message: err.message };

--- a/src/backend/services/fs/FSService.ts
+++ b/src/backend/services/fs/FSService.ts
@@ -558,10 +558,20 @@ export class FSService extends PuterService {
                 );
             }
             if (existingEntry && !normalizedInput.overwrite) {
+                // v1 wire contract: clients (the GUI's save dialogs among
+                // them) key on `item_with_same_name_exists` + `entry_name`
+                // to offer an overwrite prompt.
                 throw new HttpError(
                     409,
                     'A file already exists at this path and overwrite was not requested',
-                    { legacyCode: 'conflict' },
+                    {
+                        legacyCode: 'item_with_same_name_exists',
+                        fields: {
+                            entry_name: pathPosix.basename(
+                                normalizedInput.path,
+                            ),
+                        },
+                    },
                 );
             }
 

--- a/src/gui/src/initgui.js
+++ b/src/gui/src/initgui.js
@@ -54,7 +54,10 @@ import { LaunchOnInitService } from './services/LaunchOnInitService.js';
 import { LocaleService } from './services/LocaleService.js';
 import { ProcessService } from './services/ProcessService.js';
 import { ThemeService } from './services/ThemeService.js';
-import { privacy_aware_path } from './util/desktop.js';
+// Curried: takes `{ window }` and returns the path mapper. Import under a
+// factory name so a bare `privacy_aware_path(path)` call in this module can't
+// silently resolve to the factory — use `window.privacy_aware_path` instead.
+import { privacy_aware_path as privacy_aware_path_factory } from './util/desktop.js';
 
 const postAuthActions = async (action) => {
     // -------------------------------------------------------------------------------------
@@ -378,7 +381,7 @@ const postAuthActions = async (action) => {
                                         metadataURL: file_signature.metadata_url,
                                         type: file_signature.type,
                                         uid: file_signature.uid,
-                                        path: privacy_aware_path(res.path),
+                                        path: window.privacy_aware_path(res.path),
                                     },
                                 }, '*');
 
@@ -2076,7 +2079,7 @@ $(document).on('contextmenu', '.disable-context-menu', function (e) {
 });
 
 // util/desktop.js
-window.privacy_aware_path = privacy_aware_path({ window });
+window.privacy_aware_path = privacy_aware_path_factory({ window });
 
 $(window).on('system-logout-event', function () {
     // Clear cookie


### PR DESCRIPTION
## Problem

Calling `puter.ui.showSaveFilePicker` from a third-party website (the popup flow) was fully broken: after entering a filename and clicking Save, the dialog threw a garbled error — `Failed to execute 'postMessage' on 'Window': function(t){return t.startsWith("~/")… could not be cloned` — the file was written but the caller's promise never resolved. Additionally, saving over an existing filename showed a raw `A file already exists at this path and overwrite was not requested` alert instead of the Replace/Cancel prompt.

## Root causes

**1. GUI (DataCloneError):** `privacy_aware_path` in `util/desktop.js` is a curried factory (`world => fspath => …`). `initgui.js` is the only module that imports it directly, so the popup save handler's `privacy_aware_path(res.path)` returned the **inner function**, which `postMessage` can't structured-clone. Every other call site resolves the bare name to the correctly bound `window.privacy_aware_path` global — which is why the in-Puter app iframe flow worked while the external-site popup flow crashed.

**2. Backend (missing overwrite prompt):** the v2 backend returns `code: 'conflict'` for a same-name write, but the v1 wire contract is `item_with_same_name_exists` + `entry_name`, which the GUI's save dialogs (and the copy/move/rename helpers) key on to offer the overwrite prompt. The `/batch` per-op error serializer also dropped `HttpError.fields`, so `entry_name` couldn't reach clients even when set.

## Changes

- `src/gui/src/initgui.js` — post `window.privacy_aware_path(res.path)` in the popup save handler; import the curried factory under a distinct name (`privacy_aware_path_factory`) so a bare call can't silently resolve to it again.
- `src/backend/services/fs/FSService.ts` — the write-conflict 409 uses `legacyCode: 'item_with_same_name_exists'` and carries `entry_name` (basename of the target path).
- `src/backend/controllers/fs/LegacyFSController.ts` — `#serializeBatchError` passes `err.fields` through, mirroring the terminal errorHandler.

## Verification

- End-to-end in Chrome against a local backend, from a fixture page on a separate origin: a fresh save resolves the caller's promise with the full signed `saved_file` (`name`, `~/Desktop/…` path, uid, read/write/metadata URLs) and the popup closes; saving an existing filename shows the Replace/Cancel prompt, and Replace overwrites and resolves.
- `/batch` write-conflict wire shape: `{"error":true,"status":409,"code":"item_with_same_name_exists","entry_name":"…"}` (HTTP 218).
- `npm run test:backend`: no new failures (2937 passed; the 9 `fetch failed` failures in `testUtil.test.ts` / `FSController.http.test.ts` are identical on clean main in this environment).
- ESLint: no new issues on the touched files.

## Notes / follow-ups (not in this PR)

- Copy/move/rename conflicts likely have the same legacy-code drift (`conflict` vs `item_with_same_name_exists`); only the write path is restored here to keep the change surgical.
- Pre-existing on main: `src/gui/src/i18n/i18n.js` default-exports `{}`, so `open_item.js` (which imports it) throws when opening a file with no associated app — same import-shadows-global trap class as bug 1.