### PR TITLE
fix(puter-js): forward temperature 0 and max_tokens 0 in ai.chat

### DIFF
--- a/src/puter-js/src/modules/ai/ai.test.js
+++ b/src/puter-js/src/modules/ai/ai.test.js
@@ -163,6 +163,18 @@ describe('ai.chat driver payloads', () => {
         });
     });
 
+    it('chat(prompt, options) forwards temperature: 0 and max_tokens: 0', async () => {
+        await ai.chat('hello', {
+            temperature: 0,
+            max_tokens: 0,
+        });
+        expect(lastBody().args).toEqual({
+            messages: [{ content: 'hello' }],
+            temperature: 0,
+            max_tokens: 0,
+        });
+    });
+
     it('chat(prompt, imageURL) builds a vision request', async () => {
         await ai.chat('describe', 'https://example.com/cat.png');
         expect(lastBody().args).toEqual({

--- a/src/puter-js/src/modules/ai/chat.js
+++ b/src/puter-js/src/modules/ai/chat.js
@@ -201,14 +201,16 @@ export async function chat (
     /** @type {ChatOptions & { stream?: boolean }} */
     const userParams = extras.find(isPlainObject) ?? {};
 
-    // Copy relevant parameters from userParams to requestParams
-    if (userParams.model) {
+    // Copy relevant parameters from userParams to requestParams.
+    // Use `!== undefined` so legitimate zeros (temperature: 0, max_tokens: 0)
+    // are forwarded — truthy checks silently drop them.
+    if (userParams.model !== undefined) {
         requestParams.model = userParams.model;
     }
-    if (userParams.temperature) {
+    if (userParams.temperature !== undefined) {
         requestParams.temperature = userParams.temperature;
     }
-    if (userParams.max_tokens) {
+    if (userParams.max_tokens !== undefined) {
         requestParams.max_tokens = userParams.max_tokens;
     }
 
@@ -220,7 +222,7 @@ export async function chat (
     }
 
     for (const name of PARAMS_TO_PASS) {
-        if (userParams[name]) {
+        if (userParams[name] !== undefined) {
             requestParams[name] = userParams[name];
         }
     }


### PR DESCRIPTION
## Summary
- `puter.ai.chat` used truthy checks for `temperature` and `max_tokens`, so `temperature: 0` / `max_tokens: 0` were silently dropped before the driver call.
- Switch to `!== undefined` (same pattern already used for `stream`) so deterministic sampling actually reaches the backend.
- Also apply `!== undefined` to `PARAMS_TO_PASS` so other falsy-but-valid values are not dropped.

## Why this is real
Documented temperature range is `0–2`. Apps requesting deterministic output (`temperature: 0`) currently get the model default instead with no error.

## Test plan
- [x] Regression test fails before the fix and passes after (`chat(prompt, options) forwards temperature: 0 and max_tokens: 0`)
- [x] `vitest run src/puter-js/src/modules/ai/ai.test.js` — 51 passed