### PR TITLE
fix(ai-chat): forward temperature 0 and max_tokens 0 to Completions providers

### DIFF
--- a/src/backend/drivers/ai-chat/providers/azure/AzureChatProvider.ts
+++ b/src/backend/drivers/ai-chat/providers/azure/AzureChatProvider.ts
@@ -50,9 +50,7 @@ import { AZURE_MODELS } from './models.js';
  * spending records, and content moderation.
  */
 export class AzureChatProvider implements IChatProvider {
-    /**
-     * @type {import('openai').OpenAI}
-     */
+    /** @type {import('openai').OpenAI} */
     #openAi: OpenAI;
 
     #defaultModel = 'gpt-5.4-nano';
@@ -95,7 +93,8 @@ export class AzureChatProvider implements IChatProvider {
 
     /**
      * Returns an array of available AI models with their pricing information.
-     * Each model object includes an ID and cost details (currency, tokens, input/output rates).
+     * Each model object includes an ID and cost details (currency, tokens,
+     * input/output rates).
      */
     models() {
         return AZURE_MODELS.filter((e) => !e.responses_api_only);
@@ -213,8 +212,10 @@ export class AzureChatProvider implements IChatProvider {
             messages: messages,
             model: modelUsed.id,
             ...(tools ? { tools } : {}),
-            ...(max_tokens ? { max_completion_tokens: max_tokens } : {}),
-            ...(temperature ? { temperature } : {}),
+            ...(max_tokens !== undefined
+                ? { max_completion_tokens: max_tokens }
+                : {}),
+            ...(temperature !== undefined ? { temperature } : {}),
             stream: !!stream,
             ...(stream
                 ? {

--- a/src/backend/drivers/ai-chat/providers/gemini/GeminiChatProvider.test.ts
+++ b/src/backend/drivers/ai-chat/providers/gemini/GeminiChatProvider.test.ts
@@ -206,6 +206,24 @@ describe('GeminiChatProvider.complete request shape', () => {
         expect(args.temperature).toBe(0.4);
     });
 
+    it('forwards temperature 0 and max_tokens 0 instead of dropping them', async () => {
+        const { provider } = makeProvider();
+        createMock.mockResolvedValueOnce(baseCompletion);
+
+        await withTestActor(() =>
+            provider.complete({
+                model: 'gemini-2.5-flash',
+                messages: [{ role: 'user', content: 'hello' }],
+                max_tokens: 0,
+                temperature: 0,
+            }),
+        );
+
+        const [args] = createMock.mock.calls[0]!;
+        expect(args.max_completion_tokens).toBe(0);
+        expect(args.temperature).toBe(0);
+    });
+
     it('omits max_completion_tokens and temperature when caller did not supply them', async () => {
         const { provider } = makeProvider();
         createMock.mockResolvedValueOnce(baseCompletion);

--- a/src/backend/drivers/ai-chat/providers/gemini/GeminiChatProvider.ts
+++ b/src/backend/drivers/ai-chat/providers/gemini/GeminiChatProvider.ts
@@ -3,18 +3,19 @@
  *
  * This file is part of Puter.
  *
- * Puter is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ * Puter is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * along with this program. If not, see
+ * [https://www.gnu.org/licenses/](https://www.gnu.org/licenses/).
  */
 
 // Preamble: Before this we used Gemini's SDK directly and as we found out
@@ -83,8 +84,10 @@ export class GeminiChatProvider implements IChatProvider {
             messages: messages,
             model: modelUsed.id,
             ...(tools ? { tools } : {}),
-            ...(max_tokens ? { max_completion_tokens: max_tokens } : {}),
-            ...(temperature ? { temperature } : {}),
+            ...(max_tokens !== undefined
+                ? { max_completion_tokens: max_tokens }
+                : {}),
+            ...(temperature !== undefined ? { temperature } : {}),
             stream,
             ...(stream
                 ? {

--- a/src/backend/drivers/ai-chat/providers/openai/OpenAiChatCompletionsProvider.test.ts
+++ b/src/backend/drivers/ai-chat/providers/openai/OpenAiChatCompletionsProvider.test.ts
@@ -269,6 +269,24 @@ describe('OpenAiChatProvider.complete request shape', () => {
         expect(args.temperature).toBe(0.4);
     });
 
+    it('forwards temperature 0 and max_tokens 0 instead of dropping them', async () => {
+        const { provider } = makeProvider();
+        createMock.mockResolvedValueOnce(baseCompletion);
+
+        await withTestActor(() =>
+            provider.complete({
+                model: 'gpt-5-nano',
+                messages: [{ role: 'user', content: 'hello' }],
+                max_tokens: 0,
+                temperature: 0,
+            }),
+        );
+
+        const [args] = createMock.mock.calls[0]!;
+        expect(args.max_completion_tokens).toBe(0);
+        expect(args.temperature).toBe(0);
+    });
+
     it('drops reasoning_effort and verbosity for gpt-5-prefixed models (they manage these themselves)', async () => {
         const { provider } = makeProvider();
         createMock.mockResolvedValueOnce(baseCompletion);

--- a/src/backend/drivers/ai-chat/providers/openai/OpenAiChatCompletionsProvider.ts
+++ b/src/backend/drivers/ai-chat/providers/openai/OpenAiChatCompletionsProvider.ts
@@ -36,16 +36,15 @@ import { OPEN_AI_MODELS } from './models.js';
 import type { OpenAiResponsesChatProvider } from './OpenAiChatResponsesProvider.js';
 
 /**
- * OpenAICompletionService class provides an interface to OpenAI's chat completion API.
- * Extends BaseService to handle chat completions, message moderation, token counting,
- * and streaming responses. Implements the puter-chat-completion interface and manages
- * OpenAI API interactions with support for multiple models including GPT-4 variants.
- * Handles usage tracking, spending records, and content moderation.
+ * OpenAICompletionService class provides an interface to OpenAI's chat
+ * completion API. Extends BaseService to handle chat completions, message
+ * moderation, token counting, and streaming responses. Implements the
+ * puter-chat-completion interface and manages OpenAI API interactions with
+ * support for multiple models including GPT-4 variants. Handles usage tracking,
+ * spending records, and content moderation.
  */
 export class OpenAiChatProvider implements IChatProvider {
-    /**
-     * @type {import('openai').OpenAI}
-     */
+    /** @type {import('openai').OpenAI} */
     #openAi: OpenAI;
 
     #defaultModel = 'gpt-5-nano';
@@ -79,7 +78,8 @@ export class OpenAiChatProvider implements IChatProvider {
 
     /**
      * Returns an array of available AI models with their pricing information.
-     * Each model object includes an ID and cost details (currency, tokens, input/output rates).
+     * Each model object includes an ID and cost details (currency, tokens,
+     * input/output rates).
      */
     models() {
         return OPEN_AI_MODELS.filter((e) => !e.responses_api_only);
@@ -192,8 +192,10 @@ export class OpenAiChatProvider implements IChatProvider {
             messages: messages,
             model: modelUsed.id,
             ...(tools ? { tools } : {}),
-            ...(max_tokens ? { max_completion_tokens: max_tokens } : {}),
-            ...(temperature ? { temperature } : {}),
+            ...(max_tokens !== undefined
+                ? { max_completion_tokens: max_tokens }
+                : {}),
+            ...(temperature !== undefined ? { temperature } : {}),
             stream: !!stream,
             ...(stream
                 ? {

--- a/src/backend/drivers/ai-chat/providers/together/TogetherAIProvider.test.ts
+++ b/src/backend/drivers/ai-chat/providers/together/TogetherAIProvider.test.ts
@@ -262,6 +262,24 @@ describe('TogetherAIProvider.complete request shape', () => {
         expect('max_tokens' in createMock.mock.calls[0]![0]).toBe(false);
     });
 
+    it('forwards temperature 0 and max_tokens 0 instead of dropping them', async () => {
+        const { provider } = makeProvider();
+        createMock.mockResolvedValueOnce(baseCompletion);
+
+        await withTestActor(() =>
+            provider.complete({
+                model: 'togetherai:Qwen/Qwen2.5-7B-Instruct-Turbo',
+                messages: [{ role: 'user', content: 'hi' }],
+                max_tokens: 0,
+                temperature: 0,
+            }),
+        );
+
+        const [args] = createMock.mock.calls[0]!;
+        expect(args.max_tokens).toBe(0);
+        expect(args.temperature).toBe(0);
+    });
+
     it('passes tools through unchanged when supplied; omits the key when not', async () => {
         const { provider } = makeProvider();
 

--- a/src/backend/drivers/ai-chat/providers/together/TogetherAIProvider.ts
+++ b/src/backend/drivers/ai-chat/providers/together/TogetherAIProvider.ts
@@ -150,8 +150,8 @@ export class TogetherAIProvider implements IChatProvider {
             messages,
             stream,
             ...(tools ? { tools } : {}),
-            ...(max_tokens ? { max_tokens } : {}),
-            ...(temperature ? { temperature } : {}),
+            ...(max_tokens !== undefined ? { max_tokens } : {}),
+            ...(temperature !== undefined ? { temperature } : {}),
             ...(stream ? { stream_options: { include_usage: true } } : {}),
         } as Together.Chat.Completions.CompletionCreateParamsNonStreaming);
 


### PR DESCRIPTION
## Summary
- OpenAI Completions, Gemini, Together, and Azure Chat providers used truthy spreads (`temperature ? { temperature } : {}`), so `temperature: 0` and `max_tokens: 0` never reached the upstream SDK.
- Align with Responses-family providers that already use `temperature !== undefined`.

## Why this is real
Even with a correct SDK payload, Completions-path providers still strip zeros. Deterministic requests only worked on Responses providers.

## Test plan
- [x] New unit tests fail before the fix and pass after for OpenAI Completions, Gemini, and Together
- [x] `npm run test:backend -- … -t "forwards temperature 0"` — 3 passed