### PR TITLE
ci: attach provenance and SBOM attestations to the published image

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -87,6 +87,8 @@ jobs:
                   platforms: linux/amd64,linux/arm64
                   context: .
                   push: true
+                  provenance: mode=max
+                  sbom: true
                   tags: ${{ steps.meta.outputs.tags }}
                   labels: ${{ steps.meta.outputs.labels }}
                   cache-from: type=gha


### PR DESCRIPTION
Hi, and thanks for Puter.

`.github/workflows/docker-image.yaml` publishes the image to `ghcr.io` on tag, but the pushed manifest carries no provenance or SBOM attestation. Someone pulling it has no way to check that it was built by this workflow, from this repository, at that tag.

For Puter that seemed worth raising because the image is the product as far as a self-hoster is concerned — people run it to host their own files and desktop, so the container is holding user data directly rather than sitting behind another distribution step that might vouch for it.

The change is two lines on the build step:

```yaml
                  push: true
                  provenance: mode=max
                  sbom: true
```

BuildKit attaches the attestation to the image manifest, so it travels with the image to GHCR without any extra plumbing — and importantly **no permissions change is needed**. Nothing has to gain `id-token`, and your existing `cache-from` / `cache-to` setup is untouched.

Consumers can then verify with:

```
docker buildx imagetools inspect ghcr.io/heyputer/puter:<tag> --format '{{ json .Provenance }}'
```

Two caveats worth knowing:

- `mode=max` records the full build including build args. Usually right for a public image; `provenance: true` gives a smaller record if any build arg has ever been sensitive.
- Attestations add an extra manifest to the index — GHCR handles this fine, but worth knowing if a mirror sits in front of it.

No SLSA level claimed; the attestation is what BuildKit produces.

Disclosure: I used AI assistance to help spot this and prepare the change, and I read the workflow myself.
