### PR TITLE
fix(ai-chat): preserve max_tokens 0 for Alibaba, DeepSeek, and Claude

### DIFF
--- a/src/backend/drivers/ai-chat/providers/alibaba/AlibabaProvider.test.ts
+++ b/src/backend/drivers/ai-chat/providers/alibaba/AlibabaProvider.test.ts
@@ -225,6 +225,21 @@ describe('AlibabaProvider.complete request shape', () => {
         expect(createMock.mock.calls[0]![0].max_tokens).toBe(256);
     });
 
+    it('forwards max_tokens 0 instead of substituting the default 1000', async () => {
+        const { provider } = makeProvider();
+        createMock.mockResolvedValueOnce(baseCompletion);
+
+        await withTestActor(() =>
+            provider.complete({
+                model: 'qwen-plus',
+                messages: [{ role: 'user', content: 'hi' }],
+                max_tokens: 0,
+            }),
+        );
+
+        expect(createMock.mock.calls[0]![0].max_tokens).toBe(0);
+    });
+
     it('forwards temperature when supplied', async () => {
         const { provider } = makeProvider();
         createMock.mockResolvedValueOnce(baseCompletion);

--- a/src/backend/drivers/ai-chat/providers/alibaba/AlibabaProvider.ts
+++ b/src/backend/drivers/ai-chat/providers/alibaba/AlibabaProvider.ts
@@ -86,7 +86,7 @@ export class AlibabaProvider implements IChatProvider {
             messages,
             model: modelUsed.id,
             ...(tools ? { tools } : {}),
-            max_tokens: max_tokens || 1000,
+            max_tokens: max_tokens ?? 1000,
             temperature,
             stream,
             ...(stream

--- a/src/backend/drivers/ai-chat/providers/claude/ClaudeProvider.test.ts
+++ b/src/backend/drivers/ai-chat/providers/claude/ClaudeProvider.test.ts
@@ -237,6 +237,22 @@ describe('ClaudeProvider.complete request shape', () => {
         });
     });
 
+    it('forwards max_tokens 0 instead of substituting the model default', async () => {
+        const { provider } = makeProvider();
+        messagesCreateMock.mockResolvedValueOnce(baseResponse);
+
+        await withTestActor(() =>
+            provider.complete({
+                model: 'claude-haiku-4-5-20251001',
+                messages: [{ role: 'user', content: 'hello' }],
+                max_tokens: 0,
+            }),
+        );
+
+        const [args] = messagesCreateMock.mock.calls[0]!;
+        expect(args.max_tokens).toBe(0);
+    });
+
     it('extracts system messages and forwards them as the top-level `system` field', async () => {
         const { provider } = makeProvider();
         messagesCreateMock.mockResolvedValueOnce(baseResponse);

--- a/src/backend/drivers/ai-chat/providers/claude/ClaudeProvider.ts
+++ b/src/backend/drivers/ai-chat/providers/claude/ClaudeProvider.ts
@@ -320,7 +320,7 @@ export class ClaudeProvider implements IChatProvider {
         } = {
             model: modelUsed.id,
             max_tokens: Math.floor(
-                max_tokens ||
+                max_tokens ??
                     (model === 'claude-3-5-sonnet-20241022' ||
                     model === 'claude-3-5-sonnet-20240620'
                         ? 8192

--- a/src/backend/drivers/ai-chat/providers/deepseek/DeepSeekProvider.test.ts
+++ b/src/backend/drivers/ai-chat/providers/deepseek/DeepSeekProvider.test.ts
@@ -216,6 +216,21 @@ describe('DeepSeekProvider.complete request shape', () => {
         expect(createMock.mock.calls[0]![0].max_tokens).toBe(256);
     });
 
+    it('forwards max_tokens 0 instead of substituting the default 1000', async () => {
+        const { provider } = makeProvider();
+        createMock.mockResolvedValueOnce(baseCompletion);
+
+        await withTestActor(() =>
+            provider.complete({
+                model: 'deepseek-v4-flash',
+                messages: [{ role: 'user', content: 'hi' }],
+                max_tokens: 0,
+            }),
+        );
+
+        expect(createMock.mock.calls[0]![0].max_tokens).toBe(0);
+    });
+
     it('omits the `tools` key entirely when no tools are supplied', async () => {
         const { provider } = makeProvider();
         createMock.mockResolvedValueOnce(baseCompletion);

--- a/src/backend/drivers/ai-chat/providers/deepseek/DeepSeekProvider.ts
+++ b/src/backend/drivers/ai-chat/providers/deepseek/DeepSeekProvider.ts
@@ -117,7 +117,7 @@ export class DeepSeekProvider implements IChatProvider {
             messages,
             model: modelUsed.id,
             ...(tools ? { tools } : {}),
-            max_tokens: max_tokens || 1000,
+            max_tokens: max_tokens ?? 1000,
             temperature,
             stream,
             ...(stream


### PR DESCRIPTION
## Summary
- Alibaba, DeepSeek, and Claude used `max_tokens || default`, so an explicit `max_tokens: 0` was replaced by the provider fallback (`1000` / model default).
- Switch to nullish coalescing (`??`) so zero is forwarded, matching MiniMax and the Completions providers fixed earlier.

## Why this is real
Callers that pass `max_tokens: 0` silently get a large default instead. No dedicated issue tracked this leftover for these three providers.

## Test plan
- [x] Regression tests fail before the fix (`expected 1000 to be 0`) and pass after for Alibaba, DeepSeek, and Claude
- [x] `npm run test:backend -- … -t "forwards max_tokens 0"` — 3 passed