### PR TITLE
fix(puter-js): guard PWispHandler against unknown stream ids

### DIFF
--- a/src/puter-js/src/modules/networking/PWispHandler.js
+++ b/src/puter-js/src/modules/networking/PWispHandler.js
@@ -29,10 +29,18 @@ export class PWispHandler {
             };
             this._ws.onmessage = (event) => {
                 const parsed = parseIncomingPacket(new Uint8Array(event.data));
+                if ( ! parsed ) {
+                    return;
+                }
                 switch ( parsed.packetType ) {
-                case DATA:
-                    this.streamMap.get(parsed.streamID).dataCallBack(parsed.payload.slice(0)); // return a copy for the user to do as they please
+                case DATA: {
+                    const stream = this.streamMap.get(parsed.streamID);
+                    if ( ! stream ) {
+                        break;
+                    }
+                    stream.dataCallBack(parsed.payload.slice(0)); // return a copy for the user to do as they please
                     break;
+                }
                 case CONTINUE:
                     if ( parsed.streamID === 0 ) {
                         this._bufferMax = parsed.remainingBuffer;
@@ -42,13 +50,22 @@ export class PWispHandler {
                         }
                         return;
                     }
-                    this.streamMap.get(parsed.streamID).buffer = parsed.remainingBuffer;
-                    this._continue(parsed.streamID);
+                    {
+                        const stream = this.streamMap.get(parsed.streamID);
+                        if ( ! stream ) {
+                            break;
+                        }
+                        stream.buffer = parsed.remainingBuffer;
+                        this._continue(parsed.streamID);
+                    }
                     break;
                 case CLOSE:
-                    if ( parsed.streamID !== 0 )
-                    {
-                        this.streamMap.get(parsed.streamID).closeCallBack(parsed.reason);
+                    if ( parsed.streamID !== 0 ) {
+                        const stream = this.streamMap.get(parsed.streamID);
+                        if ( ! stream ) {
+                            break;
+                        }
+                        stream.closeCallBack(parsed.reason);
                     }
                     break;
                 case INFO:

--- a/src/puter-js/src/modules/networking/PWispHandler.test.js
+++ b/src/puter-js/src/modules/networking/PWispHandler.test.js
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { CONTINUE, DATA, createWispPacket, parseIncomingPacket } from './parsers.js';
+import { CLOSE, CONTINUE, DATA, createWispPacket, parseIncomingPacket } from './parsers.js';
 import { PWispHandler } from './PWispHandler.js';
 
 // Fake WebSocket standing in for the relay connection. Records every instance
@@ -147,5 +147,42 @@ describe('PWispHandler backpressure', () => {
         expect(flushed.packetType).toBe(DATA);
         expect(flushed.streamID).toBe(streamID);
         expect(Array.from(flushed.payload)).toEqual([2]);
+    });
+});
+
+describe('PWispHandler unknown streams', () => {
+    // Late/duplicate frames after close (or hostile stream ids) used to
+    // null-deref streamMap.get(...) and crash the shared relay onmessage.
+    it('ignores DATA for an unknown stream id', () => {
+        new PWispHandler('wss://relay.test/', 'token');
+        handshake();
+
+        expect(() => deliver(createWispPacket({
+            packetType: DATA,
+            streamID: 999,
+            payload: new Uint8Array([1, 2, 3]),
+        }))).not.toThrow();
+    });
+
+    it('ignores CONTINUE for an unknown stream id', () => {
+        new PWispHandler('wss://relay.test/', 'token');
+        handshake();
+
+        expect(() => deliver(createWispPacket({
+            packetType: CONTINUE,
+            streamID: 999,
+            remainingBuffer: 4,
+        }))).not.toThrow();
+    });
+
+    it('ignores CLOSE for an unknown stream id', () => {
+        new PWispHandler('wss://relay.test/', 'token');
+        handshake();
+
+        expect(() => deliver(createWispPacket({
+            packetType: CLOSE,
+            streamID: 999,
+            reason: 0x02,
+        }))).not.toThrow();
     });
 });


### PR DESCRIPTION
## Summary
- `DATA` / `CONTINUE` / `CLOSE` frames for missing `streamMap` entries null-dereferenced and crashed the shared Wisp relay `onmessage` handler.
- Look up the stream first and ignore unknown ids (also guard a missing parse result).

## Why this is real
Late/duplicate frames after close, or hostile stream ids, could take down every socket sharing that Wisp connection.

## Test plan
- [x] New tests fail before the fix and pass after for unknown DATA/CONTINUE/CLOSE
- [x] `vitest run src/puter-js/src/modules/networking/PWispHandler.test.js` — 10 passed