### PR TITLE
fix: surface name collisions when pasting instead of failing silently

### DIFF
--- a/src/backend/services/fs/FSService.ts
+++ b/src/backend/services/fs/FSService.ts
@@ -3496,10 +3496,16 @@ export class FSService extends PuterService {
             } else if (input.dedupeName) {
                 name = await this.#findDedupedName(destinationParent, name);
             } else {
+                // v1 wire contract: clients (the GUI's move/paste flows among
+                // them) key on `item_with_same_name_exists` + `entry_name` to
+                // offer a replace/skip prompt.
                 throw new HttpError(
                     409,
                     `An entry already exists at ${targetPath}`,
-                    { legacyCode: 'conflict' },
+                    {
+                        legacyCode: 'item_with_same_name_exists',
+                        fields: { entry_name: name },
+                    },
                 );
             }
         }
@@ -3599,10 +3605,14 @@ export class FSService extends PuterService {
             } else if (input.dedupeName) {
                 name = await this.#findDedupedName(destinationParent, name);
             } else {
+                // v1 wire contract, as in move() above.
                 throw new HttpError(
                     409,
                     `An entry already exists at ${targetPath}`,
-                    { legacyCode: 'conflict' },
+                    {
+                        legacyCode: 'item_with_same_name_exists',
+                        fields: { entry_name: name },
+                    },
                 );
             }
         }

--- a/src/gui/src/UI/Dashboard/TabFiles.js
+++ b/src/gui/src/UI/Dashboard/TabFiles.js
@@ -3052,17 +3052,53 @@ const TabFiles = {
             return;
         }
 
+        const { html_encode } = window;
+        const multiple_items = window.clipboard.length > 1;
+        // Set once the user picks "Replace all" on a conflict; later items
+        // then overwrite without asking again.
+        let overwrite_all = false;
+
         for ( const item of window.clipboard ) {
             // Handle both object format { path, uid } and legacy string format
             const source = item.uid || item.path || item;
-            try {
-                await puter.fs.move({
-                    source: source,
-                    destination: destPath,
-                });
-            } catch ( err ) {
-                console.error('Failed to move item:', err);
-            }
+            let overwrite = overwrite_all;
+            let retry;
+            do {
+                retry = false;
+                try {
+                    await puter.fs.move({
+                        source: source,
+                        destination: destPath,
+                        overwrite: overwrite,
+                    });
+                } catch ( err ) {
+                    // Same conflict resolution as the desktop's move_items:
+                    // ask, then retry with overwrite or leave the item be.
+                    if ( err.code === 'item_with_same_name_exists' ) {
+                        const alert_resp = await UIAlert({
+                            message: `<strong>${html_encode(err.entry_name)}</strong> already exists.`,
+                            buttons: [
+                                { label: i18n('replace'), type: 'primary', value: 'replace' },
+                                ... multiple_items ? [{ label: i18n('replace_all'), value: 'replace_all' }] : [],
+                                ... multiple_items ? [{ label: i18n('skip'), value: 'skip' }] : [{ label: i18n('cancel'), value: 'cancel' }],
+                            ],
+                        });
+                        if ( alert_resp === 'replace' ) {
+                            overwrite = true;
+                            retry = true;
+                        } else if ( alert_resp === 'replace_all' ) {
+                            overwrite = true;
+                            overwrite_all = true;
+                            retry = true;
+                        }
+                        // skip/cancel: the item stays where it was cut from
+                    } else {
+                        console.error('Failed to move item:', err);
+                        const item_name = String(item.path || source).split('/').pop();
+                        UIAlert(`<p>Moving <strong>${html_encode(item_name)}</strong></p>${html_encode(err.message ?? '')}`);
+                    }
+                }
+            } while ( retry );
         }
 
         window.clipboard = [];

--- a/src/gui/src/keyboard.js
+++ b/src/gui/src/keyboard.js
@@ -870,6 +870,15 @@ $(document).bind('keyup keydown', async function (e) {
         if ( parent_container ) {
             target_el = parent_container;
             target_path = $(parent_container).attr('data-path');
+            // No path means this container isn't a filesystem view this
+            // handler can paste into — the dashboard's Files tab is one such
+            // (it has its own paste handler); pasting here anyway would
+            // double-move the clipboard, and reading .startsWith off the
+            // undefined path used to throw on every paste in dashboard mode.
+            if ( ! target_path )
+            {
+                return;
+            }
             // don't allow pasting in Trash
             if ( (target_path === window.trash_path || target_path.startsWith(`${window.trash_path }/`)) && window.clipboard_op !== 'move' )
             {


### PR DESCRIPTION
## Problem

Cut+paste onto a folder that already contains an item with the same name silently failed — no error, no dialog, and the clipboard was cleared so there was no way to retry.

## Root cause

Two layers:

1. **Backend (root cause):** the GUI's conflict prompts key on the v1 wire contract `item_with_same_name_exists` + `entry_name`. The rewritten backend preserves that contract for the write path (with a comment saying exactly why) but dropped it for `move()` and `copy()`, which throw a generic `conflict` code instead. This also silently broke the **desktop's** existing Replace/Skip dialogs for move and copy.
2. **Dashboard:** `moveClipboardItems` caught every error into `console.error`, then cleared the clipboard regardless.

## Changes

- **`FSService.ts`** — `move()` and `copy()` collision errors again return `item_with_same_name_exists` with `entry_name`, matching the write path's compat handling. `mkdir` is untouched (its test deliberately pins `conflict`).
- **`TabFiles.js`** — `moveClipboardItems` now mirrors the desktop's `move_items` conflict flow: Replace / Replace all / Skip / Cancel, retrying with `overwrite: true` on Replace. Other move errors surface in an alert with the item name and server message.
- **`keyboard.js`** — the desktop's global Ctrl+V handler threw an uncaught TypeError on every paste in dashboard mode (the dashboard's file container has no `data-path`). That crash was incidentally the only thing preventing it from double-pasting on top of the dashboard's own handler; it's now an explicit guard.

## Testing

- Live end-to-end (Playwright, Chromium against local backend): seeded `conflict.txt` in two folders, cut one, pasted onto the other — conflict dialog appears; **Cancel** leaves both files in place; **Replace** overwrites the destination and completes the move; no page errors.
- `FSService.test.ts`: 132/132 pass. The move/copy collision tests assert `statusCode` 409 only, so no expectations changed.
- Remaining failures in the fs test sweep are the pre-existing `FSController.http.test.ts` fetch failures on this machine (present on clean HEAD).