### PR TITLE
fix: thumbnails breaking after copy — duplicate the S3 object per copy

### DIFF
--- a/extensions/thumbnails.test.ts
+++ b/extensions/thumbnails.test.ts
@@ -15,6 +15,7 @@ import {
 import { PuterServer } from '../src/backend/server.ts';
 import { setupTestServer } from '../src/backend/testUtil.ts';
 import {
+    handleFsCopyNodeThumbnail,
     handleFsRemoveNodeThumbnail,
     handleThumbnailCreated,
     handleThumbnailRead,
@@ -399,5 +400,109 @@ describe('thumbnails extension — handleFsRemoveNodeThumbnail', () => {
             { target: { thumbnail: 'https://cdn.example.com/x.png' } },
             { s3, bucketName: BUCKET },
         );
+    });
+});
+
+describe('thumbnails extension — handleFsCopyNodeThumbnail', () => {
+    let server: PuterServer;
+    let s3: S3Client;
+
+    beforeAll(async () => {
+        server = await setupTestServer();
+        s3 = server.clients.s3.get();
+    });
+
+    afterAll(async () => {
+        await server?.shutdown();
+    });
+
+    it('duplicates the shared thumbnail object and repoints the copied row', async () => {
+        const sourceKey = mintedKey();
+        const body = Buffer.from(TINY_PNG_BASE64, 'base64');
+        await s3.send(
+            new PutObjectCommand({
+                Bucket: BUCKET,
+                Key: sourceKey,
+                Body: body,
+                ContentType: 'image/png',
+            }),
+        );
+
+        const copyUuid = crypto.randomUUID();
+        const db = { write: vi.fn().mockResolvedValue(undefined) };
+        await handleFsCopyNodeThumbnail(
+            {
+                copy: {
+                    thumbnail: `s3://${BUCKET}/${sourceKey}`,
+                    uuid: copyUuid,
+                },
+            },
+            { s3, bucketName: BUCKET, db },
+        );
+
+        // The copied row was repointed at a fresh object...
+        expect(db.write).toHaveBeenCalledTimes(1);
+        const [, params] = db.write.mock.calls[0] as [string, [string, string]];
+        const [newPointer, updatedUuid] = params;
+        expect(updatedUuid).toBe(copyUuid);
+        expect(newPointer.startsWith(`s3://${BUCKET}/thumbnails/`)).toBe(true);
+        expect(newPointer).not.toBe(`s3://${BUCKET}/${sourceKey}`);
+
+        // ...whose content matches, while the source object survives — so
+        // deleting either entry can no longer break the other's thumbnail.
+        const newKey = newPointer.slice(`s3://${BUCKET}/`.length);
+        const duplicated = await s3.send(
+            new GetObjectCommand({ Bucket: BUCKET, Key: newKey }),
+        );
+        expect(
+            (await streamToBuffer(duplicated.Body as never)).equals(body),
+        ).toBe(true);
+        const original = await s3.send(
+            new GetObjectCommand({ Bucket: BUCKET, Key: sourceKey }),
+        );
+        expect(original.ContentType).toBe('image/png');
+    });
+
+    it('drops the pointer when the shared object is already gone', async () => {
+        const copyUuid = crypto.randomUUID();
+        const db = { write: vi.fn().mockResolvedValue(undefined) };
+        await handleFsCopyNodeThumbnail(
+            {
+                copy: {
+                    thumbnail: `s3://${BUCKET}/${mintedKey()}`, // never uploaded
+                    uuid: copyUuid,
+                },
+            },
+            { s3, bucketName: BUCKET, db },
+        );
+
+        expect(db.write).toHaveBeenCalledTimes(1);
+        const [sql, params] = db.write.mock.calls[0] as [string, [string]];
+        expect(sql).toContain('NULL');
+        expect(params).toEqual([copyUuid]);
+    });
+
+    it('does not duplicate an object the pointer names but we did not mint', async () => {
+        const foreignKey = crypto.randomUUID(); // shaped like an fs object key
+        const db = { write: vi.fn().mockResolvedValue(undefined) };
+        await handleFsCopyNodeThumbnail(
+            {
+                copy: {
+                    thumbnail: `s3://${BUCKET}/${foreignKey}`,
+                    uuid: crypto.randomUUID(),
+                },
+            },
+            { s3, bucketName: BUCKET, db },
+        );
+        expect(db.write).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op when the copy has no thumbnail', async () => {
+        const db = { write: vi.fn().mockResolvedValue(undefined) };
+        await handleFsCopyNodeThumbnail(
+            { copy: { thumbnail: null, uuid: crypto.randomUUID() } },
+            { s3, bucketName: BUCKET, db },
+        );
+        expect(db.write).not.toHaveBeenCalled();
     });
 });

--- a/extensions/thumbnails.ts
+++ b/extensions/thumbnails.ts
@@ -1,4 +1,5 @@
 import {
+    CopyObjectCommand,
     DeleteObjectCommand,
     GetObjectCommand,
     PutObjectCommand,
@@ -280,6 +281,55 @@ export const handleThumbnailRead = async (
     }
 };
 
+export const handleFsCopyNodeThumbnail = async (
+    payload: { copy?: { thumbnail?: string | null; uuid?: string } | null },
+    deps: {
+        s3: S3Client;
+        bucketName: string;
+        db: { write: (sql: string, params: unknown[]) => Promise<unknown> };
+    },
+): Promise<void> => {
+    const copy = payload.copy;
+    const thumbnailUrl = copy?.thumbnail;
+    if (!copy || !copy.uuid || typeof thumbnailUrl !== 'string') return;
+
+    // Same trust rule as the read and remove paths: only touch objects this
+    // extension minted.
+    const sourceKey = resolveThumbnailKey(thumbnailUrl);
+    if (!sourceKey) return;
+
+    // The copied row points at the SAME S3 object as its source, and
+    // fs.remove.node deletes the pointed-to object — so the first removal
+    // among the sharers (an overwrite, a trash purge) would break every
+    // other sharer's thumbnail. Give the copy an object of its own.
+    const newKey = mintThumbnailKey();
+    try {
+        await deps.s3.send(
+            new CopyObjectCommand({
+                Bucket: deps.bucketName,
+                CopySource: `${deps.bucketName}/${sourceKey}`,
+                Key: newKey,
+            }),
+        );
+    } catch (err) {
+        // The shared object is already gone (e.g. a sharer was removed
+        // before this fix existed) — the pointer is dead either way, so
+        // drop it rather than leave the row advertising a thumbnail it
+        // doesn't have.
+        await deps.db.write(
+            'UPDATE `fsentries` SET `thumbnail` = NULL WHERE `uuid` = ?',
+            [copy.uuid],
+        );
+        console.warn('[thumbnails] failed to duplicate thumbnail on copy', err);
+        return;
+    }
+
+    await deps.db.write(
+        'UPDATE `fsentries` SET `thumbnail` = ? WHERE `uuid` = ?',
+        [`s3://${deps.bucketName}/${newKey}`, copy.uuid],
+    );
+};
+
 export const handleFsRemoveNodeThumbnail = async (
     payload: { target: { thumbnail?: string | null } },
     deps: { s3: S3Client; bucketName: string },
@@ -333,6 +383,23 @@ extension.on('thumbnail.read', async (_key, entry: Record<string, unknown>) => {
         bucketEndpoint: extensionBucketEndpoint,
         db: clients.db,
     });
+});
+
+// -- fs.copy.node ----------------------------------------------------
+// A copied entry initially shares its source's thumbnail object; duplicate
+// it so removing either entry can't break the other's thumbnail.
+
+extension.on('fs.copy.node', async (_key, payload) => {
+    await handleFsCopyNodeThumbnail(
+        payload as {
+            copy?: { thumbnail?: string | null; uuid?: string } | null;
+        },
+        {
+            s3: getClient(),
+            bucketName: thumbnailBucketName,
+            db: clients.db,
+        },
+    );
 });
 
 // -- fs.remove.node --------------------------------------------------


### PR DESCRIPTION
Follow-up to #3493. After a replace-on-copy, thumbnails broke — for the new copy, the source file, and any deduped copies, all at once.

## Root cause

Thumbnails are S3 objects (`thumbnails/<uuid>`) referenced by an `s3://` pointer in the fsentry row, and the thumbnails extension deletes the pointed-to object on `fs.remove.node`. `FSService.#copyLeafEntry` copies the pointer verbatim, so a copy **shares** its source's thumbnail object.

The service emits `fs.copy.node` for exactly this reason — its doc comment says the thumbnail extension is notified "so it can duplicate the backing S3 object (otherwise deleting one copy would nuke the other's thumbnail)" — **but the extension never subscribed to the event**. Replace-on-copy hits the failure fast because every Replace removes an entry: the first removal among the sharers deletes the shared object and dangles every other sharer's pointer.

## Changes (`extensions/thumbnails.ts`)

- New `fs.copy.node` handler: S3-copies the thumbnail to a freshly minted `thumbnails/<uuid>` key and repoints the copied row, under the same only-keys-we-minted trust rule as the read and remove paths (foreign pointers are left untouched).
- If the shared object is already gone (damage predating this fix), the handler nulls the copy's pointer rather than leaving the row advertising a thumbnail it doesn't have.

## Notes

- Thumbnails already broken by this bug stay broken — their S3 objects were deleted; re-uploading the file regenerates them.
- Directory and empty-file clones don't emit `fs.copy.node`; they essentially never carry minted thumbnails, so they're deliberately left alone.

## Testing

- Four new unit tests (`extensions/thumbnails.test.ts`): duplicate-and-repoint with content equality and source survival, dead-pointer fallback to NULL, refusal to touch keys the extension didn't mint, and no-thumbnail no-op — 26/26 pass.
- Live end-to-end (Playwright against local backend): upload an image → copy into Documents → paste again → Replace → fresh directory listings; both the source's and the new copy's thumbnails are signed URLs that load successfully. Before the fix this exact flow left the source pointing at a deleted object.
- `tsc --noEmit` reports no errors in the touched files (the build's `noCheck` would otherwise mask type errors).