### PR TITLE
fix: phantom name conflict when pasting onto a just-renamed path

### DIFF
--- a/src/backend/services/fs/FSService.test.ts
+++ b/src/backend/services/fs/FSService.test.ts
@@ -2492,6 +2492,34 @@ describe('FSService copy', () => {
         expect(await readBack(overwritten)).toBe('source');
     });
 
+    it('does not see a phantom collision after the occupant is renamed', async () => {
+        const destination = (await entryAt(user, '/Desktop'))!;
+        const source = await writeFile(
+            user,
+            `${user.home}/Documents/phantom.txt`,
+            'src',
+        );
+
+        // First copy occupies Desktop/phantom.txt (and primes the path cache).
+        const first = await fs.copy(user.userId, {
+            source,
+            destinationParent: destination,
+        });
+        expect(first.path).toBe(`${user.home}/Desktop/phantom.txt`);
+
+        // Renaming the occupant frees the path...
+        await fs.rename(first, 'phantom-renamed.txt');
+
+        // ...so an immediate re-copy must succeed. A stale path-cache entry
+        // for the old name used to surface a phantom conflict here — and a
+        // Replace against it would have deleted the renamed file.
+        const second = await fs.copy(user.userId, {
+            source,
+            destinationParent: destination,
+        });
+        expect(second.path).toBe(`${user.home}/Desktop/phantom.txt`);
+    });
+
     it('cleans up and reports 404 when the source object has vanished', async () => {
         const source = await writeFile(
             user,

--- a/src/backend/stores/fs/FSEntryStore.ts
+++ b/src/backend/stores/fs/FSEntryStore.ts
@@ -2485,8 +2485,7 @@ export class FSEntryStore extends PuterStore {
         } = {},
     ): Promise<{ entries: FSEntry[]; cursor?: string }> {
         const payload = decodeCursor(options.cursor) as
-            | { v: unknown; id: number; s?: string; o?: string }
-            | undefined;
+            { v: unknown; id: number; s?: string; o?: string } | undefined;
 
         const requestedSort = options.sortBy ?? null;
         const requestedOrder = options.sortOrder ?? null;
@@ -2669,8 +2668,7 @@ export class FSEntryStore extends PuterStore {
         const limit = normalizeLimit(options.limit, { cap: 10_000 }) ?? 1000;
 
         const payload = decodeCursor(options.cursor) as
-            | { p: string }
-            | undefined;
+            { p: string } | undefined;
         const seek = payload ? 'AND path > ?' : '';
         const params: unknown[] = payload
             ? [userId, likePattern, maxSlashes, payload.p, limit + 1]
@@ -2834,6 +2832,17 @@ export class FSEntryStore extends PuterStore {
             return existing;
         }
 
+        // A path-changing patch (rename, move) must also drop the OLD path's
+        // cache key — invalidating only the updated entry leaves
+        // `prodfsv2:fsentry:path:any:<old path>` serving the pre-update entry
+        // for the full TTL. That stale hit made a paste right after renaming
+        // the occupant report a phantom name conflict, and accepting the
+        // Replace it offered deleted the renamed file (the stale entry
+        // carries its uuid). Read the pre-update entry so its keys can be
+        // invalidated alongside the new ones.
+        const previous =
+            patch.path !== undefined ? await this.getEntryByUuid(uuid) : null;
+
         await this.clients.db.write(
             `UPDATE fsentries SET ${assignments.join(', ')} WHERE uuid = ?`,
             [...values, uuid],
@@ -2850,6 +2859,9 @@ export class FSEntryStore extends PuterStore {
             });
         }
         const updated = this.#mapFSEntryRow(row);
+        if (previous && previous.path !== updated.path) {
+            await this.#invalidateEntryCache(previous);
+        }
         await this.#invalidateEntryCache(updated);
         await this.#writeEntryToCache(updated);
         return updated;


### PR DESCRIPTION
Follow-up to #3493/#3494. Paste an item into a directory, rename the pasted item, paste again — the second paste reported a name conflict ("already exists… Replace?") for a file that no longer exists under that name. Worse than cosmetic: accepting the Replace deleted the **renamed** file, because the stale entry carries its uuid.

## Root cause

`FSEntryStore` caches entries under `prodfsv2:fsentry:path:any:<path>` with a 60s TTL. `updateEntry` invalidated only the keys derived from the **updated** row — whose `path` is already the *new* one — so a path-changing patch (rename, move) left the **old** path's key serving the pre-update entry until TTL. The collision checks in `FSService.copy`/`move` read through that cache, so the freed name looked occupied.

Move was shielded by the `outer.gui.item.moved` handler in `FSEntryCacheInvalidationEventHandler`, which explicitly invalidates `old_path` — a controller-layer band-aid for this exact hole. **Rename was never registered there**, and nothing else cleaned up the old key.

## Change

`updateEntry` reads the pre-update entry when the patch changes `path` and invalidates its keys alongside the new ones. Fixing the store covers every caller (rename, move, batch flows) regardless of which GUI events fire, and the store's invalidation broadcast already fans out cluster-wide.

## Testing

- New regression test mirroring the reported flow (`FSService.test.ts`): copy → rename the copy → copy again must succeed. **Fails on main** with the phantom 409, passes with the fix.
- Full fs suites (`FSService`, `FSEntryStore`, `cacheInvalidation`, `LegacyFSController`): 360/360 pass.
- Live end-to-end (Playwright, network-instrumented): upload → paste into Documents → `puter.fs.rename` the pasted file → paste again within the TTL window → the second `/copy` returns **200** with no conflict dialog, and both the renamed file and the new paste are present.

## Note

Descendants of a renamed/moved **directory** (`updatePathPrefixForUser`) still rely on TTL decay for their cached paths — same documented tradeoff as `renameUserHome`. That's a pre-existing, milder staleness (≤60s) and is left out of scope here.