### PR TITLE
docs: document the provider option and refresh the vendor list in chat()

### DIFF
--- a/src/docs/src/AI/chat.md
+++ b/src/docs/src/AI/chat.md
@@ -27,7 +27,8 @@ A string containing the prompt you want to complete.
 
 An object containing the following properties:
 
-- `model` (String) - The model you want to use for the completion. If not specified, defaults to `gpt-5-nano`. More than 500 models are available, including, but not limited to, OpenAI, Anthropic, Google, xAI, Mistral, OpenRouter, and DeepSeek. For a full list, see the [AI models list](https://developer.puter.com/ai/models/) page.
+- `model` (String) - The model you want to use for the completion. If not specified, defaults to `gpt-5-nano`. More than 500 models are available from vendors including OpenAI, Anthropic, Google, Alibaba Cloud, xAI, Mistral, OpenRouter, Infron, and others. For a full list, see the [AI models list](https://developer.puter.com/ai/models/) page.
+- `provider` (String) (Optional) - Pin the request to a specific vendor, for example `openrouter` or `infron`. Without it, Puter selects a vendor for the requested model. Call [`puter.ai.listModelProviders()`](/AI/listModelProviders) for the available values, and [`puter.ai.listModels(provider)`](/AI/listModels) for the models a given vendor serves.
 - `stream` (Boolean) - A boolean indicating whether you want to stream the completion. Defaults to `false`.
 - `max_tokens` (Number) - The maximum number of tokens to generate in the completion. By default, the specific model's maximum is used.
 - `temperature` (Number) - A number between 0 and 2 indicating the randomness of the completion. Lower values make the output more focused and deterministic, while higher values make it more random. By default, the specific model's temperature is used.
@@ -111,7 +112,7 @@ In case of an error, the `Promise` will reject with an error message.
 
 ## Vendors
 
-We use different vendors for different models and try to use the best vendor available at the time of the request. Vendors include, but are not limited to, OpenAI, Anthropic, Google, xAI, Mistral, OpenRouter, and DeepSeek.
+We use different vendors for different models and try to use the best vendor available at the time of the request. Vendors currently include Alibaba Cloud, Anthropic, Azure OpenAI, DeepSeek, Google, Infron, MiniMax, Mistral, Moonshot AI, OpenAI, OpenRouter, Together AI, xAI, and Z.AI. Call [`puter.ai.listModelProviders()`](/AI/listModelProviders) for the current list, or pass `provider` in the options object to pin a request to one of them.
 
 ## Function Calling
 


### PR DESCRIPTION
## What

Two documentation changes to `puter.ai.chat()`:

1. Document the `provider` option, which is not currently in the options list.
2. Refresh the vendor list, which names 7 vendors while `puter.ai.listModelProviders()` returns 16.

## Why

**`provider` is undocumented.** `ChatCompletionDriver.complete()` reads `args.provider` and passes it to `#resolveModel()` to pin a request to a vendor, and `puter.ai.chat()` forwards the option through. Nothing in the docs mentions it, so there is currently no documented way to ask for a specific vendor.

**The vendor list is stale.** Both places name OpenAI, Anthropic, Google, xAI, Mistral, OpenRouter and DeepSeek. `puter.ai.listModelProviders()` returned 16 ids when I ran the playground example on 2026-08-04:

```
alibaba, azure-openai, azure-openai-responses, claude, deepseek, gemini, infron,
minimax, mistral, moonshotai, openai-completion, openai-responses, openrouter,
together-ai, xai, zai
```

The replacement list is those ids written as company names, merging the two pairs that are one vendor (`azure-openai` + `azure-openai-responses`, `openai-completion` + `openai-responses`). It is the API response rather than a hand-picked selection.

Both new links also give `listModelProviders` its first inbound link from the docs. Nothing currently links to that page.

## One question for a maintainer

I deliberately did not document what happens when the requested vendor does not serve the requested model. `#resolveModel()` currently returns `models.find(m => m.provider === provider) ?? models[0]`, so it falls back to the default vendor for that model rather than erroring. I did not want to write that down as intended behaviour without someone confirming it is intended. Happy to add a sentence either way, or to leave it out.

## Disclosure

Infron is one of the vendors added to the list. I work on the Infron provider integration merged in #3433. The list is taken from the API response rather than curated, and the `provider` documentation applies to every vendor equally.
