### PR TITLE
fix(ai-chat): infron default model is dropped by the aggregator alias rule

### DIFF
--- a/src/backend/drivers/ai-chat/providers/infron/InfronProvider.test.ts
+++ b/src/backend/drivers/ai-chat/providers/infron/InfronProvider.test.ts
@@ -101,6 +101,16 @@ const SAMPLE_API_MODELS = [
         min_completion_price: 30,
     },
     {
+        id: 'qwen/qwen3.5-flash',
+        display_name: 'Qwen: Qwen 3.5 Flash',
+        category_type: 'LLM',
+        supported_endpoint_types: ['openai'],
+        context_length: 1000000,
+        max_output_tokens: 64000,
+        min_prompt_price: 0.1,
+        min_completion_price: 0.4,
+    },
+    {
         id: 'anthropic/claude-haiku-4.5',
         display_name: 'Anthropic: Claude Haiku 4.5',
         category_type: 'LLM',
@@ -221,9 +231,7 @@ describe('InfronProvider construction', () => {
 describe('InfronProvider model catalog', () => {
     it('returns the infron-prefixed default model id', () => {
         const { provider } = makeProvider();
-        expect(provider.getDefaultModel()).toBe(
-            'infron:deepseek/deepseek-v4-flash',
-        );
+        expect(provider.getDefaultModel()).toBe('infron:qwen/qwen3.5-flash');
     });
 
     it('sends the API key as a bearer token on the catalog fetch', async () => {
@@ -240,6 +248,7 @@ describe('InfronProvider model catalog', () => {
         const { provider } = makeProvider();
         const ids = await provider.list();
         expect(ids).toContain('infron:deepseek/deepseek-v4-flash');
+        expect(ids).toContain(provider.getDefaultModel());
         expect(ids).toContain('infron:anthropic/claude-haiku-4.5');
         expect(ids).not.toContain('infron:black-forest-labs/flux-2.1');
         expect(ids).not.toContain('infron:example/display-only-model');

--- a/src/backend/drivers/ai-chat/providers/infron/InfronProvider.ts
+++ b/src/backend/drivers/ai-chat/providers/infron/InfronProvider.ts
@@ -80,7 +80,7 @@ export class InfronProvider implements IChatProvider {
     }
 
     getDefaultModel() {
-        return 'infron:deepseek/deepseek-v4-flash';
+        return 'infron:qwen/qwen3.5-flash';
     }
 
     /**


### PR DESCRIPTION
## The problem

`puter.ai.chat(prompt, { provider: 'infron' })` returns a 400.

Reproduced in the playground:

```js
puter.ai.chat('What is life?', { provider: 'infron' })
  .then(puter.print)
  .catch(e => puter.print('ERR: ' + (e.message || e.error || JSON.stringify(e))));
```

```
ERR: Model not found: infron:deepseek/deepseek-v4-flash
```

## Why

1. `InfronProvider.getDefaultModel()` returned `infron:deepseek/deepseek-v4-flash`.
2. That catalog entry carries the alias `deepseek/deepseek-v4-flash`.
3. The first-party `deepseek` provider already owns that alias.
4. In `ChatCompletionDriver.#buildModelMap()`, the AGGREGATORS branch treats a colliding alias as a reason to drop the model: `skip = true`, the entry pushed under `model.id` is popped, and the bucket is deleted. So the fully qualified `infron:deepseek/deepseek-v4-flash` never enters `#modelIdMap` either.
5. `complete()` sets `args.model` from `getDefaultModel()` when a provider is given without a model, `#resolveModel()` returns null, and the request 400s.

This is our bug, from #3433. Requests that pass an explicit model id are unaffected, which is why it went unnoticed.

## The fix

Point the default at a model whose fully qualified id survives the aggregator alias rule, i.e. one no other vendor on Puter serves. `infron:qwen/qwen3.5-flash` is in the live catalog, has a 1M context window, and is cheap enough to be a sensible default.

The test fixture gains the matching catalog entry, and `list()` now asserts the default model is among the ids the provider actually serves.

## Two things worth flagging

**This turns a failing path into a billable one.** Today the call fails and costs nothing. After this it succeeds and spends the user's credits at the model's rate. That is the intended behaviour, but it is a real change under the User-Pays model, so I would rather say it than let you find it.

**A provider-level test cannot catch a recurrence of this.** The provider's own catalog always contains its default; the failure only appears once the driver has built its model map and applied the alias rule. The assertion added here is a guard, not a proof. If you would like a driver-level test that resolves each provider's default model through `#modelIdMap`, tell me where it belongs and I will add it.
