### PR TITLE
CORS policy: Response to preflight request doesn't pass access co...

### DIFF
--- a/doc/self-hosting.md
+++ b/doc/self-hosting.md
@@ -26,7 +26,7 @@ Generates secrets, writes `.env` + `puter/config/config.json`, downloads `docker
 | `puter-valkey`  | `valkey/valkey:8-alpine` | Redis-compatible cache + rate-limiter                      |
 | `puter-dynamo`  | `amazon/dynamodb-local`  | KV store — table auto-created on first boot                |
 | `puter-s3`      | `rustfs/rustfs`          | S3-compatible object storage (MinIO drop-in noted in file) |
-| `puter-s3-init` | `amazon/aws-cli`         | One-shot — creates the bucket on first boot, then exits    |
+| `puter-s3-init` | `amazon/aws-cli`         | One-shot — creates the bucket and applies its CORS policy on first boot, then exits |
 
 Optional services (compose profile `ai`, opt-in):
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -140,7 +140,18 @@ services:
 
   s3-init:
     # One-shot container that creates the `puter-local` bucket on first
-    # boot. Exits 0 once the bucket exists; stays exited 0 thereafter.
+    # boot and makes sure it has a CORS policy. Exits 0 once both are in
+    # place; stays exited 0 thereafter.
+    #
+    # The CORS policy matters because browsers PUT/GET straight to
+    # `s3.<domain>` using presigned URLs (see the `@s3` block in
+    # caddy/Caddyfile) — without it, uploads through the GUI (e.g.
+    # Dev Center's "Use files") fail preflight with "No
+    # 'Access-Control-Allow-Origin' header is present". Puter's own
+    # subdomains are dynamic (per-user site./app. hosts, optional custom
+    # domains), so pinning AllowedOrigins to a fixed list isn't practical
+    # here; access to the bucket is already gated by the request's AWS
+    # signature, so a wildcard origin doesn't loosen that.
     image: amazon/aws-cli:latest
     container_name: puter-s3-init
     depends_on:
@@ -163,6 +174,9 @@ services:
           echo "creating bucket $$bucket"
           aws --endpoint-url "$$endpoint" s3 mb "s3://$$bucket"
         fi
+        echo "applying bucket CORS policy"
+        echo '{"CORSRules":[{"AllowedOrigins":["*"],"AllowedMethods":["GET","PUT","POST","HEAD"],"AllowedHeaders":["*"],"ExposeHeaders":["ETag","x-amz-request-id"],"MaxAgeSeconds":3600}]}' > /tmp/cors.json
+        aws --endpoint-url "$$endpoint" s3api put-bucket-cors --bucket "$$bucket" --cors-configuration file:///tmp/cors.json
     restart: "no"
 
   # ── Optional: local LLM ───────────────────────────────────────────


### PR DESCRIPTION
Fixes #3379

Self-hosted S3-compatible bucket had no CORS policy after deployment, so browser uploads via presigned URLs failed preflight; s3-init now applies a permissive CORS policy right after creating the bucket, matching the workaround from the issue.

**Testing:** No JS/TS test suite applies to this docker-compose/shell change; validated narrowly by running only the s3 + s3-init services in isolation (not the full stack) and confirming via aws s3api get-bucket-cors and the exact OPTIONS preflight curl from the issue that access-control-allow-origin/methods/headers/max-age now come back, whereas the pre-fix s3-init left the bucket with no CORS config.