### PR TITLE
docs: add requestAppData() to Perms sidebar

### DIFF
--- a/src/docs/src/sidebar.js
+++ b/src/docs/src/sidebar.js
@@ -1112,6 +1112,14 @@ let sidebar = [
                 path: '/Perms/requestManageApps',
             },
             {
+                title: '<code>requestAppData()</code>',
+                page_title: '<code>puter.perms.requestAppData()</code>',
+                title_tag: 'puter.perms.requestAppData()',
+                icon: '/assets/img/function.svg',
+                source: '/Perms/requestAppData.md',
+                path: '/Perms/requestAppData',
+            },
+            {
                 title: '<code>requestReadSubdomains()</code>',
                 page_title: '<code>puter.perms.requestReadSubdomains()</code>',
                 title_tag: 'puter.perms.requestReadSubdomains()',


### PR DESCRIPTION
# docs: add `requestAppData()` to the Perms sidebar

Fixes [PUT-1485](https://linear.app/puter/issue/PUT-1485/fix-request-app-permission-docs-page)

## What

Adds a single sidebar entry for `puter.perms.requestAppData()` so its docs page is reachable from the docs navigation.

## Why

The `requestAppData()` work shipped its docs page and landing-page links, but never got an entry in `src/docs/src/sidebar.js`. Because the docs build generates both the pages *and* the nav from `sidebar.js`, the page rendered at `/Perms/requestAppData/` but nothing linked to it from the sidebar — you could only reach it by typing the URL or via the one link in `Perms.md`.

It was the only Perms doc in that state. Checking every `Perms/*.md` against the sidebar before the fix:

```
NOT IN SIDEBAR: Perms/requestAppData.md
```

`Perms.md` was already correct — it has the "Use Another App's Data" feature tab and lists the method under an **Other Apps' Data** heading between *Apps Management* and *Subdomains Management*. Only the sidebar was out of sync.

## Changes

One file, +8 lines:

| File | Change |
| --- | --- |
| `src/docs/src/sidebar.js` | Add `requestAppData()` entry to the `Perms` section |

Placed after `requestManageApps()` and before `requestReadSubdomains()`, matching the ordering `Perms.md` already uses, and following the same entry shape as its siblings (`title` / `page_title` / `title_tag` / `icon` / `source` / `path`).

## How I tested

Ran the docs end-to-end rather than just building:

- `npm run build` in `src/docs` — succeeds. The two warnings it prints are pre-existing and unrelated (`ai-txt2speech-speechify` playground example missing, referenced from `index.md` and `AI/txt2speech.md`).
- Served `dist/` and hit the page: **HTTP 200** at `/Perms/requestAppData/`, title `puter.perms.requestAppData() - Puter.js Docs`.
- Confirmed the sidebar link is present in the rendered HTML of sibling pages, in the same `/./Perms/…/` href form as the other entries.
- Verified rendered sidebar order:

  ```
  … requestReadApps, requestManageApps, requestAppData, requestReadSubdomains, requestManageSubdomains
  ```

- Screenshot:
<img width="1252" height="1187" alt="image" src="https://github.com/user-attachments/assets/99131b01-e230-4131-bf88-07cf23ea0d51" />

- Confirmed the auto-generated prev/next links wired up to `requestManageApps()` ↔ `requestReadSubdomains()`.
- Re-ran the completeness check: all 15 Perms docs now appear in the sidebar.
- Sanity-checked that the page isn't documenting a nonexistent API — `requestAppData` is implemented and exported in `src/puter-js/src/modules/perms/index.js` and typed in `src/puter-js/types/modules/perms.d.ts`.

## Notes for review

- **Docs-only.** No runtime, auth, or permission behavior changes. The permission model this page describes was implemented and reviewed separately; nothing about it is touched here.
- No new files — `Perms/requestAppData.md` already exists on `main`. `src/docs/dist/` is gitignored, so build output isn't in the diff.

