### PR TITLE
docs: update web search model

### DIFF
--- a/src/docs/src/AI/chat.md
+++ b/src/docs/src/AI/chat.md
@@ -154,7 +154,7 @@ Pass in the `tools` parameter with the type of `web_search`.
 
 ```js
 {
-  model: 'openai/gpt-5.3-chat',
+  model: 'openai/gpt-5.6-luna',
   tools: [{type: "web_search"}]
 }
 ```
@@ -603,7 +603,7 @@ for await (const part of resp) {
         puter.print(`Loading...`);
         puter.ai
             .chat("Summarize what the User-Pays Model is: https://docs.puter.com/user-pays-model/", {
-                model: "openai/gpt-5.3-chat",
+                model: "openai/gpt-5.6-luna",
                 tools: [{ type: "web_search" }],
             })
             .then(puter.print);

--- a/src/docs/src/playground/examples/ai-web-search.html
+++ b/src/docs/src/playground/examples/ai-web-search.html
@@ -5,7 +5,7 @@
         puter.print(`Loading...`);
         puter.ai
             .chat("Summarize what the User-Pays Model is: https://docs.puter.com/user-pays-model/", {
-                model: "openai/gpt-5.3-chat",
+                model: "openai/gpt-5.6-luna",
                 tools: [{ type: "web_search" }],
             })
             .then(puter.print);


### PR DESCRIPTION
## Summary

- replace the discontinued `openai/gpt-5.3-chat` model in the web-search docs
- keep the inline example and runnable playground on `openai/gpt-5.6-luna`
- leave the separate OpenRouter provider-catalog smoke test unchanged

## Validation

- `npm ci`
- `npm run build` in `src/docs`
- verified the generated docs and playground contain the new model ID

Closes #3558