### PR TITLE
feat: add Gemini 3.7 Flash support

### DIFF
--- a/src/backend/drivers/ai-chat/providers/gemini/GeminiChatProvider.integration.test.ts
+++ b/src/backend/drivers/ai-chat/providers/gemini/GeminiChatProvider.integration.test.ts
@@ -20,7 +20,7 @@
 /**
  * Integration test for the Gemini chat provider.
  *
- * Hits the real Google Gemini API with `gemini-2.5-flash-lite` (one
+ * Hits the real Google Gemini API with `gemini-3.7-flash` (one
  * of the cheapest variants). Skipped when `PUTER_TEST_AI_GEMINI_API_KEY`
  * is unset.
  */
@@ -40,14 +40,14 @@ const ENV_VAR = 'PUTER_TEST_AI_GEMINI_API_KEY';
 describe.skipIf(skipUnlessEnv(ENV_VAR))(
     'GeminiChatProvider (integration)',
     () => {
-        it('returns a non-empty completion from gemini-2.5-flash-lite', { timeout: INTEGRATION_TEST_TIMEOUT_MS }, async () => {
+        it('returns a non-empty completion from gemini-3.7-flash', { timeout: INTEGRATION_TEST_TIMEOUT_MS }, async () => {
             const provider = new GeminiChatProvider(makeMeteringStub(), {
                 apiKey: optionalEnv(ENV_VAR)!,
             });
 
             const result = await withTestActor(() =>
                 provider.complete({
-                    model: 'gemini-2.5-flash-lite',
+                    model: 'gemini-3.7-flash',
                     messages: [
                         { role: 'user', content: 'Say hi in one word.' },
                     ],

--- a/src/backend/drivers/ai-chat/providers/gemini/models.ts
+++ b/src/backend/drivers/ai-chat/providers/gemini/models.ts
@@ -220,4 +220,32 @@ export const GEMINI_MODELS: IChatModel[] = [
         },
         max_tokens: 65536,
     },
+    {
+        puterId: 'google:google/gemini-3.7-flash',
+        id: 'gemini-3.7-flash',
+        modalities: {
+            input: ['text', 'image', 'video', 'audio', 'pdf'],
+            output: ['text'],
+        },
+        open_weights: false,
+        tool_call: true,
+        knowledge: '2026-03',
+        release_date: '2026-08-13',
+        name: 'Gemini 3.7 Flash',
+        aliases: ['google/gemini-3.7-flash'],
+        context: 1_048_576,
+        max_tokens: 65_536,
+        costs_currency: 'usd-cents',
+        input_cost_key: 'prompt_tokens',
+        output_cost_key: 'completion_tokens',
+        costs: {
+            tokens: 1_000_000,
+            prompt_tokens: 75,
+            completion_tokens: 375,
+            thinking_tokens: 375,
+            cached_tokens: 7.5,
+            // Gemini 3.x grounding is $14 / 1,000 requests
+            grounding_requests: 1_400_000,
+        },
+    },
 ];


### PR DESCRIPTION
## Summary

Adds Gemini 3.7 Flash support to the Gemini chat provider.

### Changes
- Added `gemini-3.7-flash` to the Gemini model registry.
- Added model metadata, modalities, context/output limits, pricing, and grounding cost.
- Updated the Gemini integration test to use `gemini-3.7-flash`.

### Testing
- `git diff --check` passes.
- Integration test could not be executed locally because dependency installation failed while building `better-sqlite3` due to the missing Visual Studio C++ build tools.

[Closes #3578](https://github.com/HeyPuter/puter/issues/3578)

