### PR TITLE
docs: update web search examples to gpt-5.6-luna

### DIFF
--- a/src/docs/src/AI/chat.md
+++ b/src/docs/src/AI/chat.md
@@ -154,7 +154,7 @@ Pass in the `tools` parameter with the type of `web_search`.
 
 ```js
 {
-  model: 'openai/gpt-5.3-chat',
+  model: 'openai/gpt-5.6-luna',
   tools: [{type: "web_search"}]
 }
 ```
@@ -603,7 +603,7 @@ for await (const part of resp) {
         puter.print(`Loading...`);
         puter.ai
             .chat("Summarize what the User-Pays Model is: https://docs.puter.com/user-pays-model/", {
-                model: "openai/gpt-5.3-chat",
+                model: "openai/gpt-5.6-luna",
                 tools: [{ type: "web_search" }],
             })
             .then(puter.print);

--- a/src/docs/src/playground/examples/ai-web-search.html
+++ b/src/docs/src/playground/examples/ai-web-search.html
@@ -5,7 +5,7 @@
         puter.print(`Loading...`);
         puter.ai
             .chat("Summarize what the User-Pays Model is: https://docs.puter.com/user-pays-model/", {
-                model: "openai/gpt-5.3-chat",
+                model: "openai/gpt-5.6-luna",
                 tools: [{ type: "web_search" }],
             })
             .then(puter.print);


### PR DESCRIPTION
## Changes

- Updated the Web Search documentation to use `openai/gpt-5.6-luna`
- Updated the embedded Web Search example
- Updated the Web Search playground example

Closes #3558