### PR TITLE
feat: add Meta Model API chat provider (Muse Spark)

### DIFF
--- a/config.template.jsonc
+++ b/config.template.jsonc
@@ -371,6 +371,13 @@
             "apiKey": "",
             "apiBaseUrl": "https://ark.ap-southeast.bytepluses.com/api/v3"
         },
+        // Meta Model API (Muse Spark). Keys are issued per team at
+        // https://dev.meta.ai/; `apiBaseUrl` only needs setting to reach a
+        // non-default endpoint.
+        "meta": {
+            "apiKey": "",
+            "apiBaseUrl": "https://api.meta.ai/v1"
+        },
         "zai": { "apiKey": "" },
         "alibaba": { "apiKey": "" },
         "together-ai": { "apiKey": "" },

--- a/src/backend/drivers/ai-chat/ChatCompletionDriver.edges.test.ts
+++ b/src/backend/drivers/ai-chat/ChatCompletionDriver.edges.test.ts
@@ -74,6 +74,7 @@ const FULL_PROVIDER_CONFIG = {
         openrouter: { apiKey: 'k', apiBaseUrl: 'https://openrouter.test' },
         infron: { apiKey: 'k' },
         byteplus: { apiKey: 'k' },
+        meta: { apiKey: 'k' },
         neuralwatt: { apiKey: 'k' },
         // Suppress auto-discovery of a developer's local Ollama.
         ollama: { enabled: false },
@@ -186,6 +187,7 @@ describe('ChatCompletionDriver provider registration', () => {
             'openrouter',
             'infron',
             'byteplus',
+            'meta',
             'neuralwatt',
             'fake-chat',
         ]) {

--- a/src/backend/drivers/ai-chat/ChatCompletionDriver.routing.test.ts
+++ b/src/backend/drivers/ai-chat/ChatCompletionDriver.routing.test.ts
@@ -128,6 +128,7 @@ const OPENROUTER_CATALOG = [
     'deepseek/deepseek-v4-pro',
     'deepseek-ai/deepseek-v4-pro',
     'google/gemini-2.5-flash',
+    'meta/muse-spark-1.2',
 ].map((id) => ({
     id,
     name: `${id} (via OpenRouter)`,
@@ -159,6 +160,7 @@ beforeAll(async () => {
                 gemini: { apiKey: 'test-key' },
                 deepseek: { apiKey: 'test-key' },
                 infron: { apiKey: 'test-key' },
+                meta: { apiKey: 'test-key' },
                 openrouter: { apiKey: 'test-key' },
                 ollama: { enabled: false },
             },
@@ -247,6 +249,31 @@ describe('ChatCompletionDriver gemini routing', () => {
         );
 
         expect(attempts[0]).toMatchObject({ provider: 'infron' });
+    });
+});
+
+describe('ChatCompletionDriver muse-spark routing', () => {
+    // The reseller route to these models sits behind an account-level content
+    // gate upstream, so every request through it fails no matter whose it is.
+    // The direct vendor has to be tried first for the model to work at all.
+    it('serves muse-spark from Meta, with the reseller only as fallback', async () => {
+        const attempts = await attemptsFor('meta/muse-spark-1.2');
+
+        expect(attempts[0]).toMatchObject({
+            provider: 'meta',
+            model: 'muse-spark-1.2',
+        });
+        expect(attempts[1]).toMatchObject({
+            provider: 'openrouter',
+            model: 'openrouter:meta/muse-spark-1.2',
+        });
+    });
+
+    it('routes the bare and puterId forms to Meta too', async () => {
+        for (const alias of ['muse-spark-1.2', 'meta:meta/muse-spark-1.2']) {
+            const attempts = await attemptsFor(alias);
+            expect(attempts[0].provider).toBe('meta');
+        }
     });
 });
 

--- a/src/backend/drivers/ai-chat/ChatCompletionDriver.ts
+++ b/src/backend/drivers/ai-chat/ChatCompletionDriver.ts
@@ -42,6 +42,7 @@ import { FakeChatProvider } from './providers/FakeChatProvider.js';
 import { GeminiChatProvider } from './providers/gemini/GeminiChatProvider.js';
 import { GroqAIProvider } from './providers/groq/GroqAIProvider.js';
 import { InfronProvider } from './providers/infron/InfronProvider.js';
+import { MetaProvider } from './providers/meta/MetaProvider.js';
 import { MiniMaxProvider } from './providers/minimax/MiniMaxProvider.js';
 import { MistralAIProvider } from './providers/mistral/MistralAiProvider.js';
 import { MoonshotProvider } from './providers/moonshot/MoonshotProvider.js';
@@ -1206,6 +1207,25 @@ export class ChatCompletionDriver extends PuterDriver {
                     apiBaseUrl: alibaba?.apiBaseUrl as string | undefined,
                 },
                 metering,
+            );
+        }
+
+        // Meta Model API (Muse Spark). A direct vendor route for models the
+        // aggregators also carry, so it outranks them in the shared bucket.
+        const meta = providers['meta'];
+        const metaKey = readKey(meta);
+        if (metaKey) {
+            this.#providers['meta'] = new MetaProvider(
+                {
+                    apiKey: metaKey,
+                    apiBaseUrl: meta?.apiBaseUrl as string | undefined,
+                },
+                metering,
+                {
+                    fsEntry: this.stores.fsEntry,
+                    s3Object: this.stores.s3Object,
+                },
+                this.services.fs,
             );
         }
 

--- a/src/backend/drivers/ai-chat/providers/meta/MetaProvider.integration.test.ts
+++ b/src/backend/drivers/ai-chat/providers/meta/MetaProvider.integration.test.ts
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) 2024-present Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Integration test for the Meta Model API provider.
+ *
+ * Muse Spark always reasons, and reasoning tokens count against the output
+ * budget, so the max_tokens here is roomy enough to leave space for visible
+ * text after the reasoning pass. Skipped when `PUTER_TEST_AI_META_API_KEY` is
+ * unset.
+ */
+
+import { Writable } from 'node:stream';
+import { describe, expect, it } from 'vitest';
+import {
+    INTEGRATION_TEST_TIMEOUT_MS,
+    makeMeteringStub,
+    optionalEnv,
+    skipUnlessEnv,
+    withTestActor,
+} from '../../../integrationTestUtil.js';
+import { AIChatStream } from '../../utils/Streaming.js';
+import { MetaProvider } from './MetaProvider.js';
+
+const ENV_VAR = 'PUTER_TEST_AI_META_API_KEY';
+
+const makeProvider = () =>
+    new MetaProvider(
+        { apiKey: optionalEnv(ENV_VAR)! },
+        makeMeteringStub(),
+        // File resolution is not exercised here: these prompts are plain text,
+        // so `puter_path` never reaches the stores.
+        {} as never,
+        {} as never,
+    );
+
+/** Run a streamed result to completion and return the NDJSON events it wrote. */
+const drainChatStream = async (result: unknown) => {
+    const chunks: string[] = [];
+    const sink = new Writable({
+        write(chunk, _enc, cb) {
+            chunks.push(chunk.toString('utf8'));
+            cb();
+        },
+    });
+    const streamed = result as {
+        init_chat_stream: (p: { chatStream: unknown }) => Promise<void>;
+        finally_fn?: () => Promise<void>;
+    };
+    await streamed.init_chat_stream({
+        chatStream: new AIChatStream({ stream: sink }),
+    });
+    await streamed.finally_fn?.();
+    return chunks
+        .join('')
+        .split('\n')
+        .filter(Boolean)
+        .map(
+            (line) =>
+                JSON.parse(line) as { type: string; [k: string]: unknown },
+        );
+};
+
+describe.skipIf(skipUnlessEnv(ENV_VAR))('MetaProvider (integration)', () => {
+    it(
+        'returns a non-empty completion from muse-spark-1.2',
+        { timeout: INTEGRATION_TEST_TIMEOUT_MS },
+        async () => {
+            const result = await withTestActor(() =>
+                makeProvider().complete({
+                    model: 'muse-spark-1.2',
+                    messages: [
+                        { role: 'user', content: 'Say hi in one word.' },
+                    ],
+                    max_tokens: 2048,
+                    reasoning_effort: 'low',
+                }),
+            );
+
+            const text = (result as { message?: { content?: unknown } }).message
+                ?.content;
+            expect(typeof text === 'string' && text.length > 0).toBe(true);
+            const usage = (result as { usage?: Record<string, number> }).usage;
+            expect(usage?.completion_tokens).toBeGreaterThan(0);
+        },
+    );
+
+    it(
+        'streams deltas and reports usage on the final chunk',
+        { timeout: INTEGRATION_TEST_TIMEOUT_MS },
+        async () => {
+            const result = await withTestActor(() =>
+                makeProvider().complete({
+                    model: 'muse-spark-1.2',
+                    messages: [{ role: 'user', content: 'Count to three.' }],
+                    max_tokens: 2048,
+                    reasoning_effort: 'low',
+                    stream: true,
+                }),
+            );
+
+            expect((result as { stream?: boolean }).stream).toBe(true);
+
+            // Draining the stream is the point: `stream_options.include_usage`
+            // is undocumented for this API, so the usage event arriving is what
+            // proves a streamed completion gets metered at all.
+            const events = await drainChatStream(result);
+            const text = events
+                .filter((e) => e.type === 'text')
+                .map((e) => e.text)
+                .join('');
+            expect(text.length).toBeGreaterThan(0);
+
+            const usage = events.find((e) => e.type === 'usage')?.usage as
+                Record<string, number> | undefined;
+            expect(usage?.completion_tokens).toBeGreaterThan(0);
+        },
+    );
+
+    it(
+        'serves muse-spark-1.1 as well',
+        { timeout: INTEGRATION_TEST_TIMEOUT_MS },
+        async () => {
+            const result = await withTestActor(() =>
+                makeProvider().complete({
+                    model: 'meta/muse-spark-1.1',
+                    messages: [
+                        { role: 'user', content: 'Say hi in one word.' },
+                    ],
+                    max_tokens: 2048,
+                    reasoning_effort: 'low',
+                }),
+            );
+
+            const text = (result as { message?: { content?: unknown } }).message
+                ?.content;
+            expect(typeof text === 'string' && text.length > 0).toBe(true);
+        },
+    );
+});

--- a/src/backend/drivers/ai-chat/providers/meta/MetaProvider.test.ts
+++ b/src/backend/drivers/ai-chat/providers/meta/MetaProvider.test.ts
@@ -1,0 +1,732 @@
+/*
+ * Copyright (C) 2024-present Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Offline unit tests for MetaProvider.
+ *
+ * Boots a real PuterServer (in-memory sqlite + dynamo + s3 + mock redis) and
+ * constructs MetaProvider against the live wired `MeteringService`, so the
+ * recording side is exercised end-to-end. The OpenAI SDK is mocked at the
+ * module boundary — the Meta Model API is OpenAI-compatible, so the provider
+ * talks to it through the same client — so nothing reaches the network. The
+ * companion MetaProvider.integration.test.ts exercises the real endpoint.
+ */
+
+import { Writable } from 'node:stream';
+import {
+    afterAll,
+    afterEach,
+    beforeAll,
+    beforeEach,
+    describe,
+    expect,
+    it,
+    vi,
+    type MockInstance,
+} from 'vitest';
+
+import { SYSTEM_ACTOR } from '../../../../core/actor.js';
+import type { MeteringService } from '../../../../services/metering/MeteringService.js';
+import { PuterServer } from '../../../../server.js';
+import { setupTestServer } from '../../../../testUtil.js';
+import { withTestActor } from '../../../integrationTestUtil.js';
+import { AIChatStream } from '../../utils/Streaming.js';
+import { MetaProvider } from './MetaProvider.js';
+import { META_MODELS } from './models.js';
+
+// -- OpenAI SDK mock -------------------------------------------------
+
+const { createMock, openAICtor } = vi.hoisted(() => {
+    const createMock = vi.fn();
+    const openAICtor = vi.fn();
+    return { createMock, openAICtor };
+});
+
+vi.mock('openai', () => {
+    const OpenAICtor = vi.fn().mockImplementation(function (
+        this: Record<string, unknown>,
+        opts: unknown,
+    ) {
+        openAICtor(opts);
+        this.chat = { completions: { create: createMock } };
+    });
+    // The test server boots every provider, and some read `.OpenAI` off the
+    // default export, so expose the constructor under both shapes.
+    return { OpenAI: OpenAICtor, default: { OpenAI: OpenAICtor } };
+});
+
+// -- Test harness ----------------------------------------------------
+
+let server: PuterServer;
+let recordSpy: MockInstance<MeteringService['utilRecordUsageObject']>;
+
+beforeAll(async () => {
+    server = await setupTestServer();
+});
+
+afterAll(async () => {
+    await server?.shutdown();
+});
+
+const makeProvider = (
+    config: { apiKey?: string; apiBaseUrl?: string } = {},
+) => {
+    const provider = new MetaProvider(
+        {
+            apiKey: config.apiKey ?? 'test-key',
+            ...(config.apiBaseUrl ? { apiBaseUrl: config.apiBaseUrl } : {}),
+        },
+        server.services.metering,
+        {
+            fsEntry: server.stores.fsEntry,
+            s3Object: server.stores.s3Object,
+        },
+        server.services.fs,
+    );
+    return { provider };
+};
+
+const asAsyncIterable = <T>(items: T[]): AsyncIterable<T> => ({
+    async *[Symbol.asyncIterator]() {
+        for (const item of items) {
+            yield item;
+        }
+    },
+});
+
+const makeCapturingChatStream = () => {
+    const chunks: string[] = [];
+    const sink = new Writable({
+        write(chunk, _enc, cb) {
+            chunks.push(chunk.toString('utf8'));
+            cb();
+        },
+    });
+    const chatStream = new AIChatStream({ stream: sink });
+    return {
+        chatStream,
+        events: () =>
+            chunks
+                .join('')
+                .split('\n')
+                .filter(Boolean)
+                .map((line) => JSON.parse(line)),
+    };
+};
+
+const baseCompletion = {
+    choices: [
+        {
+            message: { content: 'hi', role: 'assistant' },
+            finish_reason: 'stop',
+        },
+    ],
+    usage: { prompt_tokens: 1, completion_tokens: 1 },
+};
+
+beforeEach(() => {
+    createMock.mockReset();
+    openAICtor.mockReset();
+    recordSpy = vi.spyOn(server.services.metering, 'utilRecordUsageObject');
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+// -- Construction ----------------------------------------------------
+
+describe('MetaProvider construction', () => {
+    it('points the OpenAI SDK at the Meta Model API base URL with the configured key', () => {
+        makeProvider();
+        expect(openAICtor).toHaveBeenCalledTimes(1);
+        expect(openAICtor).toHaveBeenCalledWith({
+            apiKey: 'test-key',
+            baseURL: 'https://api.meta.ai/v1',
+        });
+    });
+
+    it('honours a custom apiBaseUrl override', () => {
+        makeProvider({ apiBaseUrl: 'https://meta.test/v1' });
+        expect(openAICtor).toHaveBeenCalledWith({
+            apiKey: 'test-key',
+            baseURL: 'https://meta.test/v1',
+        });
+    });
+});
+
+// -- Model catalog ---------------------------------------------------
+
+describe('MetaProvider model catalog', () => {
+    it('returns muse-spark-1.2 as the default', () => {
+        const { provider } = makeProvider();
+        expect(provider.getDefaultModel()).toBe('muse-spark-1.2');
+    });
+
+    it('exposes the static META_MODELS list verbatim from models()', () => {
+        const { provider } = makeProvider();
+        expect(provider.models()).toBe(META_MODELS);
+    });
+
+    it('list() flattens canonical ids and vendor-qualified aliases', () => {
+        const { provider } = makeProvider();
+        const names = provider.list();
+        for (const m of META_MODELS) {
+            expect(names).toContain(m.id);
+            for (const a of m.aliases ?? []) {
+                expect(names).toContain(a);
+            }
+        }
+        // The alias the reseller route is also keyed under — this is what puts
+        // both routes in one bucket so the direct vendor can outrank it.
+        expect(names).toContain('meta/muse-spark-1.2');
+        expect(names).toContain('meta/muse-spark-1.1');
+    });
+
+    it('advertises only the models the API actually serves', () => {
+        // `GET /models` returns these two and answers 404 for the documented
+        // `-contributor` tier, so the catalog must not offer it: it would show
+        // up in listModels() as a model every request fails against, at a
+        // price that makes it look like the one to pick.
+        expect(META_MODELS.map((m) => m.id)).toEqual([
+            'muse-spark-1.2',
+            'muse-spark-1.1',
+        ]);
+    });
+});
+
+// -- Request shape ---------------------------------------------------
+
+describe('MetaProvider.complete request shape', () => {
+    it('forwards model and messages without optional knobs', async () => {
+        const { provider } = makeProvider();
+        createMock.mockResolvedValueOnce(baseCompletion);
+
+        await withTestActor(() =>
+            provider.complete({
+                model: 'muse-spark-1.2',
+                messages: [{ role: 'user', content: 'hello' }],
+            }),
+        );
+
+        const [args] = createMock.mock.calls[0]!;
+        expect(args.model).toBe('muse-spark-1.2');
+        expect(args.messages).toEqual([{ role: 'user', content: 'hello' }]);
+        for (const key of [
+            'max_completion_tokens',
+            'temperature',
+            'top_p',
+            'tools',
+            'tool_choice',
+            'reasoning_effort',
+            'prompt_cache_retention',
+            'response_format',
+            'seed',
+        ]) {
+            expect(key in args).toBe(false);
+        }
+    });
+
+    it('resolves a vendor-qualified alias to the canonical model id', async () => {
+        const { provider } = makeProvider();
+        createMock.mockResolvedValueOnce(baseCompletion);
+
+        await withTestActor(() =>
+            provider.complete({
+                model: 'meta/muse-spark-1.1',
+                messages: [{ role: 'user', content: 'hi' }],
+            }),
+        );
+
+        expect(createMock.mock.calls[0]![0].model).toBe('muse-spark-1.1');
+    });
+
+    it('falls back to the default model when the id is unknown', async () => {
+        const { provider } = makeProvider();
+        createMock.mockResolvedValueOnce(baseCompletion);
+
+        await withTestActor(() =>
+            provider.complete({
+                model: 'muse-spark-9.9',
+                messages: [{ role: 'user', content: 'hi' }],
+            }),
+        );
+
+        expect(createMock.mock.calls[0]![0].model).toBe('muse-spark-1.2');
+    });
+
+    it('renames max_tokens to max_completion_tokens', async () => {
+        const { provider } = makeProvider();
+        createMock.mockResolvedValueOnce(baseCompletion);
+
+        await withTestActor(() =>
+            provider.complete({
+                model: 'muse-spark-1.2',
+                messages: [{ role: 'user', content: 'hi' }],
+                max_tokens: 256,
+            }),
+        );
+
+        const [args] = createMock.mock.calls[0]!;
+        expect(args.max_completion_tokens).toBe(256);
+        expect('max_tokens' in args).toBe(false);
+    });
+
+    it('forwards temperature, top_p, tools, and tool_choice when supplied', async () => {
+        const { provider } = makeProvider();
+        createMock.mockResolvedValueOnce(baseCompletion);
+
+        const tools = [
+            {
+                type: 'function',
+                function: {
+                    name: 'lookup',
+                    description: 'find a thing',
+                    parameters: {
+                        type: 'object',
+                        properties: { q: { type: 'string' } },
+                        required: ['q'],
+                    },
+                },
+            },
+        ];
+
+        await withTestActor(() =>
+            provider.complete({
+                model: 'muse-spark-1.2',
+                messages: [{ role: 'user', content: 'hi' }],
+                temperature: 0.4,
+                top_p: 0.9,
+                tools,
+                tool_choice: 'auto',
+            }),
+        );
+
+        const [args] = createMock.mock.calls[0]!;
+        expect(args.temperature).toBe(0.4);
+        expect(args.top_p).toBe(0.9);
+        expect(args.tools).toBe(tools);
+        expect(args.tool_choice).toBe('auto');
+    });
+
+    it('never sends the parameters Muse Spark rejects', async () => {
+        const { provider } = makeProvider();
+        createMock.mockResolvedValueOnce(baseCompletion);
+
+        await withTestActor(() =>
+            provider.complete({
+                model: 'muse-spark-1.2',
+                messages: [{ role: 'user', content: 'hi' }],
+                verbosity: 'concise',
+                custom: { stop: ['\n\n'], n: 2, logprobs: true },
+            }),
+        );
+
+        const [args] = createMock.mock.calls[0]!;
+        for (const key of [
+            'stop',
+            'n',
+            'logprobs',
+            'logit_bias',
+            'verbosity',
+        ]) {
+            expect(key in args).toBe(false);
+        }
+    });
+
+    it('forwards reasoning_effort, including from the nested reasoning object', async () => {
+        const { provider } = makeProvider();
+        createMock.mockResolvedValueOnce(baseCompletion);
+        await withTestActor(() =>
+            provider.complete({
+                model: 'muse-spark-1.2',
+                messages: [{ role: 'user', content: 'hi' }],
+                reasoning_effort: 'high',
+            }),
+        );
+        expect(createMock.mock.calls[0]![0].reasoning_effort).toBe('high');
+
+        createMock.mockResolvedValueOnce(baseCompletion);
+        await withTestActor(() =>
+            provider.complete({
+                model: 'muse-spark-1.2',
+                messages: [{ role: 'user', content: 'hi' }],
+                reasoning: { effort: 'low' },
+            }),
+        );
+        expect(createMock.mock.calls[1]![0].reasoning_effort).toBe('low');
+    });
+
+    it('lets custom.reasoning_effort reach the efforts the driver field cannot express', async () => {
+        const { provider } = makeProvider();
+        createMock.mockResolvedValueOnce(baseCompletion);
+
+        await withTestActor(() =>
+            provider.complete({
+                model: 'muse-spark-1.2',
+                messages: [{ role: 'user', content: 'hi' }],
+                reasoning_effort: 'low',
+                custom: { reasoning_effort: 'xhigh' },
+            }),
+        );
+
+        expect(createMock.mock.calls[0]![0].reasoning_effort).toBe('xhigh');
+    });
+
+    it('drops an effort Muse Spark would reject rather than sending it', async () => {
+        const { provider } = makeProvider();
+        createMock.mockResolvedValueOnce(baseCompletion);
+
+        // The model always reasons, so `none` comes back as a 400.
+        await withTestActor(() =>
+            provider.complete({
+                model: 'muse-spark-1.2',
+                messages: [{ role: 'user', content: 'hi' }],
+                custom: { reasoning_effort: 'none' },
+            }),
+        );
+
+        expect('reasoning_effort' in createMock.mock.calls[0]![0]).toBe(false);
+    });
+
+    it('translates prompt_cache_retention to the wire spelling', async () => {
+        const { provider } = makeProvider();
+        createMock.mockResolvedValueOnce(baseCompletion);
+        await withTestActor(() =>
+            provider.complete({
+                model: 'muse-spark-1.2',
+                messages: [{ role: 'user', content: 'hi' }],
+                prompt_cache_retention: 'in-memory',
+            }),
+        );
+        expect(createMock.mock.calls[0]![0].prompt_cache_retention).toBe(
+            'in_memory',
+        );
+
+        createMock.mockResolvedValueOnce(baseCompletion);
+        await withTestActor(() =>
+            provider.complete({
+                model: 'muse-spark-1.2',
+                messages: [{ role: 'user', content: 'hi' }],
+                prompt_cache_retention: '24h',
+            }),
+        );
+        expect(createMock.mock.calls[1]![0].prompt_cache_retention).toBe('24h');
+    });
+
+    it('forwards response_format, seed, and the penalty knobs from custom', async () => {
+        const { provider } = makeProvider();
+        createMock.mockResolvedValueOnce(baseCompletion);
+
+        await withTestActor(() =>
+            provider.complete({
+                model: 'muse-spark-1.2',
+                messages: [{ role: 'user', content: 'hi' }],
+                custom: {
+                    response_format: { type: 'json_object' },
+                    seed: 42,
+                    frequency_penalty: 0.5,
+                    presence_penalty: -0.5,
+                },
+            }),
+        );
+
+        const [args] = createMock.mock.calls[0]!;
+        expect(args.response_format).toEqual({ type: 'json_object' });
+        expect(args.seed).toBe(42);
+        expect(args.frequency_penalty).toBe(0.5);
+        expect(args.presence_penalty).toBe(-0.5);
+    });
+
+    it('strips the Anthropic-only cache_control marker off messages', async () => {
+        const { provider } = makeProvider();
+        createMock.mockResolvedValueOnce(baseCompletion);
+
+        await withTestActor(() =>
+            provider.complete({
+                model: 'muse-spark-1.2',
+                messages: [
+                    {
+                        role: 'user',
+                        content: 'hi',
+                        cache_control: { type: 'ephemeral' },
+                    },
+                ],
+            }),
+        );
+
+        const [args] = createMock.mock.calls[0]!;
+        expect('cache_control' in args.messages[0]).toBe(false);
+    });
+
+    it('asks for usage on the stream when streaming', async () => {
+        const { provider } = makeProvider();
+        createMock.mockReturnValueOnce(asAsyncIterable([]));
+
+        await withTestActor(() =>
+            provider.complete({
+                model: 'muse-spark-1.2',
+                messages: [{ role: 'user', content: 'hi' }],
+                stream: true,
+            }),
+        );
+
+        const [args] = createMock.mock.calls[0]!;
+        expect(args.stream).toBe(true);
+        expect(args.stream_options).toEqual({ include_usage: true });
+    });
+
+    it('rejects a non-array messages payload before calling upstream', async () => {
+        const { provider } = makeProvider();
+
+        await expect(
+            withTestActor(() =>
+                provider.complete({
+                    model: 'muse-spark-1.2',
+                    messages: 'hello' as unknown as [],
+                }),
+            ),
+        ).rejects.toMatchObject({
+            statusCode: 400,
+            legacyCode: 'bad_request',
+        });
+        expect(createMock).not.toHaveBeenCalled();
+    });
+});
+
+// -- Non-stream output + metering ------------------------------------
+
+describe('MetaProvider.complete non-stream output', () => {
+    it('returns the first choice and bills the cache hit at the cached rate', async () => {
+        const { provider } = makeProvider();
+        createMock.mockResolvedValueOnce({
+            choices: [
+                {
+                    message: { content: 'hi there', role: 'assistant' },
+                    finish_reason: 'stop',
+                },
+            ],
+            usage: {
+                prompt_tokens: 100,
+                completion_tokens: 50,
+                prompt_tokens_details: { cached_tokens: 10 },
+            },
+        });
+
+        const result = await withTestActor(() =>
+            provider.complete({
+                model: 'muse-spark-1.2',
+                messages: [{ role: 'user', content: 'hi' }],
+            }),
+        );
+
+        expect(result).toMatchObject({
+            message: { content: 'hi there', role: 'assistant' },
+            finish_reason: 'stop',
+        });
+        // Cached reads are priced on their own key, so they come out of the
+        // prompt count instead of being charged at the full input rate too.
+        expect((result as { usage: unknown }).usage).toEqual({
+            prompt_tokens: 90,
+            completion_tokens: 50,
+            cached_tokens: 10,
+        });
+
+        const muse = META_MODELS.find((m) => m.id === 'muse-spark-1.2')!;
+        expect(recordSpy).toHaveBeenCalledTimes(1);
+        const [usage, actor, prefix, overrides] = recordSpy.mock.calls[0]!;
+        expect(usage).toEqual({
+            prompt_tokens: 90,
+            completion_tokens: 50,
+            cached_tokens: 10,
+        });
+        expect(actor).toBe(SYSTEM_ACTOR);
+        expect(prefix).toBe('meta:muse-spark-1.2');
+        expect(overrides.prompt_tokens).toBeCloseTo(
+            90 * Number(muse.costs.prompt_tokens),
+            5,
+        );
+        expect(overrides.completion_tokens).toBeCloseTo(
+            50 * Number(muse.costs.completion_tokens),
+            5,
+        );
+        expect(overrides.cached_tokens).toBeCloseTo(
+            10 * Number(muse.costs.cached_tokens),
+            5,
+        );
+    });
+
+    it('never reports a negative prompt count when the cache hit covers the prompt', async () => {
+        const { provider } = makeProvider();
+        createMock.mockResolvedValueOnce({
+            choices: [
+                {
+                    message: { content: 'ok', role: 'assistant' },
+                    finish_reason: 'stop',
+                },
+            ],
+            // A prompt count below its own cache hit shouldn't be possible,
+            // but an unclamped subtraction would turn it into negative usage
+            // and credit the account.
+            usage: {
+                prompt_tokens: 10,
+                completion_tokens: 2,
+                prompt_tokens_details: { cached_tokens: 40 },
+            },
+        });
+
+        const result = await withTestActor(() =>
+            provider.complete({
+                model: 'muse-spark-1.2',
+                messages: [{ role: 'user', content: 'hi' }],
+            }),
+        );
+
+        expect(
+            (result as { usage: Record<string, number> }).usage.prompt_tokens,
+        ).toBe(0);
+    });
+
+    it('preserves OpenAI-shaped tool_calls on the assistant response', async () => {
+        const { provider } = makeProvider();
+        createMock.mockResolvedValueOnce({
+            choices: [
+                {
+                    message: {
+                        role: 'assistant',
+                        content: null,
+                        tool_calls: [
+                            {
+                                id: 'call_1',
+                                type: 'function',
+                                function: {
+                                    name: 'lookup',
+                                    arguments: '{"q":"puter"}',
+                                },
+                            },
+                        ],
+                    },
+                    finish_reason: 'tool_calls',
+                },
+            ],
+            usage: { prompt_tokens: 5, completion_tokens: 3 },
+        });
+
+        const result = await withTestActor(() =>
+            provider.complete({
+                model: 'muse-spark-1.2',
+                messages: [{ role: 'user', content: 'look it up' }],
+            }),
+        );
+
+        expect(result).toMatchObject({ finish_reason: 'tool_calls' });
+        const message = (result as { message: Record<string, unknown> })
+            .message;
+        expect(message.tool_calls).toMatchObject([
+            { id: 'call_1', function: { name: 'lookup' } },
+        ]);
+    });
+});
+
+// -- Streaming -------------------------------------------------------
+
+describe('MetaProvider.complete streaming', () => {
+    it('streams text deltas through to text events and meters final usage', async () => {
+        const { provider } = makeProvider();
+        createMock.mockReturnValueOnce(
+            asAsyncIterable([
+                { choices: [{ delta: { content: 'hel' } }] },
+                { choices: [{ delta: { content: 'lo' } }] },
+                {
+                    choices: [{ delta: {} }],
+                    usage: {
+                        prompt_tokens: 40,
+                        completion_tokens: 2,
+                        prompt_tokens_details: { cached_tokens: 10 },
+                    },
+                },
+            ]),
+        );
+
+        const result = await withTestActor(() =>
+            provider.complete({
+                model: 'muse-spark-1.2',
+                messages: [{ role: 'user', content: 'say hi' }],
+                stream: true,
+            }),
+        );
+        expect((result as { stream: boolean }).stream).toBe(true);
+
+        const harness = makeCapturingChatStream();
+        await (
+            result as {
+                init_chat_stream: (p: { chatStream: unknown }) => Promise<void>;
+            }
+        ).init_chat_stream({ chatStream: harness.chatStream });
+
+        const events = harness.events();
+        expect(
+            events.filter((e) => e.type === 'text').map((e) => e.text),
+        ).toEqual(['hel', 'lo']);
+
+        const usageEvent = events.find((e) => e.type === 'usage');
+        expect(usageEvent?.usage).toEqual({
+            prompt_tokens: 30,
+            completion_tokens: 2,
+            cached_tokens: 10,
+        });
+
+        const muse = META_MODELS.find((m) => m.id === 'muse-spark-1.2')!;
+        expect(recordSpy).toHaveBeenCalledTimes(1);
+        const [, , prefix, overrides] = recordSpy.mock.calls[0]!;
+        expect(prefix).toBe('meta:muse-spark-1.2');
+        expect(overrides.completion_tokens).toBeCloseTo(
+            2 * Number(muse.costs.completion_tokens),
+            5,
+        );
+    });
+});
+
+// -- Error mapping ---------------------------------------------------
+
+describe('MetaProvider.complete error mapping', () => {
+    it('rethrows errors raised by the OpenAI client unchanged', async () => {
+        const { provider } = makeProvider();
+        const upstream = Object.assign(new Error('boom'), { status: 429 });
+        createMock.mockRejectedValueOnce(upstream);
+
+        await expect(
+            withTestActor(() =>
+                provider.complete({
+                    model: 'muse-spark-1.2',
+                    messages: [{ role: 'user', content: 'hi' }],
+                }),
+            ),
+        ).rejects.toBe(upstream);
+    });
+});
+
+// -- Moderation ------------------------------------------------------
+
+describe('MetaProvider.checkModeration', () => {
+    it('throws — the Meta Model API exposes no moderation endpoint', () => {
+        const { provider } = makeProvider();
+        expect(() => provider.checkModeration('anything')).toThrow();
+    });
+});

--- a/src/backend/drivers/ai-chat/providers/meta/MetaProvider.ts
+++ b/src/backend/drivers/ai-chat/providers/meta/MetaProvider.ts
@@ -1,0 +1,253 @@
+/*
+ * Copyright (C) 2024-present Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { HttpError } from '@heyputer/backend/src/core/http/HttpError.js';
+import { OpenAI } from 'openai';
+import { ChatCompletionCreateParams } from 'openai/resources/index.js';
+import { Context } from '../../../../core/context.js';
+import type { FSService } from '../../../../services/fs/FSService.js';
+import type { MeteringService } from '../../../../services/metering/MeteringService.js';
+import type { FSEntryStore } from '../../../../stores/fs/FSEntryStore.js';
+import type { S3ObjectStore } from '../../../../stores/fs/S3ObjectStore.js';
+import type { IChatProvider, ICompleteArguments } from '../../types.js';
+import * as OpenAIUtil from '../../utils/OpenAIUtil.js';
+import { buildCostsOverride } from '../../utils/pricing.js';
+import { processPuterPathUploads } from '../openai/fileUpload.js';
+import { META_MODELS } from './models.js';
+
+type MetaConfig = {
+    apiKey: string;
+    apiBaseUrl?: string;
+};
+
+type MetaCustomParams = {
+    response_format?: unknown;
+    seed?: number;
+    frequency_penalty?: number;
+    presence_penalty?: number;
+    // Muse Spark accepts two efforts the driver's own field can't express.
+    reasoning_effort?: string;
+};
+
+const DEFAULT_BASE_URL = 'https://api.meta.ai/v1';
+
+// `none` is rejected with a 400 — Muse Spark always reasons — so it is not
+// among the values we forward.
+const REASONING_EFFORTS = new Set([
+    'minimal',
+    'low',
+    'medium',
+    'high',
+    'xhigh',
+]);
+
+// The driver spells the in-memory retention with a hyphen; Meta's wire format
+// uses an underscore.
+const CACHE_RETENTION: Record<string, string> = {
+    'in-memory': 'in_memory',
+    '24h': '24h',
+};
+
+const asRecord = (value: unknown): Record<string, unknown> =>
+    value && typeof value === 'object' && !Array.isArray(value)
+        ? (value as Record<string, unknown>)
+        : {};
+
+/**
+ * Meta Model API provider — Muse Spark over Meta's OpenAI-compatible Chat
+ * Completions endpoint. https://ai.developer.meta.com/docs
+ *
+ * Puter reaches these models through OpenRouter as well. This provider is a
+ * direct vendor route, so `compareModelPreference` serves it first and leaves
+ * the reseller as the fallback.
+ */
+export class MetaProvider implements IChatProvider {
+    #openai: OpenAI;
+
+    #meteringService: MeteringService;
+
+    #stores: { fsEntry: FSEntryStore; s3Object: S3ObjectStore };
+
+    #fsService: FSService;
+
+    #defaultModel = 'muse-spark-1.2';
+
+    constructor(
+        config: MetaConfig,
+        meteringService: MeteringService,
+        stores: { fsEntry: FSEntryStore; s3Object: S3ObjectStore },
+        fsService: FSService,
+    ) {
+        this.#openai = new OpenAI({
+            apiKey: config.apiKey,
+            baseURL: config.apiBaseUrl ?? DEFAULT_BASE_URL,
+        });
+        this.#meteringService = meteringService;
+        this.#stores = stores;
+        this.#fsService = fsService;
+    }
+
+    getDefaultModel() {
+        return this.#defaultModel;
+    }
+
+    models() {
+        return META_MODELS;
+    }
+
+    list() {
+        const modelIds: string[] = [];
+        for (const model of this.models()) {
+            modelIds.push(model.id);
+            if (model.aliases) {
+                modelIds.push(...model.aliases);
+            }
+        }
+        return modelIds;
+    }
+
+    async complete(
+        params: ICompleteArguments,
+    ): ReturnType<IChatProvider['complete']> {
+        const {
+            custom,
+            max_tokens,
+            prompt_cache_retention,
+            reasoning,
+            reasoning_effort,
+            stream,
+            temperature,
+            tools,
+            tool_choice,
+            top_p,
+        } = params;
+        let { messages, model } = params;
+
+        if (!Array.isArray(messages)) {
+            throw new HttpError(400, '`messages` must be an array', {
+                legacyCode: 'bad_request',
+            });
+        }
+
+        const actor = Context.get('actor');
+        const availableModels = this.models();
+        const modelUsed =
+            availableModels.find((m) =>
+                [m.id, ...(m.aliases || [])].includes(model),
+            ) || availableModels.find((m) => m.id === this.getDefaultModel())!;
+
+        // Chat Completions takes no file references, so Puter-hosted files
+        // have to be inlined as data URLs before the call.
+        await processPuterPathUploads(
+            messages,
+            this.#stores,
+            this.#fsService,
+            actor,
+        );
+        messages = await OpenAIUtil.process_input_messages(messages);
+        messages = messages.map((message) => {
+            delete message.cache_control;
+            return message;
+        });
+
+        const customParams = asRecord(custom) as MetaCustomParams;
+
+        const requestedEffort =
+            customParams.reasoning_effort ??
+            reasoning_effort ??
+            reasoning?.effort;
+        const effort =
+            requestedEffort && REASONING_EFFORTS.has(requestedEffort)
+                ? requestedEffort
+                : undefined;
+
+        const retention = prompt_cache_retention
+            ? CACHE_RETENTION[prompt_cache_retention]
+            : undefined;
+
+        const completionParams: ChatCompletionCreateParams = {
+            messages,
+            model: modelUsed.id,
+            ...(tools ? { tools } : {}),
+            ...(tool_choice !== undefined ? { tool_choice } : {}),
+            ...(max_tokens !== undefined
+                ? { max_completion_tokens: max_tokens }
+                : {}),
+            ...(temperature !== undefined ? { temperature } : {}),
+            ...(top_p !== undefined ? { top_p } : {}),
+            ...(effort ? { reasoning_effort: effort } : {}),
+            ...(retention ? { prompt_cache_retention: retention } : {}),
+            ...(customParams.response_format
+                ? { response_format: customParams.response_format }
+                : {}),
+            ...(customParams.seed !== undefined
+                ? { seed: customParams.seed }
+                : {}),
+            ...(customParams.frequency_penalty !== undefined
+                ? { frequency_penalty: customParams.frequency_penalty }
+                : {}),
+            ...(customParams.presence_penalty !== undefined
+                ? { presence_penalty: customParams.presence_penalty }
+                : {}),
+            stream: !!stream,
+            ...(stream ? { stream_options: { include_usage: true } } : {}),
+        } as ChatCompletionCreateParams;
+
+        const completion =
+            await this.#openai.chat.completions.create(completionParams);
+
+        return OpenAIUtil.handle_completion_output({
+            usage_calculator: ({ usage }) => {
+                const cached_tokens =
+                    usage?.prompt_tokens_details?.cached_tokens ?? 0;
+                // Cached reads are billed at their own rate, so they come out
+                // of the prompt count rather than being charged twice. Clamped
+                // because a prompt count that came back below its own cache
+                // hit would otherwise bill the account a negative amount.
+                const trackedUsage = {
+                    prompt_tokens: Math.max(
+                        0,
+                        (usage?.prompt_tokens ?? 0) - cached_tokens,
+                    ),
+                    // Reasoning tokens arrive as a subset of
+                    // `completion_tokens` and bill at the same output rate, so
+                    // there is nothing to separate out.
+                    completion_tokens: usage?.completion_tokens ?? 0,
+                    cached_tokens,
+                };
+
+                this.#meteringService.utilRecordUsageObject(
+                    trackedUsage,
+                    actor!,
+                    `meta:${modelUsed.id}`,
+                    buildCostsOverride(trackedUsage, modelUsed),
+                );
+                return trackedUsage;
+            },
+            stream,
+            completion,
+        });
+    }
+
+    checkModeration(
+        _text: string,
+    ): ReturnType<IChatProvider['checkModeration']> {
+        throw new Error('Method not implemented.');
+    }
+}

--- a/src/backend/drivers/ai-chat/providers/meta/models.ts
+++ b/src/backend/drivers/ai-chat/providers/meta/models.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2024-present Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import type { IChatModel } from '../../types.js';
+import { usdPerMToken } from '../../utils/pricing.js';
+
+const K = 1_000;
+
+// The whole Muse Spark line shares a 1M-token context and a 128K output
+// ceiling. Reasoning tokens are billed as output and count against the
+// ceiling, so there is no separate thinking rate to track.
+const CONTEXT = 1_048_576;
+const MAX_OUTPUT = 128 * K;
+
+// Muse Spark takes text, image, video, audio and PDF, and returns text.
+const MULTIMODAL = ['text', 'image', 'video', 'audio', 'pdf'];
+
+const metaModel = (
+    id: string,
+    name: string,
+    costs: IChatModel['costs'],
+    description: string,
+): IChatModel => ({
+    puterId: `meta:meta/${id}`,
+    id,
+    name,
+    aliases: [`meta/${id}`],
+    description,
+    modalities: { input: MULTIMODAL, output: ['text'] },
+    open_weights: false,
+    tool_call: true,
+    context: CONTEXT,
+    max_tokens: MAX_OUTPUT,
+    costs_currency: 'usd-cents',
+    input_cost_key: 'prompt_tokens',
+    output_cost_key: 'completion_tokens',
+    costs,
+});
+
+// Hardcoded from https://ai.developer.meta.com/docs/models/ (catalog) and
+// https://ai.developer.meta.com/docs/pricing-rate-limits/ (rate card).
+//
+// `muse-spark-1.2-contributor` is documented alongside these — the same
+// weights at a twelfth of the price in exchange for Meta training on what is
+// sent to it — but it is not listed by `GET /models` and answers 404, so the
+// discount tier evidently has to be enabled on the account first. It is left
+// out rather than advertised as a model we can't serve; add it back with the
+// standard rates swapped for usdPerMToken(0.1, 0.2, 0.002) once an enrolled
+// key confirms it, and keep it free of any alias the entries below answer to
+// so its training terms can never capture their traffic.
+export const META_MODELS: IChatModel[] = [
+    metaModel(
+        'muse-spark-1.2',
+        'Muse Spark 1.2',
+        usdPerMToken(1.25, 4.25, 0.15),
+        'Reasoning model optimized for coding and long-horizon agentic work. Prompts are not used to train Meta models.',
+    ),
+    metaModel(
+        'muse-spark-1.1',
+        'Muse Spark 1.1',
+        usdPerMToken(1.25, 4.25, 0.15),
+        'Previous-generation Muse Spark reasoning model. Prompts are not used to train Meta models.',
+    ),
+];

--- a/src/docs/src/AI/chat.md
+++ b/src/docs/src/AI/chat.md
@@ -112,7 +112,7 @@ In case of an error, the `Promise` will reject with an error message.
 
 ## Vendors
 
-We use different vendors for different models and try to use the best vendor available at the time of the request. Vendors currently include Alibaba Cloud, Anthropic, Azure OpenAI, DeepSeek, Google, Infron, MiniMax, Mistral, Moonshot AI, OpenAI, OpenRouter, Together AI, xAI, and Z.AI. Call [`puter.ai.listModelProviders()`](/AI/listModelProviders) for the current list, or pass `provider` in the options object to pin a request to one of them.
+We use different vendors for different models and try to use the best vendor available at the time of the request. Vendors currently include Alibaba Cloud, Anthropic, Azure OpenAI, BytePlus, DeepSeek, Google, Groq, Infron, Meta, MiniMax, Mistral, Moonshot AI, Neuralwatt, OpenAI, OpenRouter, Together AI, xAI, and Z.AI. Call [`puter.ai.listModelProviders()`](/AI/listModelProviders) for the current list, or pass `provider` in the options object to pin a request to one of them.
 
 ## Function Calling
 


### PR DESCRIPTION
## Summary

Adds Meta's Model API as a direct chat provider (PUT-1480), serving Muse Spark
over its OpenAI-compatible Chat Completions endpoint at `api.meta.ai/v1`.

Because `compareModelPreference` ranks direct vendors above resellers in a
shared model bucket, this also changes where `meta/muse-spark-1.x` traffic goes:
Meta first, OpenRouter demoted to fallback. OpenRouter was previously the only
route, and its account-level 18+ confirmation gate made both models 403 for
every caller — the failure reported in PUT-1481.

## Models

| Model | Context | Input | Cached | Output |
|---|---|---|---|---|
| `muse-spark-1.2` | 1,048,576 | $1.25/M | $0.15/M | $4.25/M |
| `muse-spark-1.1` | 1,048,576 | $1.25/M | $0.15/M | $4.25/M |

Both are multimodal (text, image, video, audio, PDF) with tool calling.

`muse-spark-1.2-contributor` is **deliberately excluded**. It is documented with
a public rate card (12x cheaper, in exchange for Meta training on prompts and
completions), but it is absent from `GET /models` and answers
`404 The requested model was not found` — the discount tier evidently has to be
enabled on the account. Shipping it would put a model in `listModels()` that
every request fails against, at a price that makes it look like the one to pick.
`models.ts` carries a note with the rates to restore it once an enrolled key
confirms it works.

## Provider details

- `max_tokens` → `max_completion_tokens`
- `reasoning_effort` passes through from either `reasoning_effort` or
  `reasoning.effort`; `custom.reasoning_effort` reaches the `minimal`/`xhigh`
  tiers the driver's own field can't express. `none` is dropped — Muse Spark
  always reasons and returns a 400 for it.
- `prompt_cache_retention` is translated from the driver's `in-memory` to Meta's
  `in_memory`. This is load-bearing, not cosmetic: the hyphenated form is
  rejected upstream with `unknown variant 'in-memory', expected 'in_memory' or '24h'`.
- Cached reads are subtracted from the prompt count so they aren't billed at both
  the input and the cached rate (same approach as the Gemini provider).
- Reasoning tokens arrive as a subset of `completion_tokens` and bill at the
  output rate, so nothing is separated out.
- The parameters Muse Spark rejects (`stop`, `n > 1`, `logprobs`, `logit_bias`,
  `verbosity`) are never forwarded.
- `puter_path` content parts are inlined via the OpenAI `fileUpload` helper,
  reusing what Azure already does for the same OpenAI-compatible shape.

## Testing

**Offline** — 29 unit tests for the provider (construction, catalog, request
shape, parameter translation, usage/metering, streaming, error passthrough) plus
2 routing regression tests.

Negative control: with the provider unregistered, both routing tests fail and
`meta/muse-spark-1.2` resolves to `openrouter:meta/muse-spark-1.2` — the
age-gated route. So the tests genuinely pin the routing change.

**Live, against the real API with a key** —
- both models, non-streaming and streamed (stream drained, usage asserted)
- tool calling returns a well-formed `tool_calls` block
- confirmed the usage wire shape is OpenAI's nested
  `prompt_tokens_details.cached_tokens`, not a flat `cached_tokens`
- confirmed the cache-retention spellings above (200 vs 400)
- end-to-end through `ChatCompletionDriver` asking for `meta/muse-spark-1.2`:
  returned the expected text and metered 0.0774¢, matching the rate card exactly
  (14 × $1.25/M + 178 × $4.25/M)

**Full backend suite**: 6160 passed, 0 failed, 27 skipped. Typecheck and eslint
clean. Rebased onto current main (`#3604` moved the provider-registration
anchor this change attaches to; Meta now sits after `alibaba`, still ahead of
the aggregators).

## Notes for review

- `max_tokens` is set to 128K from secondary sources; Meta's own docs don't state
  an output ceiling and the API accepted a 200,000 request without complaint, so
  this number is unconfirmed. It feeds the credit cap, so it's worth a second
  opinion.
- **This does not demonstrably fix the "insufficient balance" wording** in
  PUT-1481, only the underlying failure. That dialog comes from `promptUpgrade`
  in `networkUtils.js`, which fires on HTTP 402 or `insufficient_funds`, whereas
  a lone upstream 403 is classified as 500 `upstream_auth_failed` — neither
  trigger. Worth keeping PUT-1481 open until someone confirms against the
  reporter's repro.
- Auth/permissions/data-export: no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
