### PR TITLE
feat: add Gemini Interactions API support and Omni Flash video

### DIFF
--- a/config.template.jsonc
+++ b/config.template.jsonc
@@ -346,6 +346,10 @@
             "apiURL": ""
         },
         "gemini": { "apiKey": "" },
+        // Gemini again, over Google's Interactions API instead of its
+        // OpenAI-compat shim. Same models and same prices; set a key here as
+        // well as under `gemini` to add it as a second route.
+        "gemini-interactions": { "apiKey": "" },
         "groq": { "apiKey": "" },
         "deepseek": { "apiKey": "" },
         "mistral": { "apiKey": "" },

--- a/src/backend/drivers/ai-chat/ChatCompletionDriver.routing.test.ts
+++ b/src/backend/drivers/ai-chat/ChatCompletionDriver.routing.test.ts
@@ -65,6 +65,24 @@ vi.mock('openai', () => {
     return { OpenAI: OpenAICtor, default: { OpenAI: OpenAICtor } };
 });
 
+// -- Gemini SDK mock ------------------------------------------------
+// The Interactions route talks to Google through @google/genai rather than
+// the OpenAI shim, so it needs its own egress point stubbed for the
+// registration tests below to observe a failed attempt offline.
+
+const { interactionsCreateMock } = vi.hoisted(() => ({
+    interactionsCreateMock: vi.fn(),
+}));
+
+vi.mock('@google/genai', () => {
+    const GoogleGenAI = vi.fn().mockImplementation(function (
+        this: Record<string, unknown>,
+    ) {
+        this.interactions = { create: interactionsCreateMock };
+    });
+    return { GoogleGenAI };
+});
+
 // -- axios mock (gateway model catalog) -----------------------------
 
 const { axiosRequestMock } = vi.hoisted(() => ({ axiosRequestMock: vi.fn() }));
@@ -241,12 +259,93 @@ describe('ChatCompletionDriver gemini routing', () => {
         }
     });
 
+    it('leaves the Interactions route out of the bucket unless configured', async () => {
+        // Registering it by default would put a second first-party route in
+        // front of every reseller, changing what the fallback loop tries
+        // second for deployments that never opted in.
+        const attempts = await attemptsFor('gemini-2.5-flash');
+        expect(attempts.some((a) => a.provider === 'gemini-interactions')).toBe(
+            false,
+        );
+    });
+
     it('still routes models only the gateway carries to the gateway', async () => {
         const attempts = await attemptsFor(
             'google/gemini-2.5-flash-image-preview',
         );
 
         expect(attempts[0]).toMatchObject({ provider: 'infron' });
+    });
+});
+
+describe('ChatCompletionDriver gemini-interactions registration', () => {
+    /**
+     * Built in isolation from the shared driver: this one only needs the
+     * catalog to prove the route joined the bucket, and routing a request
+     * through it would reach the real Gemini SDK rather than the mocked OpenAI
+     * one.
+     */
+    const driverWith = async (providers: Record<string, unknown>) => {
+        const d = new ChatCompletionDriver(
+            { providers } as never,
+            server.clients,
+            server.stores,
+            server.services,
+        );
+        d.onServerStart();
+        // `onServerStart` doesn't await `#buildModelMap`; poll until the
+        // catalog lands, same as the shared driver above.
+        for (let i = 0; i < 200; i++) {
+            if ((await d.list()).includes('google:google/gemini-2.5-flash')) {
+                break;
+            }
+            await new Promise((r) => setTimeout(r, 5));
+        }
+        return d;
+    };
+
+    it('registers nothing without a keyed gemini-interactions block', async () => {
+        const d = await driverWith({
+            gemini: { apiKey: 'test-key' },
+            ollama: { enabled: false },
+        });
+        const models = await d.models();
+
+        expect(models.some((m) => m.provider === 'gemini-interactions')).toBe(
+            false,
+        );
+    });
+
+    it('joins the same bucket, behind the shim, once configured', async () => {
+        const d = await driverWith({
+            gemini: { apiKey: 'test-key' },
+            'gemini-interactions': { apiKey: 'test-key' },
+            ollama: { enabled: false },
+        });
+
+        createMock.mockRejectedValue(new Error('upstream down'));
+        interactionsCreateMock.mockRejectedValue(new Error('upstream down'));
+
+        let attempts: { provider: string }[] = [];
+        try {
+            await withTestActor(() =>
+                d.complete({
+                    model: 'gemini-2.5-flash',
+                    messages: [{ role: 'user', content: 'hi' }],
+                }),
+            );
+        } catch (e) {
+            attempts = (
+                e as unknown as {
+                    fields: { attempts: { provider: string }[] };
+                }
+            ).fields.attempts;
+        }
+
+        expect(attempts.map((a) => a.provider)).toEqual([
+            'gemini',
+            'gemini-interactions',
+        ]);
     });
 });
 

--- a/src/backend/drivers/ai-chat/ChatCompletionDriver.ts
+++ b/src/backend/drivers/ai-chat/ChatCompletionDriver.ts
@@ -40,6 +40,7 @@ import { ClaudeProvider } from './providers/claude/ClaudeProvider.js';
 import { DeepSeekProvider } from './providers/deepseek/DeepSeekProvider.js';
 import { FakeChatProvider } from './providers/FakeChatProvider.js';
 import { GeminiChatProvider } from './providers/gemini/GeminiChatProvider.js';
+import { GeminiInteractionsChatProvider } from './providers/gemini/GeminiInteractionsChatProvider.js';
 import { GroqAIProvider } from './providers/groq/GroqAIProvider.js';
 import { InfronProvider } from './providers/infron/InfronProvider.js';
 import { MiniMaxProvider } from './providers/minimax/MiniMaxProvider.js';
@@ -1131,6 +1132,19 @@ export class ChatCompletionDriver extends PuterDriver {
             this.#providers['gemini'] = new GeminiChatProvider(metering, {
                 apiKey: geminiKey,
             });
+        }
+
+        // Same catalog as `gemini`, reached over Google's Interactions API
+        // instead of its OpenAI-compat shim. Keyed separately rather than
+        // sharing the `gemini` key: two routes to one model doubles every
+        // Gemini bucket, which changes what the fallback loop tries second for
+        // deployments that never asked for it.
+        const geminiInteractionsKey = readKey(providers['gemini-interactions']);
+        if (geminiInteractionsKey) {
+            this.#providers['gemini-interactions'] =
+                new GeminiInteractionsChatProvider(metering, {
+                    apiKey: geminiInteractionsKey,
+                });
         }
 
         const groqKey = readKey(providers['groq']);

--- a/src/backend/drivers/ai-chat/providers/gemini/GeminiInteractionsChatProvider.integration.test.ts
+++ b/src/backend/drivers/ai-chat/providers/gemini/GeminiInteractionsChatProvider.integration.test.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2024-present Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Integration test for the Gemini Interactions chat provider.
+ *
+ * Hits the real `/v1beta/interactions` endpoint. Skipped when
+ * `PUTER_TEST_AI_GEMINI_API_KEY` is unset.
+ *
+ * The thinking-tokens case is the reason this file exists rather than being
+ * optional: `INTERACTIONS_OUTPUT_EXCLUDES_THOUGHTS` encodes an assumption about
+ * whether Google counts thought tokens inside `total_output_tokens`, and
+ * getting it wrong silently over- or under-bills every reasoning request.
+ * Nothing offline can settle it — only a live response can.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+    INTEGRATION_TEST_TIMEOUT_MS,
+    makeMeteringStub,
+    optionalEnv,
+    skipUnlessEnv,
+    withTestActor,
+} from '../../../integrationTestUtil.js';
+import { GeminiInteractionsChatProvider } from './GeminiInteractionsChatProvider.js';
+
+const ENV_VAR = 'PUTER_TEST_AI_GEMINI_API_KEY';
+const MODEL = 'gemini-3.7-flash';
+
+const makeProvider = () =>
+    new GeminiInteractionsChatProvider(makeMeteringStub(), {
+        apiKey: optionalEnv(ENV_VAR)!,
+    });
+
+describe.skipIf(skipUnlessEnv(ENV_VAR))(
+    'GeminiInteractionsChatProvider (integration)',
+    () => {
+        it(
+            'returns a non-empty completion',
+            { timeout: INTEGRATION_TEST_TIMEOUT_MS },
+            async () => {
+                const result = await withTestActor(() =>
+                    makeProvider().complete({
+                        model: MODEL,
+                        messages: [
+                            { role: 'user', content: 'Say hi in one word.' },
+                        ],
+                        max_tokens: 16,
+                    }),
+                );
+
+                const text = (result as { message?: { content?: string } })
+                    .message?.content;
+                expect(typeof text === 'string' && text.length > 0).toBe(true);
+            },
+        );
+
+        it(
+            'reports thought tokens as a subset of the output it bills',
+            { timeout: INTEGRATION_TEST_TIMEOUT_MS },
+            async () => {
+                const result = (await withTestActor(() =>
+                    makeProvider().complete({
+                        model: MODEL,
+                        messages: [
+                            {
+                                role: 'user',
+                                content:
+                                    'A bat and ball cost $1.10. The bat costs $1 more than the ball. How much is the ball? Think it through.',
+                            },
+                        ],
+                        reasoning_effort: 'high',
+                    }),
+                )) as { usage: Record<string, number> };
+
+                // The adapter has already normalised to the OpenAI convention:
+                // thinking is its own line, and completion_tokens is what is
+                // left of the output after thinking is taken out. If Google
+                // counts thoughts inside total_output_tokens after all, this
+                // is where it shows up — completion_tokens collapses toward
+                // zero while the model plainly produced an answer.
+                expect(result.usage.thinking_tokens).toBeGreaterThan(0);
+                expect(result.usage.completion_tokens).toBeGreaterThan(0);
+            },
+        );
+
+        it(
+            'streams text through the shared pipeline',
+            { timeout: INTEGRATION_TEST_TIMEOUT_MS },
+            async () => {
+                const result = (await withTestActor(() =>
+                    makeProvider().complete({
+                        model: MODEL,
+                        messages: [
+                            { role: 'user', content: 'Count to three.' },
+                        ],
+                        stream: true,
+                    }),
+                )) as { stream: true };
+
+                expect(result.stream).toBe(true);
+            },
+        );
+    },
+);

--- a/src/backend/drivers/ai-chat/providers/gemini/GeminiInteractionsChatProvider.test.ts
+++ b/src/backend/drivers/ai-chat/providers/gemini/GeminiInteractionsChatProvider.test.ts
@@ -1,0 +1,287 @@
+/*
+ * Copyright (C) 2024-present Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Offline unit tests for GeminiInteractionsChatProvider.
+ *
+ * Boots a real PuterServer so metering is exercised against the live
+ * MeteringService, and mocks @google/genai at the module boundary — the actual
+ * network egress point. What these assert is the drop-in claim: an Interactions
+ * upstream comes back out of the provider in the same shape the driver already
+ * consumes from every OpenAI-compatible one.
+ */
+
+import { Writable } from 'node:stream';
+import {
+    afterAll,
+    afterEach,
+    beforeAll,
+    beforeEach,
+    describe,
+    expect,
+    it,
+    vi,
+    type MockInstance,
+} from 'vitest';
+
+import type { MeteringService } from '../../../../services/metering/MeteringService.js';
+import { PuterServer } from '../../../../server.js';
+import { setupTestServer } from '../../../../testUtil.js';
+import { withTestActor } from '../../../integrationTestUtil.js';
+import { AIChatStream } from '../../utils/Streaming.js';
+import { GeminiInteractionsChatProvider } from './GeminiInteractionsChatProvider.js';
+
+const { createMock, genAICtor } = vi.hoisted(() => ({
+    createMock: vi.fn(),
+    genAICtor: vi.fn(),
+}));
+
+vi.mock('@google/genai', () => {
+    const GoogleGenAI = vi.fn().mockImplementation(function (
+        this: Record<string, unknown>,
+        opts: unknown,
+    ) {
+        genAICtor(opts);
+        this.interactions = { create: createMock };
+    });
+    return { GoogleGenAI };
+});
+
+let server: PuterServer;
+let recordSpy: MockInstance<MeteringService['utilRecordUsageObject']>;
+
+beforeAll(async () => {
+    server = await setupTestServer();
+});
+
+afterAll(async () => {
+    await server?.shutdown();
+});
+
+const makeProvider = () =>
+    new GeminiInteractionsChatProvider(server.services.metering, {
+        apiKey: 'test-key',
+    });
+
+const makeCapturingChatStream = () => {
+    const chunks: string[] = [];
+    const sink = new Writable({
+        write(chunk, _enc, cb) {
+            chunks.push(chunk.toString('utf8'));
+            cb();
+        },
+    });
+    return {
+        chatStream: new AIChatStream({ stream: sink }),
+        events: () =>
+            chunks
+                .join('')
+                .split('\n')
+                .filter(Boolean)
+                .map((line) => JSON.parse(line)),
+    };
+};
+
+const interaction = (overrides: Record<string, unknown> = {}) => ({
+    id: 'int_1',
+    created: '2026-08-19T00:00:00Z',
+    updated: '2026-08-19T00:00:01Z',
+    status: 'completed',
+    model: 'gemini-3.5-flash',
+    outputs: [{ type: 'text', text: 'hello' }],
+    usage: { total_input_tokens: 10, total_output_tokens: 4 },
+    ...overrides,
+});
+
+beforeEach(() => {
+    createMock.mockReset();
+    genAICtor.mockReset();
+    recordSpy = vi.spyOn(server.services.metering, 'utilRecordUsageObject');
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe('catalog', () => {
+    it('serves the same models as the OpenAI-compat route', async () => {
+        const ids = (await makeProvider().models()).map((m) => m.id);
+        expect(ids).toContain('gemini-3.5-flash');
+    });
+
+    it('hands out copies so the driver cannot mutate the shared catalog', async () => {
+        const provider = makeProvider();
+        const first = await provider.models();
+        first[0].aliases!.push('mutated');
+        const second = await provider.models();
+        expect(second[0].aliases).not.toContain('mutated');
+    });
+});
+
+describe('complete (non-streaming)', () => {
+    it('returns a chat-completions choice and meters the turn', async () => {
+        createMock.mockResolvedValue(interaction());
+        const provider = makeProvider();
+
+        const result = await withTestActor(() =>
+            provider.complete({
+                messages: [{ role: 'user', content: 'hi' }],
+                model: 'gemini-3.5-flash',
+            }),
+        );
+
+        expect(result).toMatchObject({
+            finish_reason: 'stop',
+            message: { role: 'assistant', content: 'hello' },
+        });
+        expect(recordSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                prompt_tokens: 10,
+                completion_tokens: 4,
+            }),
+            expect.anything(),
+            'gemini:gemini-3.5-flash',
+            expect.anything(),
+        );
+    });
+
+    it('sends turns, system_instruction and store:false upstream', async () => {
+        createMock.mockResolvedValue(interaction());
+        const provider = makeProvider();
+
+        await withTestActor(() =>
+            provider.complete({
+                messages: [
+                    { role: 'system', content: 'be terse' },
+                    { role: 'user', content: 'hi' },
+                ],
+                model: 'gemini-3.5-flash',
+            }),
+        );
+
+        expect(createMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                model: 'gemini-3.5-flash',
+                system_instruction: 'be terse',
+                // Puter resends history every turn; nothing here is Google's
+                // to retain.
+                store: false,
+                input: [
+                    { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+                ],
+            }),
+        );
+    });
+
+    it('bills thinking tokens separately from generated output', async () => {
+        createMock.mockResolvedValue(
+            interaction({
+                usage: {
+                    total_input_tokens: 100,
+                    total_output_tokens: 40,
+                    total_thought_tokens: 25,
+                    total_cached_tokens: 10,
+                },
+            }),
+        );
+
+        await withTestActor(() =>
+            makeProvider().complete({
+                messages: [{ role: 'user', content: 'hi' }],
+                model: 'gemini-3.5-flash',
+            }),
+        );
+
+        expect(recordSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                prompt_tokens: 90,
+                completion_tokens: 40,
+                cached_tokens: 10,
+                thinking_tokens: 25,
+            }),
+            expect.anything(),
+            expect.any(String),
+            expect.anything(),
+        );
+    });
+
+    it('refuses a caller-supplied previous_response_id', async () => {
+        await expect(
+            withTestActor(() =>
+                makeProvider().complete({
+                    messages: [{ role: 'user', content: 'hi' }],
+                    model: 'gemini-3.5-flash',
+                    previous_response_id: 'int_someone_else',
+                }),
+            ),
+        ).rejects.toThrow(/not supported/i);
+        expect(createMock).not.toHaveBeenCalled();
+    });
+});
+
+describe('complete (streaming)', () => {
+    it('drives the shared stream handler to a normal NDJSON stream', async () => {
+        async function* events() {
+            yield {
+                event_type: 'interaction.start',
+                interaction: interaction(),
+            };
+            yield {
+                event_type: 'content.delta',
+                index: 0,
+                delta: { type: 'text', text: 'hel' },
+            };
+            yield {
+                event_type: 'content.delta',
+                index: 0,
+                delta: { type: 'text', text: 'lo' },
+            };
+            yield {
+                event_type: 'interaction.complete',
+                interaction: interaction(),
+            };
+        }
+        createMock.mockResolvedValue(events());
+
+        const result = (await withTestActor(() =>
+            makeProvider().complete({
+                messages: [{ role: 'user', content: 'hi' }],
+                model: 'gemini-3.5-flash',
+                stream: true,
+            }),
+        )) as {
+            init_chat_stream: (p: { chatStream: unknown }) => Promise<void>;
+        };
+
+        const harness = makeCapturingChatStream();
+        await result.init_chat_stream({ chatStream: harness.chatStream });
+
+        const chunks = harness.events();
+        expect(
+            chunks
+                .filter((c) => c.type === 'text')
+                .map((c) => c.text)
+                .join(''),
+        ).toBe('hello');
+        expect(chunks.find((c) => c.type === 'usage')?.usage).toMatchObject({
+            prompt_tokens: 10,
+        });
+        expect(recordSpy).toHaveBeenCalled();
+    });
+});

--- a/src/backend/drivers/ai-chat/providers/gemini/GeminiInteractionsChatProvider.ts
+++ b/src/backend/drivers/ai-chat/providers/gemini/GeminiInteractionsChatProvider.ts
@@ -1,0 +1,223 @@
+/*
+ * Copyright (C) 2024-present Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { GoogleGenAI, type Interactions } from '@google/genai';
+import { Context } from '../../../../core/context.js';
+import { HttpError } from '../../../../core/http/HttpError.js';
+import type { MeteringService } from '../../../../services/metering/MeteringService.js';
+import {
+    interactionStreamToChunks,
+    interactionToCompletion,
+    messagesToInteractionsInput,
+    toGenerationConfig,
+    toolsToInteractionsTools,
+    type IOpenAIUsage,
+} from '../../../util/interactions/index.js';
+import type {
+    IChatModel,
+    IChatProvider,
+    ICompleteArguments,
+} from '../../types.js';
+import {
+    handle_completion_output,
+    process_input_messages,
+} from '../../utils/OpenAIUtil.js';
+import { buildCostsOverride } from '../../utils/pricing.js';
+import { GEMINI_MODELS } from './models.js';
+
+/**
+ * Gemini over the Interactions API.
+ *
+ * Serves the same catalog as [[GeminiChatProvider]], which reaches Gemini
+ * through Google's OpenAI-compatible shim. Two routes to one model is the shape
+ * the driver's model map already expects, so this registers as its own
+ * provider: callers pin it with `provider: 'gemini-interactions'`, everyone
+ * else keeps the shim, and either can cover for the other when a route fails.
+ *
+ * The translation lives in `drivers/util/interactions`; this class is the thin
+ * part — metering and the request/response handoff.
+ */
+export class GeminiInteractionsChatProvider implements IChatProvider {
+    #client: GoogleGenAI;
+    #meteringService: MeteringService;
+
+    // Matches the OpenAI-compat route's default: swapping transports must not
+    // also swap which model an unspecified request lands on.
+    defaultModel = 'gemini-2.5-flash';
+
+    constructor(meteringService: MeteringService, config: { apiKey: string }) {
+        this.#meteringService = meteringService;
+        this.#client = new GoogleGenAI({ apiKey: config.apiKey });
+    }
+
+    getDefaultModel() {
+        return this.defaultModel;
+    }
+
+    async models(): Promise<IChatModel[]> {
+        // Copied, not shared: the driver's model map appends `puterId` onto
+        // `aliases` in place, and the shim provider hands out these same
+        // entries.
+        return GEMINI_MODELS.map((model) => ({
+            ...model,
+            aliases: [...(model.aliases ?? [])],
+        }));
+    }
+
+    async list() {
+        return (await this.models())
+            .map((m) => [m.id, ...(m.aliases || [])])
+            .flat();
+    }
+
+    async complete(
+        args: ICompleteArguments,
+    ): ReturnType<IChatProvider['complete']> {
+        const {
+            messages,
+            stream,
+            model,
+            tools,
+            tool_choice,
+            max_tokens,
+            temperature,
+            top_p,
+            reasoning,
+            reasoning_effort,
+            previous_response_id,
+        } = args;
+
+        if (previous_response_id) {
+            // Interactions ids are scoped to our API key, not to the caller, so
+            // honouring a caller-supplied one would let any app pull another
+            // user's stored turn into its context. Server-side state needs an
+            // ownership record before it can be exposed; until then this path
+            // stays closed rather than half-open.
+            throw new HttpError(
+                400,
+                'previous_response_id is not supported on gemini-interactions; resend the conversation in `messages`',
+                { legacyCode: 'bad_request' },
+            );
+        }
+
+        const actor = Context.get('actor');
+        const normalized = await process_input_messages(messages);
+        for (const message of normalized) {
+            delete message.cache_control;
+        }
+
+        const catalog = await this.models();
+        const modelUsed =
+            catalog.find((m) => [m.id, ...(m.aliases || [])].includes(model)) ??
+            catalog.find((m) => m.id === this.getDefaultModel())!;
+
+        const { input, system_instruction } =
+            messagesToInteractionsInput(normalized);
+        const generation_config = toGenerationConfig({
+            max_tokens,
+            temperature,
+            top_p,
+            tool_choice,
+            reasoning_effort,
+            reasoning,
+        });
+
+        const interactionsTools = toolsToInteractionsTools(tools);
+        const params = {
+            model: modelUsed.id,
+            input,
+            ...(system_instruction ? { system_instruction } : {}),
+            ...(interactionsTools ? { tools: interactionsTools } : {}),
+            ...(generation_config ? { generation_config } : {}),
+            // Puter's chat API is stateless — the caller resends history every
+            // turn — so there is nothing here worth Google retaining for 55
+            // days on our behalf.
+            store: false,
+            stream,
+        };
+
+        let completion;
+        try {
+            if (stream) {
+                const events = await this.#client.interactions.create({
+                    ...params,
+                    stream: true,
+                } as Interactions.CreateModelInteractionParamsStreaming);
+                completion = interactionStreamToChunks(events, {
+                    model: modelUsed.id,
+                });
+            } else {
+                const interaction = await this.#client.interactions.create({
+                    ...params,
+                    stream: false,
+                } as Interactions.CreateModelInteractionParamsNonStreaming);
+                completion = interactionToCompletion(interaction, {
+                    model: modelUsed.id,
+                });
+            }
+        } catch (e) {
+            console.error('Gemini interactions error: ', e);
+            throw e;
+        }
+
+        return handle_completion_output({
+            stream,
+            completion,
+            usage_calculator: (calculatorArgs) => {
+                const usage = calculatorArgs.usage as unknown as IOpenAIUsage;
+
+                const cached_tokens =
+                    usage?.prompt_tokens_details?.cached_tokens ?? 0;
+                const thinking_tokens =
+                    usage?.completion_tokens_details?.reasoning_tokens ?? 0;
+
+                const trackedUsage = {
+                    prompt_tokens: (usage?.prompt_tokens ?? 0) - cached_tokens,
+                    completion_tokens: Math.max(
+                        0,
+                        (usage?.completion_tokens ?? 0) - thinking_tokens,
+                    ),
+                    cached_tokens,
+                    thinking_tokens,
+                    tool_use_tokens: usage?.tool_use_tokens ?? 0,
+                    // A real count, where the shim provider can only infer that
+                    // grounding happened at all and bill it as one request.
+                    grounding_requests: usage?.grounding_requests ?? 0,
+                };
+
+                this.#meteringService.utilRecordUsageObject(
+                    trackedUsage,
+                    actor!,
+                    // Same ledger key as the shim route: same vendor, same
+                    // model, same price — only the transport differs.
+                    `gemini:${modelUsed.id}`,
+                    buildCostsOverride(trackedUsage, modelUsed),
+                );
+
+                return trackedUsage;
+            },
+        });
+    }
+
+    checkModeration(
+        _text: string,
+    ): ReturnType<IChatProvider['checkModeration']> {
+        throw new Error('No moderation logic.');
+    }
+}

--- a/src/backend/drivers/ai-chat/utils/OpenAIUtil.js
+++ b/src/backend/drivers/ai-chat/utils/OpenAIUtil.js
@@ -406,7 +406,13 @@ export const create_chat_stream_handler =
         chatStream.reportUsage(usage);
 
         if (mode === 'text') textblock.end();
-        if (mode === 'tool') toolblock.end();
+        // Every tool block, not just the one the last chunk happened to touch:
+        // parallel tool calls arrive as separate indices, and ending only the
+        // final `toolblock` dropped the others on the floor — the completion
+        // was generated and billed, and the caller saw one of the calls.
+        if (mode === 'tool') {
+            for (const block of tool_call_blocks) block?.end();
+        }
 
         message.end();
         chatStream.end(usage);

--- a/src/backend/drivers/ai-chat/utils/OpenAIUtil.test.ts
+++ b/src/backend/drivers/ai-chat/utils/OpenAIUtil.test.ts
@@ -536,6 +536,66 @@ describe('create_chat_stream_handler', () => {
         expect(toolEvent?.input).toEqual({ q: 'puter' });
     });
 
+    it('flushes every parallel tool_use block, not just the last one', async () => {
+        // Regression: only the most recently touched block was ended, so a
+        // completion with two tool calls emitted one and silently dropped the
+        // other — after the caller had already been billed for both.
+        const completion = asAsyncIterable([
+            {
+                choices: [
+                    {
+                        delta: {
+                            tool_calls: [
+                                {
+                                    index: 0,
+                                    id: 'call_1',
+                                    function: {
+                                        name: 'first',
+                                        arguments: '{"n":1}',
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                ],
+            },
+            {
+                choices: [
+                    {
+                        delta: {
+                            tool_calls: [
+                                {
+                                    index: 1,
+                                    id: 'call_2',
+                                    function: {
+                                        name: 'second',
+                                        arguments: '{"n":2}',
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                ],
+            },
+            { choices: [{ delta: {} }], usage: { prompt_tokens: 3 } },
+        ]);
+        const init = create_chat_stream_handler({
+            deviations: undefined,
+            completion,
+            usage_calculator: () => ({}),
+        });
+        const harness = makeCapturingChatStream();
+        await init({ chatStream: harness.chatStream });
+
+        const toolEvents = harness
+            .events()
+            .filter((e) => e.type === 'tool_use');
+        expect(toolEvents.map((e) => [e.name, e.input])).toEqual([
+            ['first', { n: 1 }],
+            ['second', { n: 2 }],
+        ]);
+    });
+
     it('honors the deviations.chunk_but_like_actually unwrap', async () => {
         // Mistral wraps each chunk under `.data`.
         const completion = asAsyncIterable([

--- a/src/backend/drivers/ai-video/VideoGenerationDriver.ts
+++ b/src/backend/drivers/ai-video/VideoGenerationDriver.ts
@@ -27,6 +27,7 @@ import { PuterDriver } from '../types.js';
 import { secureFetch } from '../../util/secureHttp.js';
 import { AI_CONCURRENT, AI_RATE_LIMIT } from '../util/aiLimits.js';
 import { BytePlusVideoProvider } from './providers/byteplus/BytePlusVideoProvider.js';
+import { GeminiOmniVideoProvider } from './providers/gemini/GeminiOmniVideoProvider.js';
 import { GeminiVideoProvider } from './providers/gemini/GeminiVideoProvider.js';
 import { OpenAIVideoProvider } from './providers/openai/OpenAIVideoProvider.js';
 import { TogetherVideoProvider } from './providers/together/TogetherVideoProvider.js';
@@ -297,6 +298,11 @@ export class VideoGenerationDriver extends PuterDriver {
         if (geminiKey) {
             this.#providers['gemini-video-generation'] =
                 new GeminiVideoProvider({ apiKey: geminiKey }, m);
+            // Omni reaches Gemini through the Interactions API rather than
+            // generateVideos, so it is its own provider rather than another
+            // entry in the Veo catalog.
+            this.#providers['gemini-omni-video-generation'] =
+                new GeminiOmniVideoProvider({ apiKey: geminiKey }, m);
         }
 
         // Falls back to the shared `byteplus` (ai-chat) key; `apiBaseUrl`

--- a/src/backend/drivers/ai-video/providers/gemini/GeminiOmniVideoProvider.test.ts
+++ b/src/backend/drivers/ai-video/providers/gemini/GeminiOmniVideoProvider.test.ts
@@ -1,0 +1,331 @@
+/*
+ * Copyright (C) 2024-present Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Offline unit tests for GeminiOmniVideoProvider.
+ *
+ * Boots a real PuterServer so the affordability gate and metering run against
+ * the live MeteringService, and mocks @google/genai at the network boundary.
+ */
+
+import {
+    afterAll,
+    afterEach,
+    beforeAll,
+    beforeEach,
+    describe,
+    expect,
+    it,
+    vi,
+    type MockInstance,
+} from 'vitest';
+
+import type { MeteringService } from '../../../../services/metering/MeteringService.js';
+import { PuterServer } from '../../../../server.js';
+import { setupTestServer } from '../../../../testUtil.js';
+import { withTestActor } from '../../../integrationTestUtil.js';
+import { GeminiOmniVideoProvider } from './GeminiOmniVideoProvider.js';
+
+const { createMock, getMock, deleteMock, filesGetMock } = vi.hoisted(() => ({
+    createMock: vi.fn(),
+    getMock: vi.fn(),
+    deleteMock: vi.fn(),
+    filesGetMock: vi.fn(),
+}));
+
+vi.mock('@google/genai', () => {
+    const GoogleGenAI = vi.fn().mockImplementation(function (
+        this: Record<string, unknown>,
+    ) {
+        this.interactions = {
+            create: createMock,
+            get: getMock,
+            delete: deleteMock,
+        };
+        this.files = { get: filesGetMock };
+    });
+    return { GoogleGenAI };
+});
+
+let server: PuterServer;
+let remainingUsageSpy: MockInstance<MeteringService['getRemainingUsage']>;
+let recordSpy: MockInstance<MeteringService['utilRecordUsageObject']>;
+
+const AMPLE_CREDIT = 100_000_000_000;
+const VIDEO_URI =
+    'https://generativelanguage.googleapis.com/v1beta/files/abc123:download';
+
+beforeAll(async () => {
+    server = await setupTestServer();
+});
+
+afterAll(async () => {
+    await server?.shutdown();
+});
+
+const makeProvider = () =>
+    new GeminiOmniVideoProvider(
+        { apiKey: 'test-key' },
+        server.services.metering,
+    );
+
+const completed = (overrides: Record<string, unknown> = {}) => ({
+    id: 'int_omni_1',
+    created: '2026-08-19T00:00:00Z',
+    updated: '2026-08-19T00:00:30Z',
+    status: 'completed',
+    model: 'gemini-omni-flash-preview',
+    outputs: [{ type: 'video', mime_type: 'video/mp4', uri: VIDEO_URI }],
+    usage: {
+        total_input_tokens: 20,
+        total_output_tokens: 46_336,
+        output_tokens_by_modality: [{ modality: 'video', tokens: 46_336 }],
+    },
+    ...overrides,
+});
+
+beforeEach(() => {
+    createMock.mockReset();
+    getMock.mockReset();
+    deleteMock.mockReset().mockResolvedValue(undefined);
+    filesGetMock.mockReset().mockResolvedValue({ state: 'ACTIVE' });
+    remainingUsageSpy = vi.spyOn(server.services.metering, 'getRemainingUsage');
+    remainingUsageSpy.mockResolvedValue(AMPLE_CREDIT);
+    recordSpy = vi.spyOn(server.services.metering, 'utilRecordUsageObject');
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe('validation', () => {
+    it('rejects an empty prompt before reaching the upstream', async () => {
+        await expect(
+            withTestActor(() => makeProvider().generate({ prompt: '   ' })),
+        ).rejects.toThrow(/non-empty/);
+        expect(createMock).not.toHaveBeenCalled();
+    });
+
+    it('short-circuits test_mode without spending credit', async () => {
+        const result = await withTestActor(() =>
+            makeProvider().generate({ prompt: 'hi', test_mode: true }),
+        );
+        expect(result).toBe('https://assets.puter.site/txt2vid.mp4');
+        expect(createMock).not.toHaveBeenCalled();
+        expect(recordSpy).not.toHaveBeenCalled();
+    });
+});
+
+describe('request shaping', () => {
+    it('asks for a text_to_video interaction with uri delivery', async () => {
+        createMock.mockResolvedValue(completed());
+
+        await withTestActor(() =>
+            makeProvider().generate({ prompt: 'a marble rolling' }),
+        );
+
+        expect(createMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                model: 'gemini-omni-flash-preview',
+                input: [{ type: 'text', text: 'a marble rolling' }],
+                response_format: {
+                    type: 'video',
+                    aspect_ratio: '16:9',
+                    delivery: 'uri',
+                },
+                generation_config: { video_config: { task: 'text_to_video' } },
+            }),
+        );
+    });
+
+    it('switches to image_to_video when a first frame is supplied', async () => {
+        createMock.mockResolvedValue(completed());
+
+        await withTestActor(() =>
+            makeProvider().generate({
+                prompt: 'animate this',
+                input_reference: 'data:image/png;base64,QUJD',
+            }),
+        );
+
+        const params = createMock.mock.calls[0][0];
+        expect(params.generation_config.video_config.task).toBe(
+            'image_to_video',
+        );
+        expect(params.input).toContainEqual({
+            type: 'image',
+            data: 'QUJD',
+            mime_type: 'image/png',
+        });
+    });
+
+    it('maps a portrait size to a 9:16 aspect ratio', async () => {
+        createMock.mockResolvedValue(completed());
+
+        await withTestActor(() =>
+            makeProvider().generate({ prompt: 'hi', size: '720x1280' }),
+        );
+
+        expect(createMock.mock.calls[0][0].response_format.aspect_ratio).toBe(
+            '9:16',
+        );
+    });
+});
+
+describe('completion', () => {
+    it('returns the video uri once the file is active', async () => {
+        createMock.mockResolvedValue(completed());
+
+        const result = await withTestActor(() =>
+            makeProvider().generate({ prompt: 'hi' }),
+        );
+
+        expect(result).toBe(VIDEO_URI);
+        expect(filesGetMock).toHaveBeenCalledWith({ name: 'files/abc123' });
+    });
+
+    it('waits for a file that is still processing', async () => {
+        vi.useFakeTimers();
+        try {
+            createMock.mockResolvedValue(completed());
+            filesGetMock
+                .mockResolvedValueOnce({ state: 'PROCESSING' })
+                .mockResolvedValueOnce({ state: 'ACTIVE' });
+
+            const promise = withTestActor(() =>
+                makeProvider().generate({ prompt: 'hi' }),
+            );
+            await vi.advanceTimersByTimeAsync(2_000);
+
+            expect(await promise).toBe(VIDEO_URI);
+            expect(filesGetMock).toHaveBeenCalledTimes(2);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it('polls an in-progress interaction to completion', async () => {
+        vi.useFakeTimers();
+        try {
+            createMock.mockResolvedValue(
+                completed({ status: 'in_progress', outputs: [], usage: {} }),
+            );
+            getMock.mockResolvedValue(completed());
+
+            const promise = withTestActor(() =>
+                makeProvider().generate({ prompt: 'hi' }),
+            );
+            await vi.advanceTimersByTimeAsync(10_000);
+
+            expect(await promise).toBe(VIDEO_URI);
+            expect(getMock).toHaveBeenCalledWith('int_omni_1');
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it('returns inline bytes as a data url', async () => {
+        createMock.mockResolvedValue(
+            completed({
+                outputs: [
+                    { type: 'video', mime_type: 'video/mp4', data: 'QUJD' },
+                ],
+            }),
+        );
+
+        expect(
+            await withTestActor(() =>
+                makeProvider().generate({ prompt: 'hi' }),
+            ),
+        ).toBe('data:video/mp4;base64,QUJD');
+        expect(filesGetMock).not.toHaveBeenCalled();
+    });
+
+    it('raises when the interaction produced no video', async () => {
+        createMock.mockResolvedValue(completed({ outputs: [] }));
+
+        await expect(
+            withTestActor(() => makeProvider().generate({ prompt: 'hi' })),
+        ).rejects.toThrow(/did not include a video/);
+    });
+
+    it('deletes the stored interaction once the output is collected', async () => {
+        createMock.mockResolvedValue(completed());
+
+        await withTestActor(() => makeProvider().generate({ prompt: 'hi' }));
+
+        expect(deleteMock).toHaveBeenCalledWith('int_omni_1');
+    });
+
+    it('does not fail a generated video over a cleanup error', async () => {
+        createMock.mockResolvedValue(completed());
+        deleteMock.mockRejectedValue(new Error('gone'));
+
+        expect(
+            await withTestActor(() =>
+                makeProvider().generate({ prompt: 'hi' }),
+            ),
+        ).toBe(VIDEO_URI);
+    });
+});
+
+describe('credit', () => {
+    it('rejects up front when the worst-case clip is unaffordable', async () => {
+        // 8s x 5792 tokens/s x 1750 micro-cents/token ~= $0.81.
+        remainingUsageSpy.mockResolvedValue(1_000_000);
+
+        await expect(
+            withTestActor(() => makeProvider().generate({ prompt: 'hi' })),
+        ).rejects.toThrow(/Insufficient funds/);
+        expect(createMock).not.toHaveBeenCalled();
+    });
+
+    it('bills video output at the video rate', async () => {
+        createMock.mockResolvedValue(completed());
+
+        await withTestActor(() => makeProvider().generate({ prompt: 'hi' }));
+
+        expect(recordSpy).toHaveBeenCalledWith(
+            { prompt_tokens: 20, completion_tokens: 0, video_tokens: 46_336 },
+            expect.anything(),
+            'gemini:gemini-omni-flash-preview',
+            expect.objectContaining({ video_tokens: 46_336 * 1750 }),
+        );
+    });
+
+    it('bills an unbroken-down output as video rather than as text', async () => {
+        createMock.mockResolvedValue(
+            completed({
+                usage: { total_input_tokens: 5, total_output_tokens: 1_000 },
+            }),
+        );
+
+        await withTestActor(() => makeProvider().generate({ prompt: 'hi' }));
+
+        expect(recordSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                video_tokens: 1_000,
+                completion_tokens: 0,
+            }),
+            expect.anything(),
+            expect.any(String),
+            expect.anything(),
+        );
+    });
+});

--- a/src/backend/drivers/ai-video/providers/gemini/GeminiOmniVideoProvider.ts
+++ b/src/backend/drivers/ai-video/providers/gemini/GeminiOmniVideoProvider.ts
@@ -1,0 +1,414 @@
+/*
+ * Copyright (C) 2024-present Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { GoogleGenAI, type Interactions } from '@google/genai';
+import type { Actor } from '../../../../core/actor.js';
+import { Context } from '../../../../core/context.js';
+import { HttpError } from '../../../../core/http/HttpError.js';
+import type { MeteringService } from '../../../../services/metering/MeteringService.js';
+import { partitionOutputs } from '../../../util/interactions/index.js';
+import type { IGenerateVideoParams, IVideoModel } from '../../types.js';
+import { VideoProvider } from '../VideoProvider.js';
+import {
+    GEMINI_OMNI_VIDEO_MODELS,
+    IGeminiOmniModel,
+    OMNI_MAX_BILLED_SECONDS,
+    OMNI_VIDEO_TOKENS_PER_SECOND_720P,
+} from './omniModels.js';
+
+const DEFAULT_TEST_VIDEO_URL = 'https://assets.puter.site/txt2vid.mp4';
+const POLL_INTERVAL_MS = 10_000;
+const FILE_POLL_INTERVAL_MS = 2_000;
+const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000;
+
+const ASPECT_BY_DIMENSION: Record<string, string> = {
+    '1280x720': '16:9',
+    '720x1280': '9:16',
+};
+
+const FILE_NAME_IN_URI = /\/(files\/[^/:?]+)/;
+
+/**
+ * Gemini Omni video generation, over the Interactions API.
+ *
+ * Omni is reachable only through `/v1beta/interactions` — there is no
+ * `generateVideos` operation to poll — so this is a sibling of
+ * [[GeminiVideoProvider]] rather than another entry in its catalog. What the
+ * two share is the `IVideoProvider` contract: a prompt in, a video URL out.
+ *
+ * Two things Veo's shape does not cover:
+ *
+ * - Omni exposes no duration parameter, so there is no clip length to clamp to
+ *   the caller's remaining credit. The affordability gate checks the worst-case
+ *   clip up front instead, and metering reads the tokens actually billed.
+ * - Retrieving a long-running interaction requires Google to have stored it, so
+ *   `store` cannot be false here the way it is on the chat route. The
+ *   interaction is deleted once the video URI is in hand.
+ */
+export class GeminiOmniVideoProvider extends VideoProvider {
+    #client: GoogleGenAI;
+    #meteringService: MeteringService;
+
+    constructor(config: { apiKey: string }, meteringService: MeteringService) {
+        super();
+        if (!config.apiKey) {
+            throw new Error('Gemini Omni video generation requires an API key');
+        }
+        this.#client = new GoogleGenAI({ apiKey: config.apiKey });
+        this.#meteringService = meteringService;
+    }
+
+    getDefaultModel(): string {
+        return GEMINI_OMNI_VIDEO_MODELS[0].id;
+    }
+
+    async models(): Promise<IVideoModel[]> {
+        return GEMINI_OMNI_VIDEO_MODELS.map((model) => ({
+            ...model,
+            aliases: [model.id, `google/${model.id}`],
+        }));
+    }
+
+    async generate(params: IGenerateVideoParams): Promise<unknown> {
+        const {
+            prompt,
+            model: requestedModel,
+            size,
+            reference_images: referenceImages,
+            input_reference: inputReference,
+            test_mode: testMode,
+        } = params ?? {};
+
+        if (typeof prompt !== 'string' || !prompt.trim()) {
+            throw new HttpError(400, 'prompt must be a non-empty string', {
+                legacyCode: 'bad_request',
+            });
+        }
+
+        const selectedModel = this.#getModel(requestedModel);
+
+        if (testMode) {
+            return DEFAULT_TEST_VIDEO_URL;
+        }
+
+        const actor = Context.get('actor') as Actor | undefined;
+        if (!actor) {
+            throw new HttpError(401, 'Authentication required', {
+                legacyCode: 'unauthorized',
+            });
+        }
+
+        await this.#assertAffordable(actor, selectedModel);
+
+        const firstFrame =
+            selectedModel.supportsImageInput &&
+            typeof inputReference === 'string' &&
+            inputReference.trim()
+                ? inputReference
+                : undefined;
+        const refImages =
+            selectedModel.supportsReferenceImages &&
+            Array.isArray(referenceImages)
+                ? referenceImages.filter(
+                      (img) => typeof img === 'string' && img.trim(),
+                  )
+                : [];
+
+        const input: Interactions.Content[] = [{ type: 'text', text: prompt }];
+        for (const image of firstFrame ? [firstFrame] : refImages) {
+            input.push(this.#imageContent(image));
+        }
+
+        const task = firstFrame
+            ? 'image_to_video'
+            : refImages.length
+              ? 'reference_to_video'
+              : 'text_to_video';
+
+        const interaction = await this.#createAndAwait({
+            model: selectedModel.id,
+            input,
+            response_format: {
+                type: 'video',
+                aspect_ratio: this.#aspectRatio(size, selectedModel),
+                // Base64 delivery caps out at 4MB, which a real clip clears
+                // immediately.
+                delivery: 'uri',
+            },
+            generation_config: { video_config: { task } },
+            // Forced by retrieval, not chosen: see the class comment.
+            store: true,
+            stream: false,
+        });
+
+        try {
+            const video = this.#extractVideo(interaction);
+            await this.#meter(actor, selectedModel, interaction.usage);
+
+            if (video.uri) {
+                await this.#awaitFileActive(video.uri);
+                return video.uri;
+            }
+            return `data:${video.mime_type ?? 'video/mp4'};base64,${video.data}`;
+        } finally {
+            await this.#forget(interaction.id);
+        }
+    }
+
+    // -- Upstream ------------------------------------------------------------
+
+    async #createAndAwait(
+        params: Record<string, unknown>,
+    ): Promise<Interactions.Interaction> {
+        let interaction: Interactions.Interaction;
+        try {
+            interaction = await this.#client.interactions.create(
+                params as unknown as Interactions.CreateModelInteractionParamsNonStreaming,
+            );
+        } catch (e) {
+            console.error('Gemini Omni video generation error:', e);
+            throw e;
+        }
+
+        const start = Date.now();
+        while (interaction.status === 'in_progress') {
+            if (Date.now() - start > DEFAULT_TIMEOUT_MS) {
+                throw new HttpError(
+                    504,
+                    'Timed out waiting for Gemini Omni video generation to complete',
+                    { legacyCode: 'timeout' },
+                );
+            }
+            await this.#delay(POLL_INTERVAL_MS);
+            interaction = await this.#client.interactions.get(interaction.id);
+        }
+
+        if (interaction.status !== 'completed') {
+            throw new HttpError(
+                502,
+                `Gemini Omni video generation ${interaction.status}`,
+                { legacyCode: 'bad_response' },
+            );
+        }
+
+        return interaction;
+    }
+
+    /**
+     * A URI-delivered video is a Files API entry that is still being written
+     * when the interaction completes. Handing the caller a URI that 404s until
+     * processing finishes makes the wait their problem instead of ours.
+     */
+    async #awaitFileActive(uri: string): Promise<void> {
+        const name = FILE_NAME_IN_URI.exec(uri)?.[1];
+        if (!name) return;
+
+        const start = Date.now();
+        for (;;) {
+            const file = await this.#client.files.get({ name });
+            if (file.state === 'ACTIVE') return;
+            if (file.state === 'FAILED') {
+                throw new HttpError(
+                    502,
+                    'Gemini Omni video failed to process',
+                    { legacyCode: 'bad_response' },
+                );
+            }
+            if (Date.now() - start > DEFAULT_TIMEOUT_MS) {
+                throw new HttpError(
+                    504,
+                    'Timed out waiting for the generated video to become available',
+                    { legacyCode: 'timeout' },
+                );
+            }
+            await this.#delay(FILE_POLL_INTERVAL_MS);
+        }
+    }
+
+    /**
+     * Drop the stored interaction now that its output has been collected.
+     *
+     * Storage was a precondition for polling, not something the caller asked
+     * for, so it does not outlive the request. Best-effort: a video we already
+     * have is not worth failing over a retention cleanup.
+     */
+    async #forget(id: string): Promise<void> {
+        try {
+            await this.#client.interactions.delete(id);
+        } catch (e) {
+            console.error('Failed to delete Gemini Omni interaction:', e);
+        }
+    }
+
+    #extractVideo(
+        interaction: Interactions.Interaction,
+    ): Interactions.VideoContent {
+        const { extra } = partitionOutputs(interaction.outputs);
+        const video = extra.find(
+            (output): output is Interactions.VideoContent =>
+                output.type === 'video',
+        );
+
+        if (!video || (!video.uri && !video.data)) {
+            throw new HttpError(
+                502,
+                'Gemini Omni response did not include a video',
+                { legacyCode: 'bad_response' },
+            );
+        }
+
+        return video;
+    }
+
+    // -- Metering ------------------------------------------------------------
+
+    /** Micro-cents per token for one of the model's per-million-token rates. */
+    #microCentsPerToken(model: IGeminiOmniModel, key: string): number {
+        const scale = model.costs?.tokens ?? 1_000_000;
+        const rate = model.costs?.[key];
+        if (!Number.isFinite(rate)) {
+            throw new Error(
+                `No '${key}' cost configured for video model '${model.id}'`,
+            );
+        }
+        return (rate! * 1_000_000) / scale;
+    }
+
+    /**
+     * Reject up front what the account cannot cover.
+     *
+     * Veo's equivalent shortens the clip to fit the wallet. Omni takes no
+     * duration, so the only honest gate is whether the longest clip it might
+     * return is affordable — anything less risks handing back a video the
+     * account cannot pay for.
+     */
+    async #assertAffordable(
+        actor: Actor,
+        model: IGeminiOmniModel,
+    ): Promise<void> {
+        const worstCase = Math.ceil(
+            OMNI_MAX_BILLED_SECONDS *
+                OMNI_VIDEO_TOKENS_PER_SECOND_720P *
+                this.#microCentsPerToken(model, 'video_tokens'),
+        );
+
+        if (await this.#meteringService.hasEnoughCredits(actor, worstCase)) {
+            return;
+        }
+
+        const usd = (microCents: number) => (microCents / 1e8).toFixed(2);
+        throw new HttpError(
+            402,
+            `Insufficient funds: ${model.id} bills up to $${usd(worstCase)} ` +
+                `per clip and does not accept a duration to shorten it.`,
+            { legacyCode: 'insufficient_funds' },
+        );
+    }
+
+    async #meter(
+        actor: Actor,
+        model: IGeminiOmniModel,
+        usage?: Interactions.Usage,
+    ): Promise<void> {
+        const byModality = new Map(
+            (usage?.output_tokens_by_modality ?? []).map((entry) => [
+                entry.modality,
+                entry.tokens ?? 0,
+            ]),
+        );
+        const totalOutput = usage?.total_output_tokens ?? 0;
+
+        // No breakdown means we cannot tell text output from video output. Bill
+        // it all at the video rate: this is a video model, video is the
+        // expensive modality, and guessing the cheap one gives the clip away.
+        const videoTokens = byModality.size
+            ? (byModality.get('video') ?? 0)
+            : totalOutput;
+        const textTokens = byModality.size
+            ? Math.max(0, totalOutput - videoTokens)
+            : 0;
+
+        const trackedUsage = {
+            prompt_tokens: usage?.total_input_tokens ?? 0,
+            completion_tokens: textTokens,
+            video_tokens: videoTokens,
+        };
+
+        const costs: Record<string, number> = {
+            prompt_tokens:
+                trackedUsage.prompt_tokens *
+                this.#microCentsPerToken(model, 'prompt_tokens'),
+            completion_tokens:
+                trackedUsage.completion_tokens *
+                this.#microCentsPerToken(model, 'completion_tokens'),
+            video_tokens:
+                trackedUsage.video_tokens *
+                this.#microCentsPerToken(model, 'video_tokens'),
+        };
+
+        await this.#meteringService.utilRecordUsageObject(
+            trackedUsage,
+            actor,
+            `gemini:${model.id}`,
+            costs,
+        );
+    }
+
+    // -- Request shaping -----------------------------------------------------
+
+    #imageContent(input: string): Interactions.Content {
+        if (input.startsWith('data:')) {
+            const commaIdx = input.indexOf(',');
+            const header = input.substring(5, commaIdx);
+            if (commaIdx !== -1 && header.endsWith(';base64')) {
+                return {
+                    type: 'image',
+                    data: input.substring(commaIdx + 1),
+                    mime_type: header.substring(0, header.length - 7),
+                } as Interactions.Content;
+            }
+        }
+        if (/^https?:\/\//.test(input)) {
+            return { type: 'image', uri: input } as Interactions.Content;
+        }
+        return {
+            type: 'image',
+            data: input,
+            mime_type: 'image/png',
+        } as Interactions.Content;
+    }
+
+    #aspectRatio(size: string | undefined, model: IGeminiOmniModel): string {
+        return (
+            (size ? ASPECT_BY_DIMENSION[size] : undefined) ??
+            model.aspectRatios[0]
+        );
+    }
+
+    #getModel(requestedModel?: string): IGeminiOmniModel {
+        return (
+            GEMINI_OMNI_VIDEO_MODELS.find((m) => m.id === requestedModel) ??
+            GEMINI_OMNI_VIDEO_MODELS[0]
+        );
+    }
+
+    async #delay(ms: number): Promise<void> {
+        return await new Promise((resolve) => setTimeout(resolve, ms));
+    }
+}

--- a/src/backend/drivers/ai-video/providers/gemini/omniModels.ts
+++ b/src/backend/drivers/ai-video/providers/gemini/omniModels.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2024-present Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { IVideoModel } from '../../types.js';
+
+export interface IGeminiOmniModel extends IVideoModel {
+    aspectRatios: string[];
+    supportsImageInput: boolean;
+    supportsReferenceImages: boolean;
+}
+
+/**
+ * Video tokens Google bills per second of 720p output.
+ *
+ * Omni prices video as output tokens, not as clip length, and exposes no
+ * duration parameter. This ratio is the only bridge between the two, and it is
+ * what turns a wallet balance into "can this request run at all".
+ *
+ * https://ai.google.dev/gemini-api/docs/pricing
+ */
+export const OMNI_VIDEO_TOKENS_PER_SECOND_720P = 5792;
+
+/**
+ * Longest clip Omni is documented to produce, used for the affordability
+ * pre-check. Nothing caps generation at request time, so the gate has to assume
+ * the worst case rather than clamp toward it the way Veo does.
+ */
+export const OMNI_MAX_BILLED_SECONDS = 8;
+
+// https://ai.google.dev/gemini-api/docs/omni
+// https://ai.google.dev/gemini-api/docs/pricing
+//
+// Unsupported by the model, and therefore ignored rather than forwarded:
+// `negative_prompt`, `seconds`/`duration` (the model chooses its own length),
+// `fps`, `seed`, `guidance_scale`, and system instructions. `durationSeconds`
+// is null so the driver does not normalise a duration the upstream will not
+// honour.
+export const GEMINI_OMNI_VIDEO_MODELS: IGeminiOmniModel[] = [
+    {
+        puterId: 'google:google/gemini-omni-flash',
+        id: 'gemini-omni-flash-preview',
+        name: 'Gemini Omni Flash',
+        costs_currency: 'usd-cents',
+        costs: {
+            tokens: 1_000_000,
+            prompt_tokens: 150,
+            completion_tokens: 900,
+            video_tokens: 1750,
+            // Derived, published for parity with the Veo entries so callers
+            // comparing models see one number in the same unit.
+            'per-second': 10,
+        },
+        output_cost_key: 'video_tokens',
+        durationSeconds: null,
+        dimensions: ['1280x720', '720x1280'],
+        aspectRatios: ['16:9', '9:16'],
+        supportsImageInput: true,
+        supportsReferenceImages: true,
+        promptSupported: true,
+    },
+];

--- a/src/backend/drivers/util/interactions/index.ts
+++ b/src/backend/drivers/util/interactions/index.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2024-present Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * OpenAI <-> Gemini Interactions translation.
+ *
+ * Google's Interactions API is the single endpoint behind Gemini models,
+ * agents, and Omni video. It is not chat-completions shaped, and Puter
+ * normalises every chat upstream to chat-completions. This module is the seam:
+ * it speaks Interactions on one side and chat-completions on the other, so
+ * adopting an Interactions-only model is a provider plus a catalog entry
+ * instead of a new response path through the driver.
+ *
+ * Lives under `drivers/util` rather than `ai-chat/utils` because the video
+ * driver needs the same translation for Omni.
+ */
+
+export {
+    messagesToInteractionsInput,
+    toGenerationConfig,
+    toolsToInteractionsTools,
+    type IGenerationConfigArgs,
+    type IInteractionsInput,
+} from './request.js';
+
+export {
+    INTERACTIONS_OUTPUT_EXCLUDES_THOUGHTS,
+    interactionStreamToChunks,
+    interactionToCompletion,
+    interactionUsageToOpenAI,
+    partitionOutputs,
+    type IPartitionedOutputs,
+} from './response.js';
+
+export type {
+    IOpenAIChoice,
+    IOpenAIChunk,
+    IOpenAIChunkDelta,
+    IOpenAICompletion,
+    IOpenAIMessage,
+    IOpenAIToolCall,
+    IOpenAIUsage,
+    OpenAIChatMessage,
+} from './types.js';

--- a/src/backend/drivers/util/interactions/request.test.ts
+++ b/src/backend/drivers/util/interactions/request.test.ts
@@ -1,0 +1,265 @@
+/*
+ * Copyright (C) 2024-present Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+    messagesToInteractionsInput,
+    toGenerationConfig,
+    toolsToInteractionsTools,
+} from './request.js';
+
+describe('messagesToInteractionsInput', () => {
+    it('hoists system messages into system_instruction', () => {
+        const { input, system_instruction } = messagesToInteractionsInput([
+            { role: 'system', content: 'be terse' },
+            { role: 'system', content: 'be kind' },
+            { role: 'user', content: 'hi' },
+        ]);
+
+        expect(system_instruction).toBe('be terse\n\nbe kind');
+        expect(input).toEqual([
+            { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+        ]);
+    });
+
+    it('maps assistant turns to the model role', () => {
+        const { input } = messagesToInteractionsInput([
+            { role: 'user', content: 'hi' },
+            { role: 'assistant', content: 'hello' },
+        ]);
+
+        expect(input.map((turn) => turn.role)).toEqual(['user', 'model']);
+    });
+
+    it('splits a data url into inline bytes and a mime type', () => {
+        const { input } = messagesToInteractionsInput([
+            {
+                role: 'user',
+                content: [
+                    { type: 'text', text: 'what is this' },
+                    {
+                        type: 'image_url',
+                        image_url: { url: 'data:image/jpeg;base64,QUJD' },
+                    },
+                ],
+            },
+        ]);
+
+        expect(input[0].content).toEqual([
+            { type: 'text', text: 'what is this' },
+            { type: 'image', data: 'QUJD', mime_type: 'image/jpeg' },
+        ]);
+    });
+
+    it('passes a remote image through as a uri', () => {
+        const { input } = messagesToInteractionsInput([
+            {
+                role: 'user',
+                content: [
+                    {
+                        type: 'image_url',
+                        image_url: { url: 'https://example.com/cat.png' },
+                    },
+                ],
+            },
+        ]);
+
+        expect(input[0].content).toEqual([
+            { type: 'image', uri: 'https://example.com/cat.png' },
+        ]);
+    });
+
+    it('converts tool calls to function_call blocks with parsed arguments', () => {
+        const { input } = messagesToInteractionsInput([
+            {
+                role: 'assistant',
+                content: null,
+                tool_calls: [
+                    {
+                        id: 'call_1',
+                        type: 'function',
+                        function: {
+                            name: 'get_weather',
+                            arguments: '{"city":"Zagreb"}',
+                        },
+                    },
+                ],
+            },
+        ]);
+
+        expect(input[0]).toEqual({
+            role: 'model',
+            content: [
+                {
+                    type: 'function_call',
+                    id: 'call_1',
+                    name: 'get_weather',
+                    arguments: { city: 'Zagreb' },
+                },
+            ],
+        });
+    });
+
+    it('round-trips a thought signature back to the model', () => {
+        const { input } = messagesToInteractionsInput([
+            {
+                role: 'assistant',
+                content: null,
+                tool_calls: [
+                    {
+                        id: 'call_1',
+                        type: 'function',
+                        function: { name: 'f', arguments: '{}' },
+                        extra_content: { signature: 'sig-abc' },
+                    },
+                ],
+            },
+        ]);
+
+        expect(
+            (input[0].content as Record<string, unknown>[])[0],
+        ).toMatchObject({ signature: 'sig-abc' });
+    });
+
+    it('degrades unparseable tool arguments to an empty object', () => {
+        const { input } = messagesToInteractionsInput([
+            {
+                role: 'assistant',
+                content: null,
+                tool_calls: [
+                    {
+                        id: 'call_1',
+                        type: 'function',
+                        function: { name: 'f', arguments: '{"a":' },
+                    },
+                ],
+            },
+        ]);
+
+        expect(
+            (input[0].content as Record<string, unknown>[])[0],
+        ).toMatchObject({ arguments: {} });
+    });
+
+    it('merges consecutive tool results into one user turn', () => {
+        const { input } = messagesToInteractionsInput([
+            { role: 'tool', tool_call_id: 'call_1', content: 'sunny' },
+            { role: 'tool', tool_call_id: 'call_2', content: 'warm' },
+        ]);
+
+        expect(input).toHaveLength(1);
+        expect(input[0]).toEqual({
+            role: 'user',
+            content: [
+                { type: 'function_result', call_id: 'call_1', result: 'sunny' },
+                { type: 'function_result', call_id: 'call_2', result: 'warm' },
+            ],
+        });
+    });
+
+    it('drops empty messages rather than emitting contentless turns', () => {
+        const { input } = messagesToInteractionsInput([
+            { role: 'user', content: '' },
+            { role: 'user', content: 'real' },
+        ]);
+
+        expect(input).toEqual([
+            { role: 'user', content: [{ type: 'text', text: 'real' }] },
+        ]);
+    });
+});
+
+describe('toolsToInteractionsTools', () => {
+    it('flattens OpenAI function declarations', () => {
+        expect(
+            toolsToInteractionsTools([
+                {
+                    type: 'function',
+                    function: {
+                        name: 'get_weather',
+                        description: 'looks up weather',
+                        parameters: { type: 'object' },
+                    },
+                },
+            ]),
+        ).toEqual([
+            {
+                type: 'function',
+                name: 'get_weather',
+                description: 'looks up weather',
+                parameters: { type: 'object' },
+            },
+        ]);
+    });
+
+    it('passes native Interactions tools through untouched', () => {
+        const googleSearch = { type: 'google_search' };
+        expect(toolsToInteractionsTools([googleSearch])).toEqual([
+            googleSearch,
+        ]);
+    });
+
+    it('returns undefined for an empty tool list', () => {
+        expect(toolsToInteractionsTools([])).toBeUndefined();
+        expect(toolsToInteractionsTools(undefined)).toBeUndefined();
+    });
+});
+
+describe('toGenerationConfig', () => {
+    it('returns undefined when the caller set nothing', () => {
+        expect(toGenerationConfig({})).toBeUndefined();
+    });
+
+    it('maps sampling knobs onto their Interactions names', () => {
+        expect(
+            toGenerationConfig({
+                max_tokens: 100,
+                temperature: 0.2,
+                top_p: 0.9,
+            }),
+        ).toEqual({
+            max_output_tokens: 100,
+            temperature: 0.2,
+            top_p: 0.9,
+        });
+    });
+
+    it("translates OpenAI 'required' tool choice to 'any'", () => {
+        expect(toGenerationConfig({ tool_choice: 'required' })).toEqual({
+            tool_choice: 'any',
+        });
+    });
+
+    it('narrows a named tool choice to that tool', () => {
+        expect(
+            toGenerationConfig({
+                tool_choice: { type: 'function', function: { name: 'f' } },
+            }),
+        ).toEqual({
+            tool_choice: { allowed_tools: { mode: 'any', tools: ['f'] } },
+        });
+    });
+
+    it('asks for thought summaries whenever an effort level is set', () => {
+        expect(toGenerationConfig({ reasoning_effort: 'high' })).toEqual({
+            thinking_level: 'high',
+            thinking_summaries: 'auto',
+        });
+    });
+});

--- a/src/backend/drivers/util/interactions/request.ts
+++ b/src/backend/drivers/util/interactions/request.ts
@@ -1,0 +1,298 @@
+/*
+ * Copyright (C) 2024-present Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import type { Interactions } from '@google/genai';
+import type { OpenAIChatMessage } from './types.js';
+
+/**
+ * OpenAI chat-completions request -> Gemini Interactions request.
+ *
+ * The inverse of `response.ts`. Together they make the Interactions API
+ * addressable through the same provider contract as every other chat upstream,
+ * so a model that moves onto Interactions is a catalog entry rather than a
+ * rewrite.
+ */
+
+/** `data:<mime>;base64,<payload>` — anything else is treated as a fetchable URI. */
+const DATA_URL = /^data:([^;,]+);base64,(.*)$/s;
+
+const mediaContent = (
+    url: string,
+    type: 'image' | 'video' | 'audio',
+): Interactions.Content => {
+    const match = DATA_URL.exec(url);
+    if (match) {
+        return {
+            type,
+            data: match[2],
+            mime_type: match[1],
+        } as Interactions.Content;
+    }
+    return { type, uri: url } as Interactions.Content;
+};
+
+const asText = (content: unknown): string => {
+    if (typeof content === 'string') return content;
+    if (!Array.isArray(content)) return '';
+    return content
+        .map((part) => (typeof part === 'string' ? part : (part?.text ?? '')))
+        .join('');
+};
+
+/**
+ * Arguments survive a round trip through our own stream as a JSON string. A
+ * string the model truncated mid-call parses to nothing useful; send an empty
+ * object rather than failing the whole turn on history we already served.
+ */
+const parseArguments = (raw: unknown): Record<string, unknown> => {
+    if (raw && typeof raw === 'object') return raw as Record<string, unknown>;
+    if (typeof raw !== 'string' || raw.trim() === '') return {};
+    try {
+        const parsed = JSON.parse(raw);
+        return parsed && typeof parsed === 'object' ? parsed : {};
+    } catch {
+        return {};
+    }
+};
+
+const contentBlocks = (message: OpenAIChatMessage): Interactions.Content[] => {
+    const blocks: Interactions.Content[] = [];
+    const content = message.content;
+
+    if (typeof content === 'string') {
+        if (content !== '') blocks.push({ type: 'text', text: content });
+    } else if (Array.isArray(content)) {
+        for (const part of content) {
+            if (typeof part === 'string') {
+                if (part !== '') blocks.push({ type: 'text', text: part });
+                continue;
+            }
+            if (!part || typeof part !== 'object') continue;
+
+            switch (part.type) {
+                case 'text':
+                case 'input_text':
+                case 'output_text':
+                    if (part.text)
+                        blocks.push({ type: 'text', text: part.text });
+                    break;
+                case 'image_url': {
+                    const url = part.image_url?.url ?? part.image_url;
+                    if (url) blocks.push(mediaContent(url, 'image'));
+                    break;
+                }
+                case 'video_url': {
+                    const url = part.video_url?.url ?? part.video_url;
+                    if (url) blocks.push(mediaContent(url, 'video'));
+                    break;
+                }
+                case 'input_audio': {
+                    const { data, format } = part.input_audio ?? {};
+                    if (data) {
+                        blocks.push({
+                            type: 'audio',
+                            data,
+                            mime_type: `audio/${format ?? 'wav'}`,
+                        } as Interactions.Content);
+                    }
+                    break;
+                }
+                default:
+                    // An unknown part with text on it is still worth sending;
+                    // dropping it silently loses prompt the caller paid to send.
+                    if (part.text)
+                        blocks.push({ type: 'text', text: part.text });
+            }
+        }
+    }
+
+    for (const call of message.tool_calls ?? []) {
+        blocks.push({
+            type: 'function_call',
+            id: call.id,
+            name: call.function?.name ?? call.name,
+            arguments: parseArguments(
+                call.function?.arguments ?? call.arguments,
+            ),
+            ...(call.extra_content?.signature
+                ? { signature: call.extra_content.signature as string }
+                : {}),
+        });
+    }
+
+    return blocks;
+};
+
+export interface IInteractionsInput {
+    input: Interactions.Turn[];
+    /** Hoisted from `system` messages; Interactions has no system turn. */
+    system_instruction?: string;
+}
+
+/**
+ * Convert Puter's normalised (OpenAI chat-completions) `messages` into
+ * Interactions turns.
+ *
+ * Adjacent turns of the same role are merged: a multi-tool turn arrives from
+ * `process_input_messages` as one `tool` message per result, and Gemini expects
+ * those results together in the turn that answers the model.
+ */
+export const messagesToInteractionsInput = (
+    messages: OpenAIChatMessage[],
+): IInteractionsInput => {
+    const systemParts: string[] = [];
+    const turns: Interactions.Turn[] = [];
+
+    const push = (role: 'user' | 'model', content: Interactions.Content[]) => {
+        if (content.length === 0) return;
+        const last = turns[turns.length - 1];
+        if (last && last.role === role && Array.isArray(last.content)) {
+            last.content.push(...content);
+            return;
+        }
+        turns.push({ role, content });
+    };
+
+    for (const message of messages ?? []) {
+        if (!message) continue;
+
+        if (message.role === 'system' || message.role === 'developer') {
+            const text = asText(message.content);
+            if (text) systemParts.push(text);
+            continue;
+        }
+
+        if (message.role === 'tool') {
+            push('user', [
+                {
+                    type: 'function_result',
+                    call_id: message.tool_call_id ?? message.tool_use_id,
+                    result: message.content ?? '',
+                } as Interactions.Content,
+            ]);
+            continue;
+        }
+
+        push(
+            message.role === 'assistant' ? 'model' : 'user',
+            contentBlocks(message),
+        );
+    }
+
+    return {
+        input: turns,
+        ...(systemParts.length
+            ? { system_instruction: systemParts.join('\n\n') }
+            : {}),
+    };
+};
+
+/**
+ * Convert OpenAI tool declarations to Interactions tools.
+ *
+ * A declaration that is already Interactions-native (`{ type: 'google_search'
+ * }` and friends) passes through untouched, which is how a caller reaches the
+ * server-side tools chat-completions has no vocabulary for.
+ */
+export const toolsToInteractionsTools = (
+    tools?: unknown[],
+): Interactions.Tool[] | undefined => {
+    if (!Array.isArray(tools) || tools.length === 0) return undefined;
+
+    return tools.map((tool) => {
+        const t = tool as {
+            type?: string;
+            function?: {
+                name?: string;
+                description?: string;
+                parameters?: unknown;
+            };
+        };
+        if (t.type !== 'function' || !t.function) {
+            return tool as Interactions.Tool;
+        }
+        return {
+            type: 'function',
+            name: t.function.name,
+            ...(t.function.description
+                ? { description: t.function.description }
+                : {}),
+            ...(t.function.parameters
+                ? { parameters: t.function.parameters }
+                : {}),
+        };
+    });
+};
+
+const toolChoiceToInteractions = (
+    toolChoice: unknown,
+): Interactions.GenerationConfig['tool_choice'] | undefined => {
+    if (toolChoice === undefined || toolChoice === null) return undefined;
+    if (toolChoice === 'auto') return 'auto';
+    if (toolChoice === 'none') return 'none';
+    // OpenAI's 'required' means "call something"; Interactions spells it 'any'.
+    if (toolChoice === 'required') return 'any';
+
+    const named = toolChoice as { function?: { name?: string } };
+    if (named?.function?.name) {
+        return { allowed_tools: { mode: 'any', tools: [named.function.name] } };
+    }
+    return undefined;
+};
+
+export interface IGenerationConfigArgs {
+    max_tokens?: number;
+    temperature?: number;
+    top_p?: number;
+    tool_choice?: unknown;
+    reasoning_effort?: 'low' | 'medium' | 'high';
+    reasoning?: { effort: 'low' | 'medium' | 'high' };
+}
+
+/**
+ * Map the sampling knobs the driver accepts onto `generation_config`.
+ *
+ * Returns undefined when the caller set nothing, so the request body stays
+ * minimal and the model's own defaults apply.
+ */
+export const toGenerationConfig = ({
+    max_tokens,
+    temperature,
+    top_p,
+    tool_choice,
+    reasoning_effort,
+    reasoning,
+}: IGenerationConfigArgs): Interactions.GenerationConfig | undefined => {
+    const effort = reasoning_effort ?? reasoning?.effort;
+    const choice = toolChoiceToInteractions(tool_choice);
+
+    const config: Interactions.GenerationConfig = {
+        ...(max_tokens !== undefined ? { max_output_tokens: max_tokens } : {}),
+        ...(temperature !== undefined ? { temperature } : {}),
+        ...(top_p !== undefined ? { top_p } : {}),
+        ...(choice !== undefined ? { tool_choice: choice } : {}),
+        // Asking for an effort level without asking for summaries yields
+        // reasoning the caller is billed for and never sees.
+        ...(effort
+            ? { thinking_level: effort, thinking_summaries: 'auto' }
+            : {}),
+    };
+
+    return Object.keys(config).length > 0 ? config : undefined;
+};

--- a/src/backend/drivers/util/interactions/response.test.ts
+++ b/src/backend/drivers/util/interactions/response.test.ts
@@ -1,0 +1,387 @@
+/*
+ * Copyright (C) 2024-present Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * The adapter's contract is "the existing chat-completions pipeline cannot tell
+ * the difference", so the streaming tests here run translated chunks through
+ * the real `create_chat_stream_handler` rather than asserting on chunk shapes a
+ * hand-written fake would happily accept.
+ */
+
+import type { Interactions } from '@google/genai';
+import { Writable } from 'node:stream';
+import { describe, expect, it } from 'vitest';
+import { create_chat_stream_handler } from '../../ai-chat/utils/OpenAIUtil.js';
+import { AIChatStream } from '../../ai-chat/utils/Streaming.js';
+import {
+    INTERACTIONS_OUTPUT_EXCLUDES_THOUGHTS,
+    interactionStreamToChunks,
+    interactionToCompletion,
+    interactionUsageToOpenAI,
+} from './response.js';
+
+const MODEL = 'gemini-3.5-flash';
+
+const interaction = (
+    overrides: Partial<Interactions.Interaction> = {},
+): Interactions.Interaction => ({
+    id: 'int_1',
+    created: '2026-08-19T00:00:00Z',
+    updated: '2026-08-19T00:00:01Z',
+    status: 'completed',
+    model: MODEL,
+    ...overrides,
+});
+
+const drain = async (
+    events: Interactions.InteractionSSEEvent[],
+): Promise<{
+    chunks: unknown[];
+    usage: Record<string, number> | undefined;
+}> => {
+    async function* source() {
+        for (const event of events) yield event;
+    }
+    const chunks: unknown[] = [];
+    for await (const chunk of interactionStreamToChunks(source(), {
+        model: MODEL,
+    })) {
+        chunks.push(chunk);
+    }
+    return { chunks, usage: undefined };
+};
+
+/** Run translated chunks through the production stream handler. */
+const runStreamHandler = async (
+    events: Interactions.InteractionSSEEvent[],
+): Promise<Record<string, unknown>[]> => {
+    async function* source() {
+        for (const event of events) yield event;
+    }
+
+    const written: string[] = [];
+    const sink = new Writable({
+        write(chunk, _enc, cb) {
+            written.push(chunk.toString('utf8'));
+            cb();
+        },
+    });
+    const chatStream = new AIChatStream({ stream: sink });
+
+    await create_chat_stream_handler({
+        completion: interactionStreamToChunks(source(), { model: MODEL }),
+        usage_calculator: ({ usage }: { usage: Record<string, number> }) =>
+            usage,
+    })({ chatStream });
+
+    return written
+        .join('')
+        .split('\n')
+        .filter(Boolean)
+        .map((line) => JSON.parse(line));
+};
+
+describe('interactionUsageToOpenAI', () => {
+    it('folds thought tokens into completion_tokens for the OpenAI convention', () => {
+        // The whole point of the constant: downstream calculators subtract
+        // reasoning back out, so it has to be in there to begin with.
+        expect(INTERACTIONS_OUTPUT_EXCLUDES_THOUGHTS).toBe(true);
+
+        const usage = interactionUsageToOpenAI({
+            total_input_tokens: 100,
+            total_output_tokens: 40,
+            total_thought_tokens: 25,
+            total_cached_tokens: 10,
+        });
+
+        expect(usage.prompt_tokens).toBe(100);
+        expect(usage.completion_tokens).toBe(65);
+        expect(usage.completion_tokens_details.reasoning_tokens).toBe(25);
+        expect(usage.prompt_tokens_details.cached_tokens).toBe(10);
+    });
+
+    it('survives an upstream that reports no usage at all', () => {
+        const usage = interactionUsageToOpenAI(undefined);
+        expect(usage.prompt_tokens).toBe(0);
+        expect(usage.completion_tokens).toBe(0);
+        expect(usage.grounding_requests).toBe(0);
+    });
+
+    it('sums grounding invocations into a real request count', () => {
+        const usage = interactionUsageToOpenAI({
+            grounding_tool_count: [
+                { type: 'google_search', count: 2 },
+                { type: 'google_maps', count: 1 },
+            ],
+        });
+        expect(usage.grounding_requests).toBe(3);
+    });
+});
+
+describe('interactionToCompletion', () => {
+    it('produces a chat-completions choice from text output', () => {
+        const completion = interactionToCompletion(
+            interaction({
+                outputs: [{ type: 'text', text: 'hello there' }],
+                usage: { total_input_tokens: 5, total_output_tokens: 2 },
+            }),
+            { model: MODEL },
+        );
+
+        expect(completion.choices[0]).toMatchObject({
+            index: 0,
+            finish_reason: 'stop',
+            message: { role: 'assistant', content: 'hello there' },
+        });
+        expect(completion.usage.prompt_tokens).toBe(5);
+    });
+
+    it('joins thought summaries into reasoning', () => {
+        const completion = interactionToCompletion(
+            interaction({
+                outputs: [
+                    {
+                        type: 'thought',
+                        summary: [{ type: 'text', text: 'thinking...' }],
+                    },
+                    { type: 'text', text: 'answer' },
+                ],
+            }),
+            { model: MODEL },
+        );
+
+        expect(completion.choices[0].message.reasoning).toBe('thinking...');
+        expect(completion.choices[0].message.content).toBe('answer');
+    });
+
+    it('reports tool calls with stringified arguments and finish_reason', () => {
+        const completion = interactionToCompletion(
+            interaction({
+                outputs: [
+                    {
+                        type: 'function_call',
+                        id: 'call_1',
+                        name: 'get_weather',
+                        arguments: { city: 'Zagreb' },
+                        signature: 'sig',
+                    },
+                ],
+            }),
+            { model: MODEL },
+        );
+
+        expect(completion.choices[0].finish_reason).toBe('tool_calls');
+        expect(completion.choices[0].message.tool_calls).toEqual([
+            {
+                id: 'call_1',
+                type: 'function',
+                function: {
+                    name: 'get_weather',
+                    arguments: '{"city":"Zagreb"}',
+                },
+                extra_content: { signature: 'sig' },
+            },
+        ]);
+        // Null, not '', so the moderation gate skips a tool-only turn.
+        expect(completion.choices[0].message.content).toBeNull();
+    });
+
+    it('routes generated media to extra_content instead of content', () => {
+        const completion = interactionToCompletion(
+            interaction({
+                outputs: [
+                    { type: 'text', text: 'here you go' },
+                    { type: 'image', uri: 'https://example.com/a.png' },
+                ],
+            }),
+            { model: MODEL },
+        );
+
+        expect(completion.choices[0].message.content).toBe('here you go');
+        expect(completion.choices[0].message.extra_content).toEqual({
+            outputs: [{ type: 'image', uri: 'https://example.com/a.png' }],
+        });
+    });
+
+    it("maps an incomplete interaction to finish_reason 'length'", () => {
+        const completion = interactionToCompletion(
+            interaction({
+                status: 'incomplete',
+                outputs: [{ type: 'text', text: 'truncated' }],
+            }),
+            { model: MODEL },
+        );
+        expect(completion.choices[0].finish_reason).toBe('length');
+    });
+
+    it('raises rather than serving an empty completion for a failed interaction', () => {
+        expect(() =>
+            interactionToCompletion(interaction({ status: 'failed' }), {
+                model: MODEL,
+            }),
+        ).toThrow(/failed/i);
+    });
+});
+
+describe('interactionStreamToChunks', () => {
+    it('forwards text deltas as chat-completions content', async () => {
+        const events = await runStreamHandler([
+            { event_type: 'interaction.start', interaction: interaction() },
+            {
+                event_type: 'content.delta',
+                index: 0,
+                delta: { type: 'text', text: 'Hel' },
+            },
+            {
+                event_type: 'content.delta',
+                index: 0,
+                delta: { type: 'text', text: 'lo' },
+            },
+            {
+                event_type: 'interaction.complete',
+                interaction: interaction({
+                    usage: { total_input_tokens: 3, total_output_tokens: 2 },
+                }),
+            },
+        ]);
+
+        const text = events
+            .filter((e) => e.type === 'text')
+            .map((e) => e.text)
+            .join('');
+        expect(text).toBe('Hello');
+
+        const usage = events.find((e) => e.type === 'usage');
+        expect(usage?.usage).toMatchObject({ prompt_tokens: 3 });
+    });
+
+    it('surfaces thought summaries as reasoning chunks', async () => {
+        const events = await runStreamHandler([
+            { event_type: 'interaction.start', interaction: interaction() },
+            {
+                event_type: 'content.delta',
+                index: 0,
+                delta: {
+                    type: 'thought_summary',
+                    content: { type: 'text', text: 'pondering' },
+                },
+            },
+            {
+                event_type: 'interaction.complete',
+                interaction: interaction({ usage: {} }),
+            },
+        ]);
+
+        expect(events.some((e) => e.reasoning === 'pondering')).toBe(true);
+    });
+
+    it('emits a tool call once, at content.stop, with parseable arguments', async () => {
+        const events = await runStreamHandler([
+            { event_type: 'interaction.start', interaction: interaction() },
+            {
+                event_type: 'content.start',
+                index: 0,
+                content: {
+                    type: 'function_call',
+                    id: 'call_1',
+                    name: 'get_weather',
+                    arguments: {},
+                },
+            },
+            {
+                event_type: 'content.delta',
+                index: 0,
+                delta: {
+                    type: 'function_call',
+                    id: 'call_1',
+                    name: 'get_weather',
+                    arguments: { city: 'Zagreb' },
+                },
+            },
+            { event_type: 'content.stop', index: 0 },
+            {
+                event_type: 'interaction.complete',
+                interaction: interaction({ usage: {} }),
+            },
+        ]);
+
+        // Two emissions would concatenate two JSON objects in the handler's
+        // per-index buffer and blow up on parse.
+        const toolUse = events.filter((e) => e.type === 'tool_use');
+        expect(toolUse).toHaveLength(1);
+        expect(toolUse[0]).toMatchObject({
+            id: 'call_1',
+            name: 'get_weather',
+            input: { city: 'Zagreb' },
+        });
+    });
+
+    it('indexes parallel tool calls independently', async () => {
+        const events = await runStreamHandler([
+            { event_type: 'interaction.start', interaction: interaction() },
+            {
+                event_type: 'content.delta',
+                index: 0,
+                delta: {
+                    type: 'function_call',
+                    id: 'call_1',
+                    name: 'a',
+                    arguments: { n: 1 },
+                },
+            },
+            {
+                event_type: 'content.delta',
+                index: 1,
+                delta: {
+                    type: 'function_call',
+                    id: 'call_2',
+                    name: 'b',
+                    arguments: { n: 2 },
+                },
+            },
+            { event_type: 'content.stop', index: 0 },
+            { event_type: 'content.stop', index: 1 },
+            {
+                event_type: 'interaction.complete',
+                interaction: interaction({ usage: {} }),
+            },
+        ]);
+
+        expect(
+            events
+                .filter((e) => e.type === 'tool_use')
+                .map((e) => [e.name, e.input]),
+        ).toEqual([
+            ['a', { n: 1 }],
+            ['b', { n: 2 }],
+        ]);
+    });
+
+    it('throws on an error event rather than ending the stream quietly', async () => {
+        await expect(
+            drain([
+                { event_type: 'interaction.start', interaction: interaction() },
+                {
+                    event_type: 'error',
+                    error: { code: 'x', message: 'upstream exploded' },
+                },
+            ]),
+        ).rejects.toThrow('upstream exploded');
+    });
+});

--- a/src/backend/drivers/util/interactions/response.ts
+++ b/src/backend/drivers/util/interactions/response.ts
@@ -1,0 +1,393 @@
+/*
+ * Copyright (C) 2024-present Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import type { Interactions } from '@google/genai';
+import { HttpError } from '../../../core/http/HttpError.js';
+import type {
+    IOpenAIChunk,
+    IOpenAICompletion,
+    IOpenAIMessage,
+    IOpenAIToolCall,
+    IOpenAIUsage,
+} from './types.js';
+
+/**
+ * Gemini Interactions response -> OpenAI chat-completions response.
+ *
+ * The inverse of `request.ts`. Both the buffered object and the SSE stream are
+ * translated, so `handle_completion_output` and `create_chat_stream_handler`
+ * consume an Interactions upstream without modification.
+ */
+
+/**
+ * Whether `usage.total_output_tokens` counts thought tokens separately from
+ * generated output — the long-standing meaning of Gemini's
+ * `candidatesTokenCount`.
+ *
+ * OpenAI's convention is the opposite: `completion_tokens` is inclusive of
+ * `reasoning_tokens`, and every downstream calculator in this repo subtracts
+ * the reasoning back out. So under Gemini's meaning the adapter has to add the
+ * thoughts in, or the subtraction bills thinking twice and generation not at
+ * all. Getting this backwards is a silent billing error in one direction or the
+ * other, which is why it is one named constant with a test rather than an
+ * inline `+`. The companion integration test asserts it against a live thinking
+ * response; flip it there, not here, if Google's meaning changes.
+ */
+export const INTERACTIONS_OUTPUT_EXCLUDES_THOUGHTS = true;
+
+/** Interactions `Usage` -> the OpenAI `usage` shape metering already reads. */
+export const interactionUsageToOpenAI = (
+    usage?: Interactions.Usage,
+): IOpenAIUsage => {
+    const input = usage?.total_input_tokens ?? 0;
+    const output = usage?.total_output_tokens ?? 0;
+    const thoughts = usage?.total_thought_tokens ?? 0;
+    const cached = usage?.total_cached_tokens ?? 0;
+
+    const completion = INTERACTIONS_OUTPUT_EXCLUDES_THOUGHTS
+        ? output + thoughts
+        : output;
+
+    return {
+        prompt_tokens: input,
+        completion_tokens: completion,
+        total_tokens: usage?.total_tokens ?? input + completion,
+        prompt_tokens_details: { cached_tokens: cached },
+        completion_tokens_details: { reasoning_tokens: thoughts },
+        tool_use_tokens: usage?.total_tool_use_tokens ?? 0,
+        // Grounding is billed per invocation. The OpenAI-compat shim only lets
+        // a provider infer "grounding happened"; here we get the real count.
+        grounding_requests: (usage?.grounding_tool_count ?? []).reduce(
+            (total, entry) => total + (entry.count ?? 0),
+            0,
+        ),
+    };
+};
+
+const thoughtText = (content: Interactions.ThoughtContent): string =>
+    (content.summary ?? [])
+        .map((part) => (part.type === 'text' ? part.text : ''))
+        .join('');
+
+const toToolCall = (
+    content: Interactions.FunctionCallContent,
+): IOpenAIToolCall => ({
+    id: content.id,
+    type: 'function',
+    function: {
+        name: content.name,
+        arguments: JSON.stringify(content.arguments ?? {}),
+    },
+    // Gemini rejects a replayed tool call whose thought signature was dropped,
+    // so it round-trips through the channel the pipeline already forwards.
+    ...(content.signature
+        ? { extra_content: { signature: content.signature } }
+        : {}),
+});
+
+const epochSeconds = (iso?: string): number => {
+    const parsed = iso ? Date.parse(iso) : Number.NaN;
+    return Number.isFinite(parsed)
+        ? Math.floor(parsed / 1000)
+        : Math.floor(Date.now() / 1000);
+};
+
+/**
+ * A terminal status is the upstream telling us it produced nothing usable.
+ * Surfaced as a 4xx/5xx rather than an empty completion so the driver's
+ * fallback loop can route around it instead of serving the caller a blank.
+ */
+const assertUsableStatus = (interaction: Interactions.Interaction): void => {
+    if (interaction.status === 'failed') {
+        throw new HttpError(502, 'Gemini interaction failed', {
+            legacyCode: 'bad_response',
+        });
+    }
+    if (interaction.status === 'cancelled') {
+        throw new HttpError(499, 'Gemini interaction was cancelled', {
+            legacyCode: 'bad_request',
+        });
+    }
+};
+
+export interface IPartitionedOutputs {
+    text: string;
+    reasoning: string;
+    toolCalls: IOpenAIToolCall[];
+    /** Everything chat-completions has no field for: media, search results. */
+    extra: Interactions.Content[];
+    annotations: unknown[];
+}
+
+/** Split `interaction.outputs` into the chat-completions message fields. */
+export const partitionOutputs = (
+    outputs: Interactions.Content[] = [],
+): IPartitionedOutputs => {
+    const partitioned: IPartitionedOutputs = {
+        text: '',
+        reasoning: '',
+        toolCalls: [],
+        extra: [],
+        annotations: [],
+    };
+
+    for (const output of outputs) {
+        switch (output.type) {
+            case 'text':
+                partitioned.text += output.text;
+                if (output.annotations?.length) {
+                    partitioned.annotations.push(...output.annotations);
+                }
+                break;
+            case 'thought':
+                partitioned.reasoning += thoughtText(output);
+                break;
+            case 'function_call':
+                partitioned.toolCalls.push(toToolCall(output));
+                break;
+            default:
+                partitioned.extra.push(output);
+        }
+    }
+
+    return partitioned;
+};
+
+const buildExtraContent = (
+    partitioned: IPartitionedOutputs,
+): Record<string, unknown> | undefined => {
+    const extra: Record<string, unknown> = {};
+    if (partitioned.extra.length) extra.outputs = partitioned.extra;
+    if (partitioned.annotations.length) {
+        extra.annotations = partitioned.annotations;
+    }
+    return Object.keys(extra).length ? extra : undefined;
+};
+
+/** Buffered `Interaction` -> OpenAI `ChatCompletion`. */
+export const interactionToCompletion = (
+    interaction: Interactions.Interaction,
+    { model }: { model: string },
+): IOpenAICompletion => {
+    assertUsableStatus(interaction);
+
+    const partitioned = partitionOutputs(interaction.outputs);
+    const extraContent = buildExtraContent(partitioned);
+
+    const message: IOpenAIMessage = {
+        role: 'assistant',
+        // Null rather than '' when the turn was purely a tool call: the
+        // moderation gate skips null and would otherwise scan an empty string.
+        content:
+            partitioned.text === '' && partitioned.toolCalls.length
+                ? null
+                : partitioned.text,
+        reasoning: partitioned.reasoning || null,
+        refusal: null,
+        ...(partitioned.toolCalls.length
+            ? { tool_calls: partitioned.toolCalls }
+            : {}),
+        ...(extraContent ? { extra_content: extraContent } : {}),
+    };
+
+    const finish_reason = partitioned.toolCalls.length
+        ? 'tool_calls'
+        : interaction.status === 'incomplete'
+          ? 'length'
+          : 'stop';
+
+    return {
+        id: interaction.id,
+        object: 'chat.completion',
+        created: epochSeconds(interaction.created),
+        model: interaction.model ?? model,
+        choices: [{ index: 0, message, finish_reason }],
+        usage: interactionUsageToOpenAI(interaction.usage),
+    };
+};
+
+interface IStreamBlock {
+    type: string;
+    toolCall?: {
+        id: string;
+        name: string;
+        arguments: Record<string, unknown>;
+        signature?: string;
+    };
+}
+
+/**
+ * SSE `InteractionSSEEvent` stream -> OpenAI `ChatCompletion.Chunk` stream.
+ *
+ * Text and thought summaries forward as they arrive. Tool calls are held until
+ * their `content.stop`: the stream handler accumulates arguments per tool-call
+ * index with `addPartialJSON`, so emitting one index twice concatenates two
+ * complete JSON objects into an unparseable buffer. Interactions delivers whole
+ * arguments per delta rather than a partial-JSON drip, so there is nothing to
+ * gain by forwarding early and a broken tool call to lose.
+ */
+export async function* interactionStreamToChunks(
+    events: AsyncIterable<Interactions.InteractionSSEEvent>,
+    { model }: { model: string },
+): AsyncGenerator<IOpenAIChunk> {
+    const blocks = new Map<number, IStreamBlock>();
+    let id = '';
+    let created = Math.floor(Date.now() / 1000);
+    let resolvedModel = model;
+    let toolCallOrdinal = 0;
+
+    const chunk = (
+        delta: IOpenAIChunk['choices'][number]['delta'],
+        finish_reason: string | null = null,
+    ): IOpenAIChunk => ({
+        id,
+        object: 'chat.completion.chunk',
+        created,
+        model: resolvedModel,
+        choices: [{ index: 0, delta, finish_reason }],
+    });
+
+    for await (const event of events) {
+        switch (event.event_type) {
+            case 'interaction.start':
+                id = event.interaction.id;
+                created = epochSeconds(event.interaction.created);
+                resolvedModel = event.interaction.model ?? model;
+                break;
+
+            case 'content.start':
+                blocks.set(event.index, { type: event.content.type });
+                if (event.content.type === 'function_call') {
+                    blocks.set(event.index, {
+                        type: 'function_call',
+                        toolCall: {
+                            id: event.content.id,
+                            name: event.content.name,
+                            arguments: event.content.arguments ?? {},
+                            signature: event.content.signature,
+                        },
+                    });
+                }
+                break;
+
+            case 'content.delta': {
+                const { delta } = event;
+                if (delta.type === 'text') {
+                    yield chunk({ content: delta.text });
+                } else if (delta.type === 'thought_summary') {
+                    const text =
+                        delta.content?.type === 'text'
+                            ? delta.content.text
+                            : '';
+                    if (text) yield chunk({ reasoning: text });
+                } else if (delta.type === 'function_call') {
+                    blocks.set(event.index, {
+                        type: 'function_call',
+                        toolCall: {
+                            id: delta.id,
+                            name: delta.name,
+                            arguments: delta.arguments ?? {},
+                            signature: delta.signature,
+                        },
+                    });
+                } else if (
+                    delta.type === 'image' ||
+                    delta.type === 'video' ||
+                    delta.type === 'audio'
+                ) {
+                    yield chunk({ extra_content: { output: delta } });
+                }
+                break;
+            }
+
+            case 'content.stop': {
+                const block = blocks.get(event.index);
+                blocks.delete(event.index);
+                if (!block?.toolCall) break;
+                yield chunk({
+                    tool_calls: [
+                        {
+                            index: toolCallOrdinal++,
+                            id: block.toolCall.id,
+                            type: 'function',
+                            function: {
+                                name: block.toolCall.name,
+                                arguments: JSON.stringify(
+                                    block.toolCall.arguments,
+                                ),
+                            },
+                            ...(block.toolCall.signature
+                                ? {
+                                      extra_content: {
+                                          signature: block.toolCall.signature,
+                                      },
+                                  }
+                                : {}),
+                        },
+                    ],
+                });
+                break;
+            }
+
+            case 'interaction.complete':
+                assertUsableStatus(event.interaction);
+                // Choices are empty on purpose: the stream handler reads usage
+                // off any chunk and skips ones that carry no choice.
+                yield {
+                    id: event.interaction.id || id,
+                    object: 'chat.completion.chunk',
+                    created,
+                    model: resolvedModel,
+                    choices: [],
+                    usage: interactionUsageToOpenAI(event.interaction.usage),
+                };
+                break;
+
+            case 'error':
+                throw new HttpError(
+                    502,
+                    event.error?.message ?? 'Gemini interaction stream failed',
+                    { legacyCode: 'bad_response' },
+                );
+
+            default:
+                break;
+        }
+    }
+
+    // A stream that ended without a closing `content.stop` still produced a
+    // tool call the caller was billed for; emitting it late beats dropping it.
+    for (const [index, block] of blocks) {
+        if (!block.toolCall) continue;
+        blocks.delete(index);
+        yield chunk({
+            tool_calls: [
+                {
+                    index: toolCallOrdinal++,
+                    id: block.toolCall.id,
+                    type: 'function',
+                    function: {
+                        name: block.toolCall.name,
+                        arguments: JSON.stringify(block.toolCall.arguments),
+                    },
+                },
+            ],
+        });
+    }
+}

--- a/src/backend/drivers/util/interactions/types.ts
+++ b/src/backend/drivers/util/interactions/types.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2024-present Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * The OpenAI chat-completions shapes the Gemini Interactions adapter emits.
+ *
+ * Puter normalises every chat upstream to chat-completions before it reaches
+ * `handle_completion_output`, so an adapter that produces these shapes drops
+ * into the existing pipeline — streaming handler, usage calculator, metering
+ * and moderation included — without any of them learning what Interactions is.
+ * Only the fields that pipeline actually reads are modelled here; this is a
+ * translation target, not a re-declaration of the OpenAI SDK.
+ */
+
+/** A message part as it arrives from Puter's normalised `messages` array. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type OpenAIChatMessage = any;
+
+export interface IOpenAIToolCall {
+    id: string;
+    type: 'function';
+    function: { name: string; arguments: string };
+    /** Non-OpenAI passthrough (thought signatures, grounding). */
+    extra_content?: Record<string, unknown>;
+}
+
+/**
+ * Usage in the OpenAI convention: `completion_tokens` is inclusive of reasoning
+ * tokens, and `prompt_tokens` is inclusive of cached tokens. Callers subtract
+ * the details back out — see `INTERACTIONS_OUTPUT_EXCLUDES_THOUGHTS` in
+ * `response.ts` for why the conversion is not a straight copy.
+ */
+export interface IOpenAIUsage {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+    prompt_tokens_details: { cached_tokens: number };
+    completion_tokens_details: { reasoning_tokens: number };
+    /** Interactions-only: tokens spent inside server-side tools. */
+    tool_use_tokens: number;
+    /** Interactions-only: billable grounding invocations, as a real count. */
+    grounding_requests: number;
+}
+
+export interface IOpenAIMessage {
+    role: 'assistant';
+    content: string | null;
+    reasoning: string | null;
+    refusal: null;
+    tool_calls?: IOpenAIToolCall[];
+    /**
+     * Non-text outputs and provider metadata. Gemini already uses this channel
+     * for grounding, and the streaming handler forwards it verbatim, so
+     * generated images/video/audio ride along without widening `content`.
+     */
+    extra_content?: Record<string, unknown>;
+}
+
+export interface IOpenAIChoice {
+    index: number;
+    message: IOpenAIMessage;
+    finish_reason: string;
+}
+
+export interface IOpenAICompletion {
+    id: string;
+    object: 'chat.completion';
+    created: number;
+    model: string;
+    choices: IOpenAIChoice[];
+    usage: IOpenAIUsage;
+}
+
+export interface IOpenAIChunkDelta {
+    role?: 'assistant';
+    content?: string;
+    reasoning?: string;
+    tool_calls?: Array<IOpenAIToolCall & { index: number }>;
+    extra_content?: Record<string, unknown>;
+}
+
+export interface IOpenAIChunk {
+    id: string;
+    object: 'chat.completion.chunk';
+    created: number;
+    model: string;
+    choices: Array<{
+        index: number;
+        delta: IOpenAIChunkDelta;
+        finish_reason: string | null;
+    }>;
+    usage?: IOpenAIUsage;
+}

--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -17,7 +17,7 @@
     "@aws-sdk/credential-providers": "^3.1021.0",
     "@aws-sdk/lib-dynamodb": "^3.490.0",
     "@aws-sdk/s3-request-presigner": "^3.1028.0",
-    "@google/genai": "^1.19.0",
+    "@google/genai": "^1.52.0",
     "@heyputer/kv.js": "^0.2.1",
     "@heyputer/putility": "^1.0.0",
     "@mistralai/mistralai": "^1.15.1",

--- a/src/docs/src/AI/txt2vid.md
+++ b/src/docs/src/AI/txt2vid.md
@@ -65,6 +65,26 @@ Available when using a Veo model (`veo-2.0-generate-001`, `veo-3.0-generate-001`
 
 For more details, see the [Google Veo API reference](https://ai.google.dev/gemini-api/docs/video).
 
+#### Google (Omni) Options
+
+Available when using `gemini-omni-flash-preview`. Omni chooses its own clip
+length, so `seconds` is ignored; it also takes no `negative_prompt`,
+`last_frame`, `fps`, or `seed`.
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `model` | `String` | Video model to use. Available: `'gemini-omni-flash-preview'` |
+| `size` | `String` | Output dimensions: `'1280x720'` (landscape, default) or `'720x1280'` (portrait). `resolution` is an alias |
+| `input_reference` | `String` | Base64 image used as the first frame (image-to-video) |
+| `reference_images` | `Array<String>` | Base64 images used as style/asset references |
+
+Omni is billed per output token rather than per second — roughly $0.10 for each
+second of 720p video. Because the request cannot cap the clip length, a
+generation is rejected up front unless the account can cover the longest clip
+the model may return.
+
+For more details, see the [Gemini Omni API reference](https://ai.google.dev/gemini-api/docs/omni).
+
 #### TogetherAI Options
 
 Available when using a TogetherAI model:


### PR DESCRIPTION
Adds support for Google's [Interactions API](https://ai.google.dev/gemini-api/docs/interactions-overview) and the [Omni Flash](https://ai.google.dev/gemini-api/docs/omni) video model (PUT-1254).

## Why a translation layer

`/v1beta/interactions` is the single endpoint behind Gemini models, agents, and Omni video. It is not chat-completions shaped, and Omni is reachable through nothing else — there is no `generateVideos` operation to poll.

Rather than teach the drivers a second response path, this adds a seam under `src/backend/drivers/util/interactions/` that speaks Interactions on one side and OpenAI chat-completions on the other:

- **`request.ts`** — messages → turns (system hoisted to `system_instruction`, data URLs split into inline bytes + mime type, tool calls → `function_call`, adjacent same-role turns merged), OpenAI tool declarations → Interactions tools (native ones like `{type:'google_search'}` pass through untouched), sampling knobs → `generation_config`.
- **`response.ts`** — `Interaction` → `ChatCompletion`, and the SSE event stream → `ChatCompletion.Chunk`.

The result is that `handle_completion_output`, `create_chat_stream_handler`, metering, and moderation all run unmodified. It lives in `drivers/util` rather than `ai-chat/utils` because the video driver needs the same translation.

No new dependency: `@google/genai` was already resolving to 1.52.0, which exposes `client.interactions` with SSE streaming. The pin moves `^1.19.0` → `^1.52.0` so a fresh install can't drop below it.

## What's on top

**`GeminiInteractionsChatProvider`** serves the same catalog, same ledger key (`gemini:<id>`), and same default model as the existing OpenAI-compat route.

- Opt-in via its own keyed `gemini-interactions` config block. Registering it automatically put a second first-party route in every Gemini bucket, which displaced `infron` as the fallback and broke two existing routing tests — deployments that never asked for it shouldn't have their fallback order rearranged.
- Sends `store: false`. Puter's chat API is stateless, so there is nothing here for Google to retain for 55 days.
- Refuses a caller-supplied `previous_response_id` with a 400. Interaction ids are scoped to our API key rather than to the caller, so honouring one would let any app pull another user's stored turn into its context. Server-side state needs an ownership record before it can be exposed.

**`GeminiOmniVideoProvider`** generates video through the same endpoint. It auto-registers under the existing `gemini` key — its model id is unique, so it forms its own bucket and can't disturb Veo routing.

- Omni takes no duration parameter, so there is no clip length to clamp to remaining credit the way `capSecondsToRemainingCredits` does for Veo. It gates on the worst-case clip (~$0.81) up front and meters the tokens actually billed, defaulting an output with no modality breakdown to the video rate rather than the cheap one.
- `store` has to be `true` here — retrieving a long-running generation requires Google to have stored it — so the interaction is deleted once its output is collected.

## Drive-by fix worth a real look

`create_chat_stream_handler` ended only the tool block the last chunk happened to touch, so a completion with parallel tool calls emitted one and silently dropped the rest — after the caller had already been billed for all of them. This affects **every** provider, not just Gemini. Regression test added; verified failing before the fix.

## One assumption that needs a live check

`INTERACTIONS_OUTPUT_EXCLUDES_THOUGHTS` encodes whether `total_output_tokens` counts thought tokens separately. Google's docs don't say, and every calculator downstream subtracts reasoning back out of `completion_tokens`, so getting it wrong is a silent billing error in one direction or the other. It's one named constant with an integration test that settles it against a real thinking response — run that with `PUTER_TEST_AI_GEMINI_API_KEY` set before relying on the metering.

## Testing

61 new tests. The streaming tests run translated chunks through the real `create_chat_stream_handler` rather than asserting on chunk shapes, since "the existing pipeline can't tell the difference" is the actual claim being made.

- Full backend suite: **4 of 5 runs green** (6189 passed).
- One run showed 6 failures in `MeteringService.test.ts` — a file this branch does not touch, running in an isolated fork that never imports the new code. Not reproducible in 4 subsequent full-suite runs, under CPU saturation, or when run alongside the new test files. `origin/main` is 3/3 green. The failing assertions are on a process-global credit cache, which reads as a latent flake in that file rather than anything here, but flagging it rather than calling it clean.
- `npm run typecheck`, `npm run build:ts`, eslint, and prettier all clean. No formatting churn in the diff — the only removed lines are the `OpenAIUtil.js` fix and the version pin.

Config template and `src/docs/src/AI/txt2vid.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
