### PR TITLE
docs: fix typo in Serverless Workers description

### DIFF
--- a/src/docs/src/Workers.md
+++ b/src/docs/src/Workers.md
@@ -1,6 +1,6 @@
 ---
 title: Serverless Workers
-description: Run and manage serverless JavaScript funcitons in the cloud.
+description: Run and manage serverless JavaScript functions in the cloud.
 ---
 
 Serverless Workers are serverless functions that run JavaScript code in the cloud.


### PR DESCRIPTION
Fixes a typo in the Serverless Workers page metadata: "funcitons" -> "functions". The description is used in search and link previews, so the misspelling is user-visible. Verified the string is the only occurrence in the docs tree; frontmatter is otherwise unchanged.