### PR TITLE
Let a browser send the device fingerprint header it is offered

### DIFF
--- a/src/backend/server.test.ts
+++ b/src/backend/server.test.ts
@@ -272,6 +272,29 @@ describe('PuterServer host header validation', () => {
         );
     });
 
+    it('lets a cross-origin preflight ask for the device fingerprint header', async () => {
+        // `fingerprint.ts` reads the device fingerprint off
+        // `x-puter-device-fingerprint` for authenticated requests with no body
+        // to carry it. That channel only exists if the preflight admits the
+        // header: a browser abandons the request otherwise, and the call never
+        // leaves it.
+        const res = await request(
+            '/healthcheck',
+            {
+                host: `api.puter.localhost:${port}`,
+                origin: 'http://puter.localhost',
+                'access-control-request-method': 'GET',
+                'access-control-request-headers':
+                    'authorization,x-puter-device-fingerprint',
+            },
+            'OPTIONS',
+        );
+        expect(res.status).toBe(200);
+        expect(
+            String(res.headers['access-control-allow-headers']).toLowerCase(),
+        ).toContain('x-puter-device-fingerprint');
+    });
+
     it('still short-circuits OPTIONS preflight off the dav subdomain', async () => {
         const res = await request(
             '/some-path',

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -685,6 +685,12 @@ export class PuterServer {
             'X-Expected-Entity-Length',
             'DAV',
             'stripe-signature',
+            // The GUI's fallback channel for the device fingerprint on
+            // authenticated requests that have no body to carry it (see
+            // core/http/middleware/fingerprint.ts). Without it here the
+            // preflight refuses the header and the request never leaves the
+            // browser.
+            'x-puter-device-fingerprint',
         ].join(', ');
 
         // What a browser DAV client is allowed to read back off a response.


### PR DESCRIPTION
## The bug

`core/http/middleware/fingerprint.ts` reads the device fingerprint from
the request body, falling back to `x-puter-device-fingerprint` for
authenticated requests that have no body to carry it. The comment there
calls it "the header the GUI may send the device fingerprint on for
non-signup requests", and `readDeviceFingerprint` has always honoured
it.

No browser can send it. `#installCors` in `server.ts` builds a fixed
`Access-Control-Allow-Headers` list that omits it, so a cross-origin
preflight replies without it and the browser abandons the request. The
call never leaves the client, and `fetch` rejects with an opaque network
error rather than a status you can act on.

Reproducible against a dev server before this change:

```
$ curl -i -X OPTIONS http://api.puter.localhost:5101/healthcheck \
    -H 'Origin: http://puter.localhost:5101' \
    -H 'Access-Control-Request-Method: GET' \
    -H 'Access-Control-Request-Headers: authorization,x-puter-device-fingerprint'

Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept,
  Authorization, Cache-Control, Pragma, sentry-trace, baggage, Depth,
  Destination, Overwrite, If, Lock-Token, DAV, stripe-signature
```

The requested header is absent, so the preflight is a refusal even
though it answers 200.

## Why it went unnoticed

Nothing in tree sends the header. Every current caller puts the
fingerprint in the body, which `Content-Type` already covers. The header
path is server-side support with no client, so the first client to use
it is the one that discovers the omission — in my case as an extension
whose every API call failed with `status: 0` and no server-side trace at
all.

## The change

One entry added to the allowlist, plus a preflight test in
`server.test.ts` asserting a browser may ask for the header. The test
fails before the fix and passes after:

```
× lets a cross-origin preflight ask for the device fingerprint header
  Tests  1 failed | 22 passed (23)      # without the fix
  Tests  23 passed (23)                 # with it
```

No behaviour changes for any existing caller: this widens what a
preflight will admit and touches nothing else. The value is still
shape-checked by `DEVICE_FINGERPRINT_SHAPE` before anything downstream
trusts it, exactly as before, so allowing the header does not allow any
new value through.