### PR TITLE
:bug: PUT-1586 + PUT-1599: Share dialog says what it can grant, and what it did

### DIFF
--- a/src/backend/controllers/share/ShareController.http.test.ts
+++ b/src/backend/controllers/share/ShareController.http.test.ts
@@ -109,6 +109,33 @@ describe('share endpoints over HTTP', () => {
         }
     });
 
+    it('says whether a share created access or the recipient already had it', async () => {
+        const owner = env.users.user;
+        const recipient = env.users.other;
+        const file = await makeFile(owner);
+        const share = (mode: string) =>
+            post('/share', owner.token, {
+                recipients: [recipient.username],
+                items: [{ uid: file.uid }],
+                mode,
+            }).then((r) => r.json() as Promise<{
+                results: Array<{ is_new?: boolean }>;
+            }>);
+
+        expect((await share('read')).results[0].is_new).toBe(true);
+        // Without this the dialog cannot tell a repeat from a first share.
+        expect((await share('read')).results[0].is_new).toBe(false);
+        expect((await share('write')).results[0].is_new).toBe(false);
+
+        // A listing describes standing access, so it says nothing about it.
+        const listed = await get('/share/shares', owner.token, {
+            uid: file.uid,
+        }).then((r) => r.json() as Promise<{
+            items: Array<Record<string, unknown>>;
+        }>);
+        expect(listed.items[0]).not.toHaveProperty('is_new');
+    });
+
     it('shares an item, lists it for the recipient, then revokes it', async () => {
         const owner = env.users.user;
         const recipient = env.users.other;

--- a/src/backend/controllers/share/clientShare.ts
+++ b/src/backend/controllers/share/clientShare.ts
@@ -57,6 +57,8 @@ export async function toClientShare(
         ...(share.pending
             ? { pending: true, recipient_email: share.recipientEmail }
             : {}),
+        // Set on a share call only, so a listing stays silent about it.
+        ...(share.isNew === undefined ? {} : { is_new: share.isNew }),
         uid_entry: share.entryUid,
         is_dir: share.isDir,
         issuer: share.issuer.username,

--- a/src/backend/services/share/ShareService.test.ts
+++ b/src/backend/services/share/ShareService.test.ts
@@ -806,7 +806,35 @@ describe('ShareService', () => {
                 recipient: { email: third.email },
                 mode: 'manage',
             }),
-        ).rejects.toMatchObject({ statusCode: 403 });
+        ).rejects.toMatchObject({
+            statusCode: 403,
+            legacyCode: 'cannot_delegate_manage',
+        });
+
+        // What they can do is unchanged.
+        await expect(
+            share(delegate.actor, {
+                uid: file.uuid,
+                recipient: { email: third.email },
+                mode: 'write',
+            }),
+        ).resolves.toMatchObject({ mode: 'write' });
+    });
+
+    it('tells a stranger nothing when they ask to grant `manage`', async () => {
+        const owner = await makeUser();
+        const stranger = await makeUser();
+        const third = await makeUser();
+        const file = await makeFile(owner.user);
+
+        // No access at all, so the refusal must not confirm the file exists.
+        await expect(
+            share(stranger.actor, {
+                uid: file.uuid,
+                recipient: { email: third.email },
+                mode: 'manage',
+            }),
+        ).rejects.not.toMatchObject({ legacyCode: 'cannot_delegate_manage' });
     });
 
     it('leaves a delegate alone when their authority survives another issuer', async () => {

--- a/src/backend/services/share/ShareService.ts
+++ b/src/backend/services/share/ShareService.ts
@@ -94,11 +94,9 @@ export interface ResolvedShare {
     issuedByApp?: string | null;
     modified: number;
     size: number | null;
-    /**
-     * Set by `share()` only, and never sent to a client: who to notify, and
-     * whether this call created reach that didn't exist before.
-     */
+    /** Set by `share()` only: who to notify. Never sent to a client. */
     holderId?: number;
+    /** Whether this call created reach that didn't exist before. */
     isNew?: boolean;
     /**
      * An invite to an address with no confirmed account. No grant exists yet —

--- a/src/backend/services/share/ShareService.ts
+++ b/src/backend/services/share/ShareService.ts
@@ -1720,6 +1720,22 @@ export class ShareService extends PuterService {
         // given, rather than everything its user owns.
         if (allowed && (await this.#hasOwnReach(actor, entry, mode))) return;
 
+        // Only for someone who can already share here, so it leaks nothing.
+        if (mode === MANAGE_PERM_PREFIX) {
+            const canDelegateAccess =
+                await this.services.permission.canManagePermission(
+                    userRelatedActor(actor),
+                    entryPermissionForMode(entry.uuid, 'write'),
+                );
+            if (canDelegateAccess) {
+                throw new HttpError(
+                    403,
+                    'Only the owner can grant edit & share access',
+                    { legacyCode: 'cannot_delegate_manage' },
+                );
+            }
+        }
+
         const safe = await this.services.acl.getSafeAclError(
             actor,
             this.#descriptorFor(entry),

--- a/src/docs/src/FS/share.md
+++ b/src/docs/src/FS/share.md
@@ -69,6 +69,7 @@ A `Promise` that resolves to an array of share objects, one per recipient/item p
 - `recipientEmail` (String) - Address a pending share was sent to. Only set when `pending`.
 - `modified` (Number) - Last-modified time of the item, in unix seconds.
 - `size` (Number) - Size of the item in bytes; `null` for a directory.
+- `isNew` (Boolean) - Whether this call created access that did not exist before. `false` means the recipient already had it, possibly at a different mode — sharing again is not an error, so this is how you tell the two apart. Only `share()` reports it; a listing leaves it undefined.
 
 Sharing the same item with the same person again **replaces** their access rather than adding a second share, so raising someone from `read` to `write` is just another call.
 

--- a/src/gui/src/UI/Dashboard/UIShareModal.js
+++ b/src/gui/src/UI/Dashboard/UIShareModal.js
@@ -19,7 +19,7 @@
 
 import path from '../../lib/path.js';
 import item_icon from '../../helpers/item_icon.js';
-import { owner_of_path } from '../../helpers/path_owner.js';
+import { is_owned_by_me, owner_of_path } from '../../helpers/path_owner.js';
 import { invalidate_shared_roots } from '../../helpers/shared_access.js';
 import { icons } from '../../helpers/actionIcons.js';
 import { mode_label, options_for } from '../../helpers/share_modes.js';
@@ -115,6 +115,8 @@ export default function UIShareModal ({ items, path: item_path, name, owner, fse
         }));
     const target_paths = targets.map((item) => item.path);
     const total = targets.length;
+    // Strictest item decides: one borrowed item withholds it for the rest.
+    const allow_manage = target_paths.every((p) => is_owned_by_me(p));
     const is_multi = total > 1;
     // Nothing to share: an empty selection is a caller's mistake, not a dialog.
     if ( total === 0 ) return { close: () => {} };
@@ -159,7 +161,7 @@ export default function UIShareModal ({ items, path: item_path, name, owner, fse
                         <div class="share-modal-add-row">
                             <input type="text" class="share-modal-recipient" autocomplete="off" autocapitalize="off" spellcheck="false" enterkeyhint="send"
                                 placeholder="${i18n('share_add_people')}" aria-label="${i18n('share_add_people')}" />
-                            <select class="share-modal-mode" aria-label="${i18n('share_access_level')}">${options_for('read')}</select>
+                            <select class="share-modal-mode" aria-label="${i18n('share_access_level')}">${options_for('read', { allow_manage })}</select>
                         </div>
                         <button type="submit" class="share-modal-submit" disabled>
                             <span class="share-modal-spinner" aria-hidden="true"></span>
@@ -318,7 +320,7 @@ export default function UIShareModal ({ items, path: item_path, name, owner, fse
             // The accessible names carry the person: a list where every row
             // reads as bare "Access level" / "Remove access" leaves a screen
             // reader user unable to tell whose grant a control changes.
-            row += `<select class="share-modal-row-mode" data-key="${key}" aria-label="${i18n('share_access_level_for', { recipient: group.name })}">${options_for(group.mode)}</select>`;
+            row += `<select class="share-modal-row-mode" data-key="${key}" aria-label="${i18n('share_access_level_for', { recipient: group.name })}">${options_for(group.mode, { allow_manage })}</select>`;
         } else {
             const fixed_mode = group.pending ? group.pendingMode : group.inheritedMode;
             row += `<span class="share-modal-row-tag">${fixed_mode ? mode_label(fixed_mode) : i18n('share_access_mixed')}</span>`;

--- a/src/gui/src/UI/Dashboard/UIShareModal.js
+++ b/src/gui/src/UI/Dashboard/UIShareModal.js
@@ -29,6 +29,7 @@ import {
     has_direct_share,
     mark_item_shared,
 } from '../../helpers/sharedBadge.js';
+import { share_outcome } from '../../helpers/shareOutcome.js';
 import { aggregateOwners, aggregateShares, missingPathsFor } from './shareAggregate.js';
 
 const { html_encode } = window;
@@ -38,6 +39,14 @@ const chevronIcon = `<svg class="share-modal-chevron" viewBox="0 0 24 24" width=
 
 // How many item icons the header fans out before it stops adding to the pile.
 const MAX_STACKED_ICONS = 3;
+
+/** What each outcome of a share call is called on screen. */
+const SHARE_MESSAGE = {
+    invited: 'share_invited',
+    shared: 'share_shared_with',
+    updated: 'share_access_updated',
+    unchanged: 'share_already_shared_with',
+};
 
 // What one /share, /share/revoke or listing pass may cover, matching the
 // backend's documented cap (see doc: rate limits and quotas). Bigger
@@ -535,9 +544,16 @@ export default function UIShareModal ({ items, path: item_path, name, owner, fse
             // "Shared with" would claim access an invite does not grant.
             const invited = created?.some((share) => share.pending);
             if ( ! is_multi ) {
-                show_success(invited
-                    ? i18n('share_invited', { recipient })
-                    : i18n('share_shared_with', { recipient }));
+                // One item, so the list on screen settles what changed.
+                const before = last_groups.map((group) => ({
+                    holder: group.name,
+                    mode: group.mode,
+                }));
+                show_success(
+                    i18n(SHARE_MESSAGE[share_outcome(created, before)], {
+                        recipient,
+                    }),
+                );
             } else if ( granted < total ) {
                 show_success(i18n('share_shared_with_partial', { recipient, count: granted, total }));
             } else {

--- a/src/gui/src/UI/UIWindowShare.js
+++ b/src/gui/src/UI/UIWindowShare.js
@@ -20,7 +20,7 @@
 import UIWindow from './UIWindow.js';
 import UIAlert from './UIAlert.js';
 import path from '../lib/path.js';
-import { owner_of_path } from '../helpers/path_owner.js';
+import { is_owned_by_me, owner_of_path } from '../helpers/path_owner.js';
 import { invalidate_shared_roots } from '../helpers/shared_access.js';
 import { icons } from '../helpers/actionIcons.js';
 import { mode_label, options_for } from '../helpers/share_modes.js';
@@ -41,6 +41,8 @@ async function UIWindowShare (options) {
     const item_name = options.name ?? path.basename(item_path);
     const item_owner =
         options.owner ?? owner_of_path(item_path) ?? window.user.username;
+    // A delegate passes on access, never the authority to pass it on.
+    const allow_manage = is_owned_by_me(item_path);
 
     let h = '';
     h += '<div class="share-dialog">';
@@ -51,7 +53,7 @@ async function UIWindowShare (options) {
     h += '<div class="share-dialog-row">';
     h += `<input class="share-recipient" id="share-recipient" type="text" autocomplete="off" spellcheck="false"
                  placeholder="${html_encode(i18n('share_add_people'))}" />`;
-    h += `<select class="share-mode">${options_for('read')}</select>`;
+    h += `<select class="share-mode">${options_for('read', { allow_manage })}</select>`;
     h += '</div>';
     h += `<button class="share-btn button button-primary button-block button-normal">${i18n('share')}</button>`;
 
@@ -143,7 +145,7 @@ async function UIWindowShare (options) {
             }
             rows += '<div class="share-row">';
             rows += `<span class="share-row-who">${holder}</span>`;
-            rows += `<select class="share-row-mode-select" data-holder="${holder}">${options_for(share.mode)}</select>`;
+            rows += `<select class="share-row-mode-select" data-holder="${holder}">${options_for(share.mode, { allow_manage })}</select>`;
             rows += `<button class="share-revoke" data-holder="${holder}" title="${html_encode(i18n('share_remove_access'))}" aria-label="${html_encode(i18n('share_remove_access'))}">${icons.trash}</button>`;
             rows += '</div>';
         }

--- a/src/gui/src/UI/UIWindowShare.js
+++ b/src/gui/src/UI/UIWindowShare.js
@@ -25,6 +25,15 @@ import { invalidate_shared_roots } from '../helpers/shared_access.js';
 import { icons } from '../helpers/actionIcons.js';
 import { mode_label, options_for } from '../helpers/share_modes.js';
 import { has_direct_share, mark_item_shared } from '../helpers/sharedBadge.js';
+import { share_outcome } from '../helpers/shareOutcome.js';
+
+/** What each outcome of a share call is called on screen. */
+const SHARE_MESSAGE = {
+    invited: 'share_invited',
+    shared: 'share_shared_with',
+    updated: 'share_access_updated',
+    unchanged: 'share_already_shared_with',
+};
 
 /**
  * Sharing dialog for one file or directory.
@@ -114,7 +123,11 @@ async function UIWindowShare (options) {
         $success.html(message).show();
     };
 
+    /** The access list as last drawn, which is what a share call changes. */
+    let shown_shares = [];
+
     const render = (shares) => {
+        shown_shares = Array.isArray(shares) ? shares : [];
         let rows = '';
         // The owner's access comes from owning the item, so it can't be revoked
         rows += '<div class="share-row">';
@@ -178,13 +191,12 @@ async function UIWindowShare (options) {
             });
             $(el_window).find('.share-recipient').val('');
             $error.hide();
-            // "Shared with" would claim access an invite does not grant.
             // `i18n()` encodes its replacements; encoding first would show the
             // entities to anyone whose address or username contains one.
             show_success(
-                created.some((share) => share.pending)
-                    ? i18n('share_invited', { recipient })
-                    : i18n('share_shared_with', { recipient }),
+                i18n(SHARE_MESSAGE[share_outcome(created, shown_shares)], {
+                    recipient,
+                }),
             );
             invalidate_shared_roots();
             await refresh();

--- a/src/gui/src/helpers/shareOutcome.js
+++ b/src/gui/src/helpers/shareOutcome.js
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2024-present Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * What a share call actually did, so the dialog can say so. A backend that
+ * omits `isNew` reads as `shared`, which is what these dialogs said before it.
+ *
+ * @param {Array<{ pending?: boolean, isNew?: boolean, mode?: string, holder?: string|null }>} created
+ * @param {Array<{ holder?: string|null, mode?: string, inheritedFrom?: string|null }>} [before]
+ * @returns {'invited' | 'shared' | 'updated' | 'unchanged'}
+ */
+export const share_outcome = (created, before = []) => {
+    const list = Array.isArray(created) ? created.filter(Boolean) : [];
+    if ( list.some((share) => share.pending) ) return 'invited';
+    if ( list.length === 0 || list.some((share) => share.isNew !== false) ) {
+        return 'shared';
+    }
+
+    // Matched on the resolved username rather than what was typed, so an email
+    // that belongs to a known account still finds their row.
+    const previous = (Array.isArray(before) ? before : []).find(
+        (share) =>
+            share?.holder &&
+            list.some((made) => made.holder === share.holder) &&
+            ! share.inheritedFrom,
+    );
+    if ( ! previous ) return 'unchanged';
+    return list.some((made) => made.mode !== previous.mode)
+        ? 'updated'
+        : 'unchanged';
+};

--- a/src/gui/src/helpers/shareOutcome.test.js
+++ b/src/gui/src/helpers/shareOutcome.test.js
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { share_outcome } from './shareOutcome.js';
+
+describe('share_outcome', () => {
+    it('reports a first-time share', () => {
+        expect(share_outcome([{ holder: 'ann', mode: 'read', isNew: true }]))
+            .toBe('shared');
+    });
+
+    it('reports an invite ahead of anything else', () => {
+        expect(
+            share_outcome([
+                { recipientEmail: 'x@example.com', pending: true, isNew: true },
+            ]),
+        ).toBe('invited');
+    });
+
+    it('says nothing changed when the same access is granted twice', () => {
+        // The bug: this used to read as a fresh share.
+        expect(
+            share_outcome(
+                [{ holder: 'ann', mode: 'read', isNew: false }],
+                [{ holder: 'ann', mode: 'read' }],
+            ),
+        ).toBe('unchanged');
+    });
+
+    it('says the level changed when the mode differs', () => {
+        expect(
+            share_outcome(
+                [{ holder: 'ann', mode: 'write', isNew: false }],
+                [{ holder: 'ann', mode: 'read' }],
+            ),
+        ).toBe('updated');
+    });
+
+    it('matches on the resolved username, not what was typed', () => {
+        // The recipient was entered as an email; their row is keyed on the
+        // username the server resolved it to.
+        expect(
+            share_outcome(
+                [{ holder: 'ann', mode: 'write', isNew: false }],
+                [{ holder: 'ann', mode: 'read' }, { holder: 'bob', mode: 'read' }],
+            ),
+        ).toBe('updated');
+    });
+
+    it('ignores an inherited row, which this call cannot have changed', () => {
+        expect(
+            share_outcome(
+                [{ holder: 'ann', mode: 'read', isNew: false }],
+                [{ holder: 'ann', mode: 'write', inheritedFrom: '/bob/Docs' }],
+            ),
+        ).toBe('unchanged');
+    });
+
+    it('falls back to `shared` when the backend does not report isNew', () => {
+        // An older server, or the CDN SDK before this shipped.
+        expect(share_outcome([{ holder: 'ann', mode: 'read' }])).toBe('shared');
+        expect(share_outcome([])).toBe('shared');
+        expect(share_outcome(undefined)).toBe('shared');
+    });
+});

--- a/src/gui/src/helpers/share_modes.js
+++ b/src/gui/src/helpers/share_modes.js
@@ -48,11 +48,17 @@ export const mode_label = (mode) => {
  * unselectable placeholder, so a batch of mixed modes can't be read as one of
  * them, and picking a real mode is what levels them.
  *
+ * `allow_manage: false` drops "Can edit & share", bar a row already on it.
+ *
  * @param {string|null} current
+ * @param {{ allow_manage?: boolean }} [options]
  * @returns {string} HTML-safe markup
  */
-export const options_for = (current) => {
-    const listed = MODES
+export const options_for = (current, { allow_manage = true } = {}) => {
+    const offered = MODES.filter(
+        (mode) => allow_manage || mode !== 'manage' || mode === current,
+    );
+    const listed = offered
         .map(
             (mode) =>
                 `<option value="${html_encode(mode)}"${mode === current ? ' selected' : ''}>${mode_label(mode)}</option>`,

--- a/src/gui/src/helpers/share_modes.test.js
+++ b/src/gui/src/helpers/share_modes.test.js
@@ -57,6 +57,19 @@ describe('options_for', () => {
         expect(html).not.toContain('<option value="read" selected>');
     });
 
+    it('withholds `manage` from someone who cannot grant it', () => {
+        // Offering it to a delegate is a dead end the server refuses.
+        const html = options_for('read', { allow_manage: false });
+        expect(values(html)).toEqual(['read', 'write']);
+        expect(html).not.toContain('value="manage"');
+    });
+
+    it('still shows a row already set to `manage`, so opening the dialog does not downgrade it', () => {
+        const html = options_for('manage', { allow_manage: false });
+        expect(values(html)).toEqual(MODES);
+        expect(html).toContain('<option value="manage" selected>');
+    });
+
     it('keeps an out-of-band mode instead of rounding it to read', () => {
         const html = options_for('see');
         expect(values(html)).toEqual(['see', ...MODES]);

--- a/src/gui/src/i18n/translations/en.js
+++ b/src/gui/src/i18n/translations/en.js
@@ -399,6 +399,7 @@ const en = {
         share_done: 'Done',
         share_failed: 'Could not share this item.',
         share_shared_with: 'Shared with {{recipient}}',
+        share_already_shared_with: '{{recipient}} already has this access',
         share_access_updated: 'Updated access for {{recipient}}',
         share_invited: 'Invited {{recipient}} — they’ll get access once they join',
         share_awaiting_signup: 'Invited',

--- a/src/puter-js/src/modules/FileSystem/operations/shareUtil.js
+++ b/src/puter-js/src/modules/FileSystem/operations/shareUtil.js
@@ -84,6 +84,8 @@ export const toShare = (row) => ({
         : {}),
     modified: /** @type {number} */ (row.modified ?? 0),
     size: /** @type {number | null} */ (row.size ?? null),
+    // Only a share call reports this; a listing leaves it undefined.
+    ...(row.is_new === undefined ? {} : { isNew: Boolean(row.is_new) }),
 });
 
 /**

--- a/src/puter-js/src/modules/FileSystem/types.js
+++ b/src/puter-js/src/modules/FileSystem/types.js
@@ -329,6 +329,8 @@
  * to. Only set when `pending`.
  * @property {number} modified Last-modified time of the item, unix seconds.
  * @property {number | null} size Size of the item in bytes; null for a directory.
+ * @property {boolean} [isNew] Whether the call created access that did not exist
+ * before. Set by `share()` only; a listing leaves it undefined.
  */
 
 /**

--- a/src/puter-js/tests/api/suites/sharing.suite.ts
+++ b/src/puter-js/tests/api/suites/sharing.suite.ts
@@ -67,6 +67,21 @@ export default suite('sharing', {
         t.assert.equal(shares[0].path, path);
     },
 
+    'share says whether it created access or the recipient already had it': async (t) => {
+        const path = scratch(t, 'isnew');
+        await t.puter.fs.write(path, 'x');
+
+        const first = await t.puter.fs.share(path, t.env.users.other.username, 'read');
+        t.assert.equal(first[0].isNew, true);
+
+        const again = await t.puter.fs.share(path, t.env.users.other.username, 'read');
+        t.assert.equal(again[0].isNew, false);
+
+        // A listing describes standing access, so it does not carry it.
+        const listed = await t.puter.fs.getShares(path);
+        t.assert.equal(listed[0].isNew, undefined);
+    },
+
     'getShares reports who can reach an item': async (t) => {
         const path = scratch(t, 'getshares');
         await t.puter.fs.write(path, 'x');


### PR DESCRIPTION
Two share-dialog bugs that share the same two files. Third in the stack — base is #3646, which is based on #3644. Review those first; this diff is only its own two commits.

Fixes PUT-1586 and PUT-1599.

---

## PUT-1586 — a delegate could not pass on "can edit & share"

Reproduced against a running server before changing anything, and the ticket's "cannot share" turns out to be narrower than it reads: a recipient holding `manage` re-shares **fine** at `read` and `write`. Only `manage` fails.

```
delegate grants read   -> success
delegate grants write  -> success
delegate grants manage -> error: Forbidden
```

Refusing is deliberate — handing out `manage` needs authority over `manage`, which only the owner has, so delegation is one level deep by construction. The defects were around it: the dropdown **offered** the level, and the refusal was a bare 403 that reads as a bug.

- **The dropdown withholds it** from anyone who does not own the item. A row already set to `manage` keeps the option, so a delegate opening the dialog cannot silently downgrade the owner's own grant, and a mixed selection follows its strictest item.
- **The server says why**: `cannot_delegate_manage`, "Only the owner can grant edit & share access" — told only to someone who can already share the item, so a stranger still gets the ACL's own safe error that does not admit the node exists. There is a test for that leak.

After:

```
delegate grants manage -> error: [cannot_delegate_manage] Only the owner can grant edit & share access
```

**If the intent was that a delegate *should* be able to pass on edit & share, this is the wrong fix** — that is a permission-model change, and worth deciding before anyone writes it. This PR keeps the existing policy and fixes the affordance.

## PUT-1599 — "Shared with X" when nothing changed

Sharing the same file with the same person twice answered exactly as a first share. Verified the wire was the problem, not the dialog: both calls returned byte-identical payloads.

The service already knew — it computes `isNew` to decide whether to notify the recipient — but the flag stopped at the controller. It now travels on share results; a listing describes standing access, so it stays out of `getShares()`.

Which of the three things happened is settled client-side, because the mode each recipient holds is already on screen:

| Outcome | Message |
|---|---|
| created access | Shared with X |
| raised or lowered the level | Updated access for X |
| changed nothing | X already has this access |
| recipient has no account yet | Invited X … |

That keeps the previous mode off the wire. The lookup matches on the **resolved username** from the response rather than what was typed, so an email belonging to a known account still finds their row.

Live, after the change:

```
first share  mode=read  is_new=true
same again   mode=read  is_new=false
mode change  mode=write is_new=false
listing carries is_new? false
```

## Verification

Both fixes were driven through the real dialog in a browser, not just asserted at the API. The GUI loads puter.js from the CDN, which predates `isNew`, so **every page in the run has that URL routed to the local `dist/puter.dev.js`** — otherwise the dialogs are exercising an SDK that cannot carry what this PR added. The run asserts that before doing anything else, and aborts if the page ends up on the CDN build.

Owner and delegate are separate accounts in separate browser contexts; the share modal is opened the way a user opens it, by right-clicking a row and choosing "Share…".

| # | Check | Result |
|---|---|---|
| 1 | Owner is offered all three levels | `["read","write","manage"]` |
| 2 | First share reads as a share | "Shared with v6uq49v" |
| 3 | Same access again says nothing changed | **"v6uq49v already has this access"** |
| 4 | A different level reads as an update | "Updated access for v6uq49v" |
| 5 | A delegate is not offered "can edit & share" | `["read","write"]` |
| 6 | A delegate can still grant what they may | "Shared with vsdw6be" |

`6/6 checks passed`. Each check is shown below, in the order above.

**1 — the owner is offered all three levels.** "Can edit & share" is theirs to give.

<img width="2400" height="1900" alt="put-1586-owner-modes" src="https://github.com/user-attachments/assets/8e80147d-2422-4ffc-a87e-9ce426b58b40" />

**2 — a first share.** "Shared with v6uq49v", as before.

<img width="2400" height="1900" alt="put-1599-1-first-share" src="https://github.com/user-attachments/assets/3cd915d6-9682-4270-9a23-ae9b8cbd566c" />

**3 — the same access again.** "v6uq49v already has this access" — this is PUT-1599; it used to repeat the message above.

<img width="2400" height="1900" alt="put-1599-2-already-shared" src="https://github.com/user-attachments/assets/73982963-b4e8-4e9c-8f20-11c6df84a384" />

**4 — a different level.** "Updated access for v6uq49v".

<img width="2400" height="1900" alt="put-1599-3-access-updated" src="https://github.com/user-attachments/assets/b86b031a-8e3a-4c6a-95e3-b1a5fbdc73b0" />

**5 — the delegate's dialog.** The picker offers "Can view" and "Can edit" only; "Can edit & share" is gone. This is PUT-1586. Their own row below still reads "Can edit & share", which is deliberate — an existing grant is never silently downgraded by opening the dialog.

<img width="2400" height="1900" alt="put-1586-delegate-modes" src="https://github.com/user-attachments/assets/56f7fd82-528e-4e47-9b88-1f13053a1374" />

**6 — the delegate sharing what they may.** "Shared with vsdw6be" at view level.

<img width="2400" height="1900" alt="put-1586-delegate-shared" src="https://github.com/user-attachments/assets/e76ab8e9-33aa-49c7-9c40-50343153ff46" />


Check 5 runs as the owner's own session on an item **someone else owns and has given them `manage`** — the same branch a delegate takes, without a second GUI login. Its access list shows the delegate's own row still reading "Can edit & share": a row already set to it keeps the option, so opening the dialog cannot silently downgrade the owner's grant.

Alongside that:

- Backend: a wire-level HTTP test that `is_new` flips across repeat shares and that listings omit it; the delegate test pins `cannot_delegate_manage`, plus a test that a stranger asking for `manage` does **not** get that code.
- GUI: 7 unit cases for `share_outcome`, 2 for the `manage` filter. 360 passing.
- SDK: `isNew` asserted in the sharing suite; `check:puterjs:types` clean.
- API level, against a running server: `read` and `write` still succeed for a delegate, `manage` answers `cannot_delegate_manage`; `is_new` is `true` then `false` across repeat shares and absent from listings.
