### PR TITLE
:wrench: PUT-1619: Publishing a directory takes ownership, not write

### DIFF
--- a/src/backend/drivers/subdomain/SubdomainDriver.test.ts
+++ b/src/backend/drivers/subdomain/SubdomainDriver.test.ts
@@ -545,6 +545,112 @@ describe('SubdomainDriver.update', () => {
     });
 });
 
+// ── publishing someone else's directory ─────────────────────────────
+//
+// Hosting serves the root dir with the ACL bypassed, so pointing a subdomain
+// at a directory publishes it. A `write` share does not carry that decision:
+// the row would live under the recipient's account, cover files the owner adds
+// later, and show up in nothing the owner can list.
+
+const shareDir = async (
+    owner: { actor: Actor },
+    holder: { actor: Actor },
+    path: string,
+    mode: 'read' | 'write' | 'manage',
+): Promise<void> => {
+    const entry = (await server.stores.fsEntry.getEntryByPath(path))!;
+    await server.services.acl.setUserUser(
+        owner.actor,
+        holder.actor,
+        {
+            path: entry.path,
+            resolveAncestors: () =>
+                server.services.fs.getAncestorChain(entry.path),
+        },
+        mode,
+    );
+};
+
+describe('SubdomainDriver root_dir publishing rights', () => {
+    it('refuses a directory shared with the actor at write', async () => {
+        const owner = await makeUser();
+        const writer = await makeUser();
+        const shared = `/${owner.actor.user!.username}/Documents`;
+        await shareDir(owner, writer, shared, 'write');
+
+        await expect(
+            withActor(writer.actor, () =>
+                driver.create({
+                    object: {
+                        subdomain: uniqueSubdomain('borrowed'),
+                        root_dir: shared,
+                    },
+                }),
+            ),
+        ).rejects.toMatchObject({ statusCode: 403 });
+    });
+
+    // "Can edit & share" is the owner delegating the decision.
+    it('accepts a directory shared with the actor at manage', async () => {
+        const owner = await makeUser();
+        const manager = await makeUser();
+        const shared = `/${owner.actor.user!.username}/Documents`;
+        await shareDir(owner, manager, shared, 'manage');
+        const sub = uniqueSubdomain('delegated');
+
+        const created = (await withActor(manager.actor, () =>
+            driver.create({
+                object: { subdomain: sub, root_dir: shared },
+            }),
+        )) as Record<string, unknown> | null;
+
+        expect(created?.subdomain).toBe(sub);
+    });
+
+    it('refuses to repoint an existing subdomain at a write-shared directory', async () => {
+        const owner = await makeUser();
+        const writer = await makeUser();
+        const shared = `/${owner.actor.user!.username}/Documents`;
+        await shareDir(owner, writer, shared, 'write');
+
+        const created = (await withActor(writer.actor, () =>
+            driver.create({
+                object: {
+                    subdomain: uniqueSubdomain('repoint'),
+                    root_dir: `/${writer.actor.user!.username}/Public`,
+                },
+            }),
+        )) as Record<string, unknown>;
+
+        await expect(
+            withActor(writer.actor, () =>
+                driver.update({
+                    uid: created.uid,
+                    object: { root_dir: shared },
+                }),
+            ),
+        ).rejects.toMatchObject({ statusCode: 403 });
+    });
+
+    // The owner's own path still only needs write, so an app hosting a
+    // directory its user gave it keeps working.
+    it("still accepts the actor's own directory", async () => {
+        const { actor } = await makeUser();
+        const sub = uniqueSubdomain('own');
+
+        const created = (await withActor(actor, () =>
+            driver.create({
+                object: {
+                    subdomain: sub,
+                    root_dir: `/${actor.user!.username}/Documents`,
+                },
+            }),
+        )) as Record<string, unknown> | null;
+
+        expect(created?.subdomain).toBe(sub);
+    });
+});
+
 // ── upsert ──────────────────────────────────────────────────────────
 
 describe('SubdomainDriver.upsert', () => {

--- a/src/backend/drivers/subdomain/SubdomainDriver.ts
+++ b/src/backend/drivers/subdomain/SubdomainDriver.ts
@@ -30,6 +30,7 @@ import type { Actor } from '../../core/actor.js';
 import type { DriverConcurrentConfig, DriverRateLimitConfig } from '../meta.js';
 import type { FSEntry } from '../../stores/fs/FSEntry.js';
 import type { UserRow } from '../../stores/user/UserStore.js';
+import { MANAGE_PERM_PREFIX } from '../../services/permission/consts.js';
 import { expandTildePath } from '../../services/fs/resolveNode.js';
 import { isUniqueViolation } from '../../util/dbError.js';
 import { buildHostedSubdomainIndexUrlCandidates } from '../../util/hostedAppBacking.js';
@@ -176,7 +177,7 @@ export class SubdomainDriver extends PuterDriver {
                 legacyCode: 'bad_request',
             });
         }
-        await this.services.fs.checkFSAccess(entry, actor);
+        await this.#checkPublishAccess(entry, actor);
 
         // A name some other user's app still points at is not free either.
         // Deleting a hosted subdomain leaves the app row's `index_url` intact,
@@ -367,7 +368,7 @@ export class SubdomainDriver extends PuterDriver {
                 });
             }
             if (rootDirId !== (row.root_dir_id ?? null)) {
-                await this.services.fs.checkFSAccess(entry, actor);
+                await this.#checkPublishAccess(entry, actor);
             }
             patch.root_dir_id = rootDirId;
         }
@@ -572,6 +573,39 @@ export class SubdomainDriver extends PuterDriver {
         // Cross-user read permission
         if (await this.#hasPermission(actor, 'read-all-subdomains')) return;
         throw new HttpError(403, 'Access denied', { legacyCode: 'forbidden' });
+    }
+
+    /**
+     * Gate on pointing a subdomain at a directory. Hosting serves everything
+     * under the root dir with the ACL bypassed, so publishing makes that
+     * subtree world-readable — for good, and including whatever is written
+     * there later. That is the owner's call to make.
+     *
+     * `write` is not it. A shared folder's writer would be exposing the owner's
+     * tree, the row belongs to the writer's account, and nothing the owner can
+     * list would show it. `manage` — "Can edit & share" — is the grant that
+     * delegates the decision.
+     */
+    async #checkPublishAccess(entry: FSEntry, actor: Actor): Promise<void> {
+        // First, because this is the check that masks a directory the caller
+        // cannot see at all as a 404.
+        await this.services.fs.checkFSAccess(entry, actor);
+        if (entry.userId === actor.user?.id) return;
+        try {
+            await this.services.fs.checkFSAccess(
+                entry,
+                actor,
+                MANAGE_PERM_PREFIX,
+            );
+        } catch {
+            // Reached only with access to the directory, so its existence is
+            // not news and there is nothing to mask.
+            throw new HttpError(
+                403,
+                'Publishing this directory is up to whoever owns it',
+                { legacyCode: 'access_denied' },
+            );
+        }
     }
 
     async #checkWriteAccess(

--- a/src/docs/src/FS/share.md
+++ b/src/docs/src/FS/share.md
@@ -38,8 +38,8 @@ Who to share with. A string containing `@` is treated as an email address, and a
 How much access to grant. Defaults to `'read'`.
 
 - `'read'` - Read the item.
-- `'write'` - Read and change the item. Does **not** allow re-sharing it.
-- `'manage'` - Everything `'write'` allows, plus re-sharing the item with other people.
+- `'write'` - Read and change the item. Does **not** allow re-sharing it, or publishing a directory as a website.
+- `'manage'` - Everything `'write'` allows, plus re-sharing the item with other people and publishing a shared directory as a website.
 - `'list'`, `'see'` - Weaker than `read`; useful for making an item discoverable without exposing its contents.
 
 #### `options` (Object) (optional)

--- a/src/docs/src/Hosting/create.md
+++ b/src/docs/src/Hosting/create.md
@@ -23,6 +23,8 @@ A string containing the name of the subdomain you want to create.
 
 A string containing the path to the directory you want to serve.
 
+The directory must be one you own. Hosting serves everything under it publicly, including files added later, so a directory someone shared with you can only be published if they gave you `manage` access — [`share()`](/FS/share/) calls that level "Can edit & share".
+
 #### `options` (Object) (optional)
 
 Alternative way to create hosting via options.

--- a/src/gui/src/helpers/generateFileContextMenu.js
+++ b/src/gui/src/helpers/generateFileContextMenu.js
@@ -123,7 +123,10 @@ const generate_file_context_menu = async function (options) {
     if ( !is_trashed && !is_trash && fsentry.is_dir ) {
         menu_items.push({
             html: i18n('publish_as_website'),
-            disabled: !fsentry.is_dir || fsentry.has_website,
+            // Publishing serves the folder to anyone, for good, so it takes the
+            // same own-it-or-`manage` right as sharing it does (SubdomainDriver
+            // enforces that). `write` on someone else's folder is not enough.
+            disabled: !fsentry.is_dir || fsentry.has_website || !may_share,
             onClick: async function () {
                 await publish_as_website({
                     uid: fsentry.uid,


### PR DESCRIPTION
Closes PUT-1619. Found via internal source audit.

Creating a hosted subdomain gated `root_dir` on `write` — `checkFSAccess` defaults to it — and hosting serves everything under that directory with the ACL deliberately bypassed. So a recipient of a `write` share could point a `*.puter.site` subdomain at the owner's folder and make that subtree world-readable. The recipient could already read those files, so this is not a read escalation; what was new is that it is continuous, covers whatever the owner writes there later, and the owner gets no signal — the subdomain row belongs to the recipient, so nothing the owner can list would show it. `update` had the same gate for a changed `root_dir`.

## The fix

`#checkPublishAccess` now decides both call sites:

- **The actor's own tree** → `write`, exactly as before.
- **Anyone else's** → `manage` required. That is the "Can edit & share" level, which is the owner delegating the decision.

Keyed on who owns the entry rather than requiring `manage` outright, which is what the ticket proposed. `manage`'s `is-owner` implicator declines to answer for app actors ([FSService.ts:238](https://github.com/HeyPuter/puter/blob/main/src/backend/services/fs/FSService.ts#L238)), so a flat `mode: 'manage'` would refuse every app publishing a directory its user handed it — with no way for an app to obtain that grant through the SDK. Apps publishing their own AppData are unaffected either way, via the ACL short-circuit.

The `write` check still runs first: it is what masks a directory the caller cannot see at all as a 404 rather than a 403. `manage` satisfies every lower mode, so a manage-holder is not tripped by the ordering.

## Tests

The two exposure tests **fail without the driver change** — verified by stashing it, they create the subdomain instead of throwing 403:

- a write-share recipient is refused on `create`;
- and refused when repointing a subdomain they own at the shared directory.

The other two are compatibility guards that pass either way: a `manage` recipient is accepted, and so is the actor's own directory.

Full backend suite: 6477 passed, 0 failed. Typecheck clean.

## Also changed

- **Docs** — `hosting.create()` states the ownership rule; `share()`'s level list now says `write` does not allow publishing a directory and `manage` does. Nothing was added to "What sharing does not promise" in `FS/share.md`, since this is fixed rather than accepted.
- **GUI** — the item context menu's Publish As Website reuses the own-it-or-`manage` answer it already computes for sharing, so the option is not offered where the backend would now refuse.

## Deliberately left alone

- **The window head context menu** still offers Publish for someone else's open folder. Its handler is synchronous and returns `true` to preserve the native context menu, so it cannot await the share-mode lookup, and the sync alternative (`is_owned_by_me`) would wrongly disable it for `manage` delegates. Clicking it now answers "Publishing this directory is up to whoever owns it", which beats a wrong disable.
- **`WorkerDriver`** also writes `root_dir_id`, but from the read-gated worker *source file*, and `__workers/` paths are carved out of public serving — so it does not produce the directory exposure this fixes.
- **The owner still cannot see a subdomain rooted in their own tree.** After this, only a `manage` delegate can create one, but the row lives under the delegate's account. That is the visibility half of the ticket and a separate change — worth its own issue if we want it.
