### PR TITLE
fix: bound failed WebDAV Basic-auth attempts per account and per address

### DIFF
--- a/src/backend/controllers/fs/limits.ts
+++ b/src/backend/controllers/fs/limits.ts
@@ -243,3 +243,29 @@ export const DAV_CONCURRENT: NonNullable<RouteOptions['concurrent']> = {
     limit: 10,
     key: 'fingerprint',
 };
+
+/**
+ * Failed HTTP Basic verifications on the DAV host.
+ *
+ * `DAV_LIMIT` counts requests, and a working DAV client resends its credentials
+ * on every one of them, so it cannot double as a credential ceiling — these
+ * count only verifications that failed, which a working client never produces.
+ * The gate reads them before the bcrypt compare, so an exhausted bucket costs
+ * nothing to serve.
+ *
+ * Two axes, sized like `/login`'s, and for the same reasons: per-account so one
+ * account can't be ground down from many networks, plus a coarser per-IP
+ * backstop, because the network fingerprint `DAV_LIMIT` buckets on rotates with
+ * client-controlled headers.
+ */
+export const DAV_AUTH_FAILURE_LIMIT: RouteRateLimit = {
+    scope: 'dav-auth',
+    limit: 10,
+    window: 15 * 60_000,
+};
+export const DAV_AUTH_FAILURE_IP_LIMIT: RouteRateLimit = {
+    scope: 'dav-auth-ip',
+    limit: 50,
+    window: 15 * 60_000,
+    key: 'ip',
+};

--- a/src/backend/controllers/webdav/WebDAVController.test.ts
+++ b/src/backend/controllers/webdav/WebDAVController.test.ts
@@ -95,6 +95,7 @@ const makeReq = (init: {
     headers?: Record<string, string>;
     actor?: unknown;
     socket?: unknown;
+    ip?: string;
 }): Request => {
     return {
         method: init.method,
@@ -104,6 +105,7 @@ const makeReq = (init: {
         headers: init.headers ?? {},
         actor: init.actor,
         socket: init.socket ?? {},
+        ip: init.ip,
     } as unknown as Request;
 };
 
@@ -296,6 +298,141 @@ describe('WebDAVController', () => {
                 noop,
             );
             expect(captured.statusCode).toBe(401);
+        });
+    });
+
+    describe('Basic-auth brute-force gate', () => {
+        // Every case pins its own `ip` so the per-IP backstop is not shared
+        // with the rest of the file — the memory bucket store is module-wide.
+        const makePasswordUser = async () => {
+            const username = `webdav-pw-${Math.random()
+                .toString(36)
+                .slice(2, 10)}`;
+            const created = await server.stores.user.create({
+                username,
+                uuid: uuidv4(),
+                password: await bcryptHash('correct-horse', 4),
+                email: `${username}@test.local`,
+                free_storage: 100 * 1024 * 1024,
+                requires_email_confirmation: false,
+            });
+            await generateDefaultFsentries(
+                server.clients.db,
+                server.stores.user,
+                created,
+            );
+            return username;
+        };
+
+        const attempt = async (headers: Record<string, string>, ip: string) => {
+            const { res, captured } = makeRes();
+            await dispatchMiddleware(
+                makeReq({ method: 'OPTIONS', headers, ip }),
+                res,
+                noop,
+            );
+            return captured;
+        };
+
+        it('stops guessing one account after ten failures, before the compare', async () => {
+            const username = await makePasswordUser();
+            const ip = '203.0.113.10';
+
+            for (let i = 0; i < 10; i++) {
+                const captured = await attempt(
+                    { authorization: basicAuth(username, `guess-${i}`) },
+                    ip,
+                );
+                expect(captured.statusCode).toBe(401);
+            }
+
+            const lookup = vi.spyOn(server.stores.user, 'getByUsername');
+            const blocked = await attempt(
+                { authorization: basicAuth(username, 'guess-11') },
+                ip,
+            );
+            expect(blocked.statusCode).toBe(429);
+            // Refused ahead of the credential work, so the attempt costs
+            // neither a user lookup nor a bcrypt round.
+            expect(lookup).not.toHaveBeenCalled();
+            lookup.mockRestore();
+
+            // Bucketed per account, not globally: another account from the
+            // same IP still gets its attempt.
+            const otherUsername = await makePasswordUser();
+            expect(
+                (
+                    await attempt(
+                        { authorization: basicAuth(otherUsername, 'nope') },
+                        ip,
+                    )
+                ).statusCode,
+            ).toBe(401);
+        });
+
+        it('does not spend the budget on successful requests', async () => {
+            const username = await makePasswordUser();
+            const ip = '203.0.113.11';
+            const good = {
+                authorization: basicAuth(username, 'correct-horse'),
+            };
+
+            // A working DAV client resends credentials on every request; well
+            // past the failure ceiling, none of them may count against it.
+            for (let i = 0; i < 20; i++) {
+                expect((await attempt(good, ip)).statusCode).toBe(200);
+            }
+            expect(
+                (
+                    await attempt(
+                        { authorization: basicAuth(username, 'wrong') },
+                        ip,
+                    )
+                ).statusCode,
+            ).toBe(401);
+        });
+
+        it('backstops spraying many accounts from one address', async () => {
+            const ip = '203.0.113.12';
+            // Unknown usernames never reach bcrypt, so this is the shape an
+            // attacker uses to mint a fresh per-account bucket every attempt.
+            for (let i = 0; i < 50; i++) {
+                const captured = await attempt(
+                    { authorization: basicAuth(`sprayed-${i}`, 'password') },
+                    ip,
+                );
+                expect(captured.statusCode).toBe(401);
+            }
+            expect(
+                (
+                    await attempt(
+                        { authorization: basicAuth('sprayed-50', 'password') },
+                        ip,
+                    )
+                ).statusCode,
+            ).toBe(429);
+        });
+
+        it('holds token guessing on the per-IP backstop', async () => {
+            const ip = '203.0.113.13';
+            for (let i = 0; i < 50; i++) {
+                expect(
+                    (
+                        await attempt(
+                            { authorization: basicAuth('-token', `bad-${i}`) },
+                            ip,
+                        )
+                    ).statusCode,
+                ).toBe(401);
+            }
+            expect(
+                (
+                    await attempt(
+                        { authorization: basicAuth('-token', 'bad-50') },
+                        ip,
+                    )
+                ).statusCode,
+            ).toBe(429);
         });
     });
 

--- a/src/backend/controllers/webdav/WebDAVController.ts
+++ b/src/backend/controllers/webdav/WebDAVController.ts
@@ -64,7 +64,16 @@ import {
     hasWritePermission,
     refreshLock,
 } from './locks.js';
-import { DAV_CONCURRENT, DAV_LIMIT } from '../fs/limits.js';
+import {
+    DAV_AUTH_FAILURE_IP_LIMIT,
+    DAV_AUTH_FAILURE_LIMIT,
+    DAV_CONCURRENT,
+    DAV_LIMIT,
+} from '../fs/limits.js';
+import {
+    checkRateLimit,
+    peekRateLimit,
+} from '../../core/http/middleware/rateLimit.js';
 import { assertActorHasCredits } from '../../services/metering/enforcement.js';
 import type { ResolvedShare } from '../../services/share/ShareService.js';
 
@@ -311,6 +320,63 @@ export class WebDAVController extends PuterController {
 
     // -- Auth ---------------------------------------------------------
 
+    /**
+     * The failure buckets for one attempt. `account` is null on the `-token`
+     * path, which has no account to bucket on — a shared bucket across every
+     * user's tokens would let bad tokens lock out good ones — so those attempts
+     * are held by the per-IP backstop alone. Otherwise it's the username as
+     * presented, lowercased: a bucket per spelling would hand an attacker one
+     * per casing.
+     */
+    #authFailureKeys(req: Request, account: string | null): string[] {
+        const ip = req.ip || req.socket?.remoteAddress || 'unknown';
+        const keys = [`${DAV_AUTH_FAILURE_IP_LIMIT.scope}:${ip}`];
+        if (account !== null) {
+            keys.unshift(
+                `${DAV_AUTH_FAILURE_LIMIT.scope}:${account.toLowerCase()}`,
+            );
+        }
+        return keys;
+    }
+
+    #authFailureSpec(key: string) {
+        return key.startsWith(`${DAV_AUTH_FAILURE_IP_LIMIT.scope}:`)
+            ? DAV_AUTH_FAILURE_IP_LIMIT
+            : DAV_AUTH_FAILURE_LIMIT;
+    }
+
+    /**
+     * Refuse before the credential work when a failure bucket is spent. Peeked
+     * rather than spent, so an honest client — which resends its credentials on
+     * every request — never draws the budget down.
+     */
+    async #assertAuthAttemptsRemain(
+        req: Request,
+        account: string | null,
+    ): Promise<void> {
+        const results = await Promise.all(
+            this.#authFailureKeys(req, account).map((key) => {
+                const spec = this.#authFailureSpec(key);
+                return peekRateLimit(key, spec.limit, spec.window);
+            }),
+        );
+        if (results.every(Boolean)) return;
+        throw new HttpError(429, 'Too many failed authentication attempts');
+    }
+
+    /** Charge one failed verification to every bucket that holds this attempt. */
+    async #recordAuthFailure(
+        req: Request,
+        account: string | null,
+    ): Promise<void> {
+        await Promise.all(
+            this.#authFailureKeys(req, account).map((key) => {
+                const spec = this.#authFailureSpec(key);
+                return checkRateLimit(key, spec.limit, spec.window);
+            }),
+        );
+    }
+
     async #resolveActor(req: Request, res: Response): Promise<Actor | null> {
         // If the global authProbe already resolved an actor, use it.
         if (req.actor?.user) return req.actor;
@@ -339,12 +405,19 @@ export class WebDAVController extends PuterController {
         }
         const username = decoded.slice(0, colonIdx);
         const password = decoded.slice(colonIdx + 1);
+        const isTokenAuth = username === '-token';
+        const failureAccount = isTokenAuth ? null : username;
+
+        // Ahead of the verification, so a spent budget never buys a bcrypt
+        // round. Throws 429; `#serve` turns that into the client's reply.
+        await this.#assertAuthAttemptsRemain(req, failureAccount);
 
         // `-token` username: password IS the auth token
-        if (username === '-token') {
+        if (isTokenAuth) {
             const actor =
                 await this.services.auth.authenticateFromToken(password);
             if (!actor) {
+                await this.#recordAuthFailure(req, failureAccount);
                 res.status(401)
                     .set('WWW-Authenticate', 'Basic realm="WebDAV"')
                     .send('Invalid token');
@@ -356,6 +429,7 @@ export class WebDAVController extends PuterController {
         // Regular username + password (with optional 6-digit OTP suffix)
         const user = await this.stores.user.getByUsername(username);
         if (!user || !user.password) {
+            await this.#recordAuthFailure(req, failureAccount);
             res.status(401)
                 .set('WWW-Authenticate', 'Basic realm="WebDAV"')
                 .send('Invalid credentials');
@@ -368,6 +442,7 @@ export class WebDAVController extends PuterController {
         let passwordOk = false;
         if (otpEnabled) {
             if (password.length <= 6) {
+                await this.#recordAuthFailure(req, failureAccount);
                 res.status(401)
                     .set('WWW-Authenticate', 'Basic realm="WebDAV"')
                     .send('Invalid credentials');
@@ -386,6 +461,7 @@ export class WebDAVController extends PuterController {
         }
 
         if (!passwordOk) {
+            await this.#recordAuthFailure(req, failureAccount);
             res.status(401)
                 .set('WWW-Authenticate', 'Basic realm="WebDAV"')
                 .send('Invalid credentials');

--- a/src/backend/core/http/middleware/rateLimit.js
+++ b/src/backend/core/http/middleware/rateLimit.js
@@ -114,6 +114,21 @@ async function checkMemory(key, limit, windowMs) {
     return true;
 }
 
+/**
+ * Read a bucket's state without spending from it. For gates whose budget is
+ * consumed by something other than the request being admitted — a failed
+ * credential check, say — where charging the check itself would bill every
+ * caller for the attacker's attempts.
+ */
+async function peekMemory(key, limit, windowMs) {
+    const entry = memoryWindows.get(key);
+    if (!entry) return true;
+    const cutoff = Date.now() - windowMs;
+    const timestamps = entry.ts;
+    while (timestamps.length > 0 && timestamps[0] < cutoff) timestamps.shift();
+    return timestamps.length < limit;
+}
+
 // -- Redis backend ---------------------------------------------------
 
 // ioredis MULTI/EXEC reports per-command failures inside the exec() result
@@ -166,6 +181,16 @@ async function checkRedis(
     return true;
 }
 
+async function peekRedis(redis, key, limit, windowMs) {
+    const redisKey = `rate:${key}`;
+    const results = await redis
+        .multi()
+        .zremrangebyscore(redisKey, 0, Date.now() - windowMs)
+        .zcard(redisKey)
+        .exec();
+    return Number(multiResult(results, 1)) < limit;
+}
+
 // -- KV backend ------------------------------------------------------
 
 async function checkKv(kv, key, limit, windowMs) {
@@ -188,6 +213,18 @@ async function checkKv(kv, key, limit, windowMs) {
         expireAt: Math.ceil((now + windowMs) / 1000),
     });
     return true;
+}
+
+// `list` filters by TTL, so a non-expired row is in-window — same read
+// `checkKv` does, minus the write.
+async function peekKv(kv, key, limit) {
+    const { res } = await kv.list({
+        as: 'keys',
+        pattern: `rate:${key}:`,
+        limit: limit + 1,
+    });
+    const keys = Array.isArray(res) ? res : (res?.items ?? []);
+    return keys.length < limit;
 }
 
 // -- Concurrent in-flight backends -----------------------------------
@@ -348,6 +385,10 @@ function instrumentBackendPair(name, pair) {
             withSpan('rate_limit.check', attrs, () =>
                 pair.rate(key, limit, windowMs),
             ),
+        peek: (key, limit, windowMs) =>
+            withSpan('rate_limit.peek', attrs, () =>
+                pair.peek(key, limit, windowMs),
+            ),
         acquire: (key, limit) =>
             withSpan('rate_limit.acquire', attrs, () =>
                 pair.acquire(key, limit),
@@ -357,6 +398,7 @@ function instrumentBackendPair(name, pair) {
 
 const memoryBackendPair = instrumentBackendPair('memory', {
     rate: checkMemory,
+    peek: peekMemory,
     acquire: acquireMemoryConcurrent,
 });
 
@@ -403,12 +445,15 @@ export function configureRateLimit({
         backends.redis = instrumentBackendPair('redis', {
             rate: (key, limit, windowMs) =>
                 checkRedis(redis, key, limit, windowMs),
+            peek: (key, limit, windowMs) =>
+                peekRedis(redis, key, limit, windowMs),
             acquire: (key, limit) => acquireRedisConcurrent(redis, key, limit),
         });
     }
     if (kv) {
         backends.kv = instrumentBackendPair('kv', {
             rate: (key, limit, windowMs) => checkKv(kv, key, limit, windowMs),
+            peek: (key, limit) => peekKv(kv, key, limit),
             acquire: (key, limit) => acquireKvConcurrent(kv, key, limit),
         });
     }
@@ -433,10 +478,10 @@ export function listConfiguredRateLimitBackends() {
 }
 
 /**
- * Resolve the `{ rate, acquire }` backend pair for a named backend. Unknown /
- * unconfigured names log once and fall through to the default so a typo in a
- * route or driver decorator doesn't 500 every request — rate limiting is
- * best-effort security.
+ * Resolve the `{ rate, peek, acquire }` backend pair for a named backend.
+ * Unknown / unconfigured names log once and fall through to the default so a
+ * typo in a route or driver decorator doesn't 500 every request — rate limiting
+ * is best-effort security.
  */
 function resolveBackend(name) {
     if (!name) return backends[defaultBackendName];
@@ -631,6 +676,26 @@ export async function checkRateLimit(key, limit, windowMs, backend) {
     } catch (err) {
         console.error(
             '[rate-limit] imperative check failed, failing open:',
+            err,
+        );
+        return true;
+    }
+}
+
+/**
+ * Read whether `key` still has budget, without spending any. The twin to
+ * `checkRateLimit` for gates whose budget is consumed by an outcome rather than
+ * by the request: a failed-credential counter has to be readable before the
+ * work that might fail, or the check itself charges every honest caller. Fails
+ * open on backend error, matching the rest of this module's policy.
+ */
+export async function peekRateLimit(key, limit, windowMs, backend) {
+    const bk = resolveBackend(backend);
+    try {
+        return await bk.peek(key, limit, windowMs);
+    } catch (err) {
+        console.error(
+            '[rate-limit] imperative peek failed, failing open:',
             err,
         );
         return true;

--- a/src/backend/core/http/middleware/rateLimit.test.js
+++ b/src/backend/core/http/middleware/rateLimit.test.js
@@ -40,6 +40,7 @@ import {
     concurrencyGate,
     configureRateLimit,
     listConfiguredRateLimitBackends,
+    peekRateLimit,
     rateLimitGate,
     sweepMemoryWindows,
 } from './rateLimit.js';
@@ -1276,6 +1277,76 @@ describe('checkRateLimit', () => {
         });
         const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
         expect(await checkRateLimit('boom', 1, 60_000)).toBe(true);
+        expect(spy).toHaveBeenCalled();
+        spy.mockRestore();
+    });
+});
+
+describe('peekRateLimit', () => {
+    beforeEach(() => configureRateLimit());
+    afterEach(() => configureRateLimit());
+
+    const backends = [
+        ['memory', () => ({})],
+        ['redis', () => ({ redis: new RedisMock() })],
+    ];
+
+    it.each(backends)(
+        'reads %s state without spending it',
+        async (name, wiring) => {
+            const cfg = wiring();
+            configureRateLimit(cfg);
+            const key = `peek-${name}-${Math.random()}`;
+
+            // Peeking is free: any number of reads leaves the budget intact.
+            for (let i = 0; i < 5; i++) {
+                expect(await peekRateLimit(key, 1, 60_000, name)).toBe(true);
+            }
+            expect(await checkRateLimit(key, 1, 60_000, name)).toBe(true);
+            expect(await peekRateLimit(key, 1, 60_000, name)).toBe(false);
+            await cfg.redis?.quit?.();
+        },
+    );
+
+    it('reports exhaustion on the kv backend without writing', async () => {
+        const server = await setupTestServer();
+        try {
+            configureRateLimit({ default: 'kv', kv: server.stores.kv });
+            const key = `peek-kv-${Math.random().toString(36).slice(2, 10)}`;
+            expect(await peekRateLimit(key, 1, 60_000)).toBe(true);
+            expect(await peekRateLimit(key, 1, 60_000)).toBe(true);
+            expect(await checkRateLimit(key, 1, 60_000)).toBe(true);
+            expect(await peekRateLimit(key, 1, 60_000)).toBe(false);
+        } finally {
+            configureRateLimit();
+            await server.shutdown();
+        }
+    });
+
+    it('ages entries out of the window', async () => {
+        vi.useFakeTimers();
+        try {
+            const key = `peek-window-${Math.random()}`;
+            expect(await checkRateLimit(key, 1, 60_000)).toBe(true);
+            expect(await peekRateLimit(key, 1, 60_000)).toBe(false);
+            vi.advanceTimersByTime(60_001);
+            expect(await peekRateLimit(key, 1, 60_000)).toBe(true);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it('fails open when the backend throws', async () => {
+        configureRateLimit({
+            default: 'redis',
+            redis: {
+                multi: () => {
+                    throw new Error('redis down');
+                },
+            },
+        });
+        const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        expect(await peekRateLimit('boom', 1, 60_000)).toBe(true);
         expect(spy).toHaveBeenCalled();
         spy.mockRestore();
     });

--- a/src/docs/src/rate-limits-and-quotas.md
+++ b/src/docs/src/rate-limits-and-quotas.md
@@ -7,11 +7,11 @@ description: The rate limits, usage credits, and storage quotas that apply to Pu
 
 Three separate mechanisms decide whether a call succeeds. They are independent, and hitting any one of them is enough to stop a request:
 
-| Mechanism | Bounds | Refills | Failure |
-| --- | --- | --- | --- |
-| **Usage credit** | what usage *costs* (AI, egress, KV capacity, storage ops, workers) | monthly, per plan | `402` `insufficient_funds` |
-| **Rate limit** | how many *requests* are made per window | rolling window (10s / 1min / 1h) | `429` `too_many_requests` |
-| **Storage quota** | how many *bytes* are kept in the filesystem | never — the user deletes or upgrades | `413` `storage_limit_reached` |
+| Mechanism         | Bounds                                                             | Refills                              | Failure                       |
+| ----------------- | ------------------------------------------------------------------ | ------------------------------------ | ----------------------------- |
+| **Usage credit**  | what usage _costs_ (AI, egress, KV capacity, storage ops, workers) | monthly, per plan                    | `402` `insufficient_funds`    |
+| **Rate limit**    | how many _requests_ are made per window                            | rolling window (10s / 1min / 1h)     | `429` `too_many_requests`     |
+| **Storage quota** | how many _bytes_ are kept in the filesystem                        | never — the user deletes or upgrades | `413` `storage_limit_reached` |
 
 A credit balance does not buy rate-limit headroom, and an empty balance does not stop metadata reads that cost nothing. Design for all three.
 
@@ -27,7 +27,7 @@ Usage is charged against the account's monthly credit allowance, metered per ope
 
 What usage costs (the big three):
 
-- **Egress** — every byte sent to a client, on *all* responses, not just file downloads. This is the one developers underestimate.
+- **Egress** — every byte sent to a client, on _all_ responses, not just file downloads. This is the one developers underestimate.
 - **AI** — priced per model and per token/second/character. `puter.ai.listModels()` reports models; the per-model rates are served by the API (`GET /metering/allCosts`) rather than printed here, because a single number would be wrong for every model.
 - **KV and storage operations** — small per-operation costs; reads served from cache are charged a fraction of an uncached read.
 
@@ -43,10 +43,10 @@ Every limit is a rolling window, keyed per user. Where three numbers are shown t
 
 Shared by chat, image generation, video, TTS, speech and OCR:
 
-| Limit | Paid | Free | Anonymous |
-| --- | --- | --- | --- |
-| Requests per 10s (per interface + method) | 200 | 30 | 20 |
-| Concurrent requests (per interface + method) | 20 | 3 | 2 |
+| Limit                                        | Paid | Free | Anonymous |
+| -------------------------------------------- | ---- | ---- | --------- |
+| Requests per 10s (per interface + method)    | 200  | 30   | 20        |
+| Concurrent requests (per interface + method) | 20   | 3    | 2         |
 
 Concurrency is counted per interface, so an image generation and a chat completion do not compete for the same slots.
 
@@ -54,19 +54,19 @@ The OpenAI- and Anthropic-compatible endpoints (`/puterai/openai/v1/*`, `/putera
 
 ### Key-value store
 
-| Limit | Paid | Free | Anonymous |
-| --- | --- | --- | --- |
-| `get` / `set` / etc. per 10s | 400 | 400 | 200 |
-| `list` (prefix scan) per minute | 240 | 120 | 60 |
-| Concurrent calls | 30 | 15 | 8 |
-| Concurrent `list` | 5 | 3 | 2 |
+| Limit                           | Paid | Free | Anonymous |
+| ------------------------------- | ---- | ---- | --------- |
+| `get` / `set` / etc. per 10s    | 400  | 400  | 200       |
+| `list` (prefix scan) per minute | 240  | 120  | 60        |
+| Concurrent calls                | 30   | 15   | 8         |
+| Concurrent `list`               | 5    | 3    | 2         |
 
 Sizes are fixed for every account:
 
-| Size | Limit |
-| --- | --- |
-| Key | 1 KB |
-| Value | 400 KB |
+| Size                      | Limit                                     |
+| ------------------------- | ----------------------------------------- |
+| Key                       | 1 KB                                      |
+| Value                     | 400 KB                                    |
 | Any number inside a value | ±9,007,199,254,740,991 (2<sup>53</sup>−1) |
 
 A key or value over its size limit is rejected outright. A number over its limit is not: it is stored clamped to the bound, and `NaN` is stored as `null` — the same thing `JSON.stringify()` does with it. This applies to numbers nested anywhere inside an object or array, so a value carrying one still keeps every other field it holds. Anything that has to stay exact past 2<sup>53</sup> — a large id, a running total — should be stored as a string.
@@ -75,62 +75,79 @@ A key or value over its size limit is rejected outright. A number over its limit
 
 All per minute unless stated:
 
-| Operation | Paid | Free | Anonymous |
-| --- | --- | --- | --- |
-| `stat` | 1,200 | 600 | 300 |
-| `readdir` | 600 | 300 | 120 |
-| `readdir` burst (per 10s) | 120 | 60 | 30 |
-| `read` | 600 | 300 | 120 |
-| `write` | 300 | 120 | 30 |
-| Multipart upload calls | 2,400 | 1,200 | 600 |
-| Mutations (mkdir/rename/delete/move/copy) | 1,200 | 900 | 600 |
-| Mutations, sustained (per hour) | 6,000 | 3,000 | 1,800 |
-| Search | 60 | 30 | 10 |
-| `space()` | 60 | 30 | 15 |
-| Sign a URL | 300 | 150 | 60 |
+| Operation                                 | Paid  | Free  | Anonymous |
+| ----------------------------------------- | ----- | ----- | --------- |
+| `stat`                                    | 1,200 | 600   | 300       |
+| `readdir`                                 | 600   | 300   | 120       |
+| `readdir` burst (per 10s)                 | 120   | 60    | 30        |
+| `read`                                    | 600   | 300   | 120       |
+| `write`                                   | 300   | 120   | 30        |
+| Multipart upload calls                    | 2,400 | 1,200 | 600       |
+| Mutations (mkdir/rename/delete/move/copy) | 1,200 | 900   | 600       |
+| Mutations, sustained (per hour)           | 6,000 | 3,000 | 1,800     |
+| Search                                    | 60    | 30    | 10        |
+| `space()`                                 | 60    | 30    | 15        |
+| Sign a URL                                | 300   | 150   | 60        |
 
 | Concurrency | Paid | Free | Anonymous |
-| --- | --- | --- | --- |
-| `read` | 10 | 5 | 3 |
-| `write` | 15 | 6 | 3 |
-| Search | 5 | 2 | 2 |
+| ----------- | ---- | ---- | --------- |
+| `read`      | 10   | 5    | 3         |
+| `write`     | 15   | 6    | 3         |
+| Search      | 5    | 2    | 2         |
 
 Signed-URL routes have no session to key on, so they are bounded per network rather than per account: 3,000 reads/min, 600 writes/min, 60 concurrent.
 
+### WebDAV
+
+The `dav` host authenticates each request itself, so its limits are bounded per network rather than per account: **600 requests/min** and **10 concurrent**, one ceiling for everyone.
+
+A DAV client resends its credentials on every request, so that ceiling can't also bound credential guessing. Failed sign-ins are counted separately — successful ones cost nothing:
+
+| Limit                            | Per 15 minutes |
+| -------------------------------- | -------------- |
+| Failed sign-ins for one account  | 10             |
+| Failed sign-ins from one address | 50             |
+
+Over either, the host answers `429` until the window rolls off — including for the right password. Ten wrong ones lock that account out of `dav` for the rest of the window, so a client left running with a stale password keeps itself locked out; fix the stored password and wait for the window rather than retrying.
+
+This applies only to `dav`. The account is unaffected everywhere else — the desktop, the API and `puter.auth` all keep working throughout.
+
+Mounting with a `-token` username and an API token as the password skips the per-account ceiling entirely, which is the better setup for anything long-lived: the token is revocable from the dashboard without changing the account password, and it can't be locked out by someone else guessing at your account.
+
 ### Sites and workers
 
-| Limit | Paid | Free | Anonymous |
-| --- | --- | --- | --- |
-| Subdomain reads per 10s | 200 | 200 | 100 |
-| Subdomain `create` per minute | 120 | 60 | 30 |
-| Concurrent subdomain calls | 20 | 10 | 5 |
-| Worker metadata reads per minute | 600 | 300 | 150 |
-| Worker `create` (deploy) per minute | 120 | 80 | 40 |
-| Worker `destroy` per minute | 30 | 20 | 10 |
-| Concurrent worker calls | 10 | 5 | 3 |
-| Concurrent deploys | 5 | 2 | 2 |
+| Limit                               | Paid | Free | Anonymous |
+| ----------------------------------- | ---- | ---- | --------- |
+| Subdomain reads per 10s             | 200  | 200  | 100       |
+| Subdomain `create` per minute       | 120  | 60   | 30        |
+| Concurrent subdomain calls          | 20   | 10   | 5         |
+| Worker metadata reads per minute    | 600  | 300  | 150       |
+| Worker `create` (deploy) per minute | 120  | 80   | 40        |
+| Worker `destroy` per minute         | 30   | 20   | 10        |
+| Concurrent worker calls             | 10   | 5    | 3         |
+| Concurrent deploys                  | 5    | 2    | 2         |
 
 ### Sharing
 
 Sharing is bounded twice: on the calls, and on how many people one account can reach in a day.
 
-| Limit | All accounts |
-| --- | --- |
-| `share` / `revoke` calls per minute | 60 |
-| `share` / `revoke` calls per day | 500 |
-| Reads (`getShares`, `listShared`) per minute | 600 |
-| New shares per day | 200 |
-| Recipients per request | 10 |
-| Items per request | 50 |
+| Limit                                        | All accounts |
+| -------------------------------------------- | ------------ |
+| `share` / `revoke` calls per minute          | 60           |
+| `share` / `revoke` calls per day             | 500          |
+| Reads (`getShares`, `listShared`) per minute | 600          |
+| New shares per day                           | 200          |
+| Recipients per request                       | 10           |
+| Items per request                            | 50           |
 
 A "new share" is one that gives someone access they didn't already have. Changing the mode on an existing share, or re-sharing an item the recipient already has, costs nothing. Over the daily limit, `share` fails with `share_daily_limit_reached`.
 
 Separately, the notification and email that tell a recipient about a share are budgeted — being told is not the same as being interrupted about it:
 
-| Announcement | Limit |
-| --- | --- |
+| Announcement                     | Limit                        |
+| -------------------------------- | ---------------------------- |
 | From one sender to one recipient | 1 per 15 minutes, 20 per day |
-| To one recipient, from anyone | 10 per hour, 50 per day |
+| To one recipient, from anyone    | 10 per hour, 50 per day      |
 
 Recipients are emailed by default and opt out with the unsubscribe link the mail carries; a deployment can turn share email off entirely with `share_email_notifications: false`.
 
@@ -138,14 +155,14 @@ Over these, **the share still succeeds** — only the announcement is dropped. T
 
 ### Peer connections
 
-| Limit | Paid | Free | Anonymous |
-| --- | --- | --- | --- |
-| Relay credentials per minute | 30 | 10 | 5 |
-| Guest grants issued per minute | 30 | 10 | 5 |
+| Limit                          | Paid | Free | Anonymous |
+| ------------------------------ | ---- | ---- | --------- |
+| Relay credentials per minute   | 30   | 10   | 5         |
+| Guest grants issued per minute | 30   | 10   | 5         |
 
 Signalling details are public deployment config and bounded per network instead of per account, at 3,000 reads/min.
 
-Guests are bounded per *host*: everyone holding grants from the same account shares **60 relay-credential requests/min**. Relay traffic a guest sends is metered against the account that issued the grant, so treat a grant as something that spends your allowance — issue it for the session you meant to host, and let it expire rather than reusing one indefinitely.
+Guests are bounded per _host_: everyone holding grants from the same account shares **60 relay-credential requests/min**. Relay traffic a guest sends is metered against the account that issued the grant, so treat a grant as something that spends your allowance — issue it for the session you meant to host, and let it expire rather than reusing one indefinitely.
 
 ### Everything at once
 
@@ -153,16 +170,16 @@ Every driver call also passes one shared per-account budget of **8,000 calls/min
 
 ## Storage quota
 
-Every account has a byte quota for the filesystem (100 MiB free; paid plans add more). Storage is what the user is *keeping*, not what they transferred — deleting files frees it immediately. At the limit, writes fail with `413` `storage_limit_reached`; reads keep working. `puter.fs.space()` returns `{ capacity, used }` live.
+Every account has a byte quota for the filesystem (100 MiB free; paid plans add more). Storage is what the user is _keeping_, not what they transferred — deleting files frees it immediately. At the limit, writes fail with `413` `storage_limit_reached`; reads keep working. `puter.fs.space()` returns `{ capacity, used }` live.
 
 ## What happens when you hit a limit
 
-| Status | `code` | Meaning | What to do |
-| --- | --- | --- | --- |
-| `429` | `too_many_requests` | Rate or concurrency limit | Back off and retry; the window is at most 60s (or 1h for the sustained FS budget) |
-| `402` | `insufficient_funds` | Monthly credit spent | The user buys credit or upgrades; resets next month |
-| `402` | `subscription_required` | The endpoint is limited to paid plans | The user upgrades — retrying or waiting changes nothing |
-| `413` | `storage_limit_reached` | Storage quota reached | The user deletes files or upgrades |
+| Status | `code`                  | Meaning                               | What to do                                                                        |
+| ------ | ----------------------- | ------------------------------------- | --------------------------------------------------------------------------------- |
+| `429`  | `too_many_requests`     | Rate or concurrency limit             | Back off and retry; the window is at most 60s (or 1h for the sustained FS budget) |
+| `402`  | `insufficient_funds`    | Monthly credit spent                  | The user buys credit or upgrades; resets next month                               |
+| `402`  | `subscription_required` | The endpoint is limited to paid plans | The user upgrades — retrying or waiting changes nothing                           |
+| `413`  | `storage_limit_reached` | Storage quota reached                 | The user deletes files or upgrades                                                |
 
 Errors come back as JSON: `{ "error": …, "message": …, "code": … }`.
 


### PR DESCRIPTION
The only thing in front of the bcrypt compare on the DAV host was the 600/min request ceiling, keyed on a fingerprint that rotates with client-controlled headers. /login guards the same credential with a captcha and two much tighter buckets; DAV had neither, which left password and TOTP guessing viable from a host that answers any origin.

The request ceiling can't double as a credential ceiling — a working DAV client resends its credentials on every request — so the new buckets count only verifications that failed: 10 per account and 50 per address per 15 minutes, sized like /login's. They're read before the compare, so an exhausted bucket costs no bcrypt round, and successful requests never draw them down. `-token` attempts are held by the address bucket alone; bucketing them per account would let bad tokens lock out good ones.

Reading a bucket without spending from it is new, hence `peekRateLimit` and the matching `peek` on all three backends.

Also documents the DAV limits, which were undisclosed.