### PR TITLE
fix: derive the signup client IP from req.ip instead of x-forwarded-for

### DIFF
--- a/src/backend/controllers/auth/AuthController.test.ts
+++ b/src/backend/controllers/auth/AuthController.test.ts
@@ -76,6 +76,7 @@ type SignupValidateOverride = (data: {
     requires_email_confirmation: boolean;
     message: string | null;
     code: string | null;
+    ip: string | null;
 }) => void;
 
 let signupValidateOverride: SignupValidateOverride | null = null;
@@ -573,6 +574,54 @@ describe('AuthController.handleSignup', () => {
         expect(
             await bcrypt.compare('correct-horse-battery', persisted!.password!),
         ).toBe(true);
+    });
+
+    it('keys the signup abuse signals on req.ip, not the x-forwarded-for header', async () => {
+        const username = `s_${uniq()}`;
+        const forged = 'evil, 198.51.100.1';
+        let seenValidateIp: string | null | undefined;
+
+        await withSignupValidateOverride(
+            (event) => {
+                seenValidateIp = event.ip;
+            },
+            async () => {
+                await controller.handleSignup(
+                    makeReq(
+                        {
+                            username,
+                            email: `${username}@test.local`,
+                            password: 'correct-horse-battery',
+                        },
+                        {
+                            ip: '203.0.113.9',
+                            headers: { 'x-forwarded-for': forged },
+                        },
+                    ),
+                    makeRes(),
+                );
+            },
+        );
+
+        // Validate hook, success hook and the persisted lookup column all have
+        // to agree, or a per-IP counter is written under one key and read
+        // under another.
+        expect(seenValidateIp).toBe('203.0.113.9');
+        expect(
+            heardSignupSuccess.find((e) => e.username === username)?.ip,
+        ).toBe('203.0.113.9');
+
+        const persisted = await server.stores.user.getByUsername(username);
+        expect(persisted!.signup_ip).toBe('203.0.113.9');
+        expect(persisted!.signup_ip_forwarded).toBe('203.0.113.9');
+        // The raw chain is still recorded, but only as audit metadata.
+        const audit = JSON.parse(
+            String(
+                (persisted as unknown as { audit_metadata: string })
+                    .audit_metadata,
+            ),
+        );
+        expect(audit.ip_fwd).toBe(forged);
     });
 
     it('forces phone verification on every signup when always_require_phone_verification is set', async () => {

--- a/src/backend/controllers/auth/AuthController.ts
+++ b/src/backend/controllers/auth/AuthController.ts
@@ -841,6 +841,10 @@ export class AuthController extends PuterController {
         // guarantee — everything between here and the insert widens the window,
         // so the check runs again against the primary immediately before the
         // write, and the unique index catches whatever still slips through.
+        const clientIp: string | null =
+            req.ip || req.socket?.remoteAddress || null;
+        const proxyIpChain = req.headers['x-forwarded-for'];
+
         let pseudo_user = is_temp
             ? null
             : await this.#resolveSignupEmailClaim(body.email);
@@ -855,12 +859,9 @@ export class AuthController extends PuterController {
         const validateEvent = {
             req,
             data: body,
-            ip: ((req.headers?.['x-forwarded-for'] as string | undefined) ||
-                (req as unknown as { connection?: { remoteAddress?: string } })
-                    .connection?.remoteAddress ||
-                req.ip ||
-                req.socket?.remoteAddress ||
-                null) as string | null,
+            // `req.ip` honors `trust proxy`; reading x-forwarded-for directly
+            // would let a client pick its own per-IP abuse bucket.
+            ip: clientIp,
             email: body.email,
             // The same canonical form `email.validate` was given, so a check
             // in the abuse harness can look up the verdict that hook cached
@@ -1035,9 +1036,6 @@ export class AuthController extends PuterController {
             });
         } else {
             // -- New user ----------------------------------------
-            const clientIp = req.ip || req.socket?.remoteAddress || null;
-            const proxyIpChain = req.headers['x-forwarded-for'];
-
             try {
                 user = await this.stores.user.create({
                     username: body.username,
@@ -1058,7 +1056,10 @@ export class AuthController extends PuterController {
                         fingerprint,
                     },
                     signup_ip: clientIp,
-                    signup_ip_forwarded: proxyIpChain,
+                    // The abuse harness and the admin IP lookup both key on
+                    // this column, so it holds the trusted client address; the
+                    // raw forwarded chain stays in `audit_metadata.ip_fwd`.
+                    signup_ip_forwarded: clientIp,
                     signup_user_agent: req.headers?.['user-agent'] ?? null,
                     signup_origin:
                         (req.headers?.origin as string | null) ?? null,
@@ -1162,18 +1163,10 @@ export class AuthController extends PuterController {
                     // a pseudo-user claim ends up with credentials, so it
                     // reports false here. Same signal completeLogin uses.
                     is_temp: user!.password === null && user!.email === null,
-                    ip:
-                        (req?.headers?.['x-forwarded-for'] as
-                            | string
-                            | undefined) ||
-                        (
-                            req as unknown as {
-                                connection?: { remoteAddress?: string };
-                            }
-                        )?.connection?.remoteAddress ||
-                        req?.ip ||
-                        req?.socket?.remoteAddress ||
-                        null,
+                    // Same derivation as the validate event above — the two
+                    // have to agree or per-IP counters are written under one
+                    // key and read under another.
+                    ip: clientIp,
                 } as never,
                 {},
             );

--- a/src/backend/services/auth/OIDCService.test.ts
+++ b/src/backend/services/auth/OIDCService.test.ts
@@ -891,6 +891,51 @@ describe('OIDCService.createUserFromOIDC', () => {
         server.clients.event.off('puter.signup.success', onSignup);
     });
 
+    it('keys the signup abuse signals on req.ip, not the x-forwarded-for header', async () => {
+        const forged = 'evil, 198.51.100.1';
+        const forgedReq = {
+            headers: {
+                'user-agent': 'test-agent',
+                origin: 'https://app.test',
+                'x-forwarded-for': forged,
+            },
+            ip: '203.0.113.9',
+            socket: { remoteAddress: '203.0.113.9' },
+        } as never;
+
+        const seen: Array<Record<string, unknown>> = [];
+        const record = (_k: string, data: unknown) =>
+            seen.push(data as Record<string, unknown>);
+        server.clients.event.on('puter.signup.validate', record);
+        server.clients.event.on('puter.signup.success', record);
+        try {
+            const email = `xff-${crypto.randomBytes(4).toString('hex')}@example.com`;
+            const result = await runWithContext({ req: forgedReq }, () =>
+                oidc().createUserFromOIDC('google', {
+                    sub: `xff-${email}`,
+                    email,
+                    email_verified: true,
+                }),
+            );
+            expect(result.success).toBe(true);
+            // Validate hook, success hook and the persisted lookup column all
+            // have to agree, or a per-IP counter is written under one key and
+            // read under another.
+            expect(seen).toHaveLength(2);
+            for (const event of seen) expect(event.ip).toBe('203.0.113.9');
+
+            const persisted = await server.stores.user.getById(
+                result.user!.id,
+                { force: true },
+            );
+            expect(persisted!.signup_ip).toBe('203.0.113.9');
+            expect(persisted!.signup_ip_forwarded).toBe('203.0.113.9');
+        } finally {
+            server.clients.event.off('puter.signup.validate', record);
+            server.clients.event.off('puter.signup.success', record);
+        }
+    });
+
     it('honours a veto from the signup-validate hook, surfacing its code and trail id', async () => {
         const veto = (_k: string, data: unknown) => {
             const e = data as Record<string, unknown>;

--- a/src/backend/services/auth/OIDCService.ts
+++ b/src/backend/services/auth/OIDCService.ts
@@ -526,12 +526,9 @@ export class OIDCService extends PuterService {
             // (e.g. Turnstile) should skip — abuse/IP/email checks still run.
             source: 'oidc' as const,
             data: { username, email },
-            ip:
-                (req?.headers?.['x-forwarded-for'] as string | undefined) ||
-                req?.connection?.remoteAddress ||
-                req?.ip ||
-                req?.socket?.remoteAddress ||
-                null,
+            // `req.ip` honors `trust proxy`; reading x-forwarded-for directly
+            // would let a client pick its own per-IP abuse bucket.
+            ip: clientIp,
             user_agent: req?.headers?.['user-agent'] ?? null,
             email,
             // See the same field in AuthController: the canonical form
@@ -658,7 +655,10 @@ export class OIDCService extends PuterService {
                     origin: req?.headers?.origin,
                 },
                 signup_ip: clientIp,
-                signup_ip_forwarded: proxyIpChain,
+                // The abuse harness and the admin IP lookup both key on this
+                // column, so it holds the trusted client address; the raw
+                // forwarded chain stays in `audit_metadata.ip_fwd`.
+                signup_ip_forwarded: clientIp,
                 signup_user_agent: req?.headers?.['user-agent'] ?? null,
                 signup_origin: req?.headers?.origin,
                 signup_server: this.config.serverId,
@@ -761,12 +761,10 @@ export class OIDCService extends PuterService {
                     user_uuid: resolved.uuid,
                     email: resolved.email,
                     username: resolved.username,
-                    ip:
-                        req?.headers?.['x-forwarded-for'] ||
-                        req?.connection?.remoteAddress ||
-                        req?.ip ||
-                        req?.socket?.remoteAddress ||
-                        null,
+                    // Same derivation as the validate event above — the two
+                    // have to agree or per-IP counters are written under one
+                    // key and read under another.
+                    ip: clientIp,
                 },
                 {},
             );


### PR DESCRIPTION
Both signup paths read the x-forwarded-for header directly for the puter.signup.validate event, the puter.signup.success event and the signup_ip_forwarded column. Behind an appending proxy a client can prefix that header with anything it likes, which gives every per-IP abuse signal a fresh bucket per request.

req.ip is the value `trust proxy` resolves, so it is the one the server can stand behind; server.ts already uses it for the ip.validate gate for exactly this reason. All three now share one derivation, so a per-IP counter is written and read under the same key. The raw chain is still recorded, but only as audit_metadata.ip_fwd, where nothing keys on it.

Rows written before this hold whatever the proxy appended, so per-IP velocity over the trailing window is undercounted until they age out.