### PR TITLE
fix: honor defaultValue for showFontPicker() in the app environment

### DIFF
--- a/src/gui/src/UI/UIWindowFontPicker.js
+++ b/src/gui/src/UI/UIWindowFontPicker.js
@@ -41,13 +41,16 @@ const font_list = new Set([
 async function UIWindowFontPicker (options) {
     // set sensible defaults
     if ( arguments.length > 0 ) {
-        // if first argument is a string, then assume it is the default color
+        // if first argument is a string, then assume it is the default font
         if ( window.isString(arguments[0]) ) {
             options = {};
             options.default = arguments[0];
         }
     }
     options = options || {};
+    // `defaultValue` and `defaultFont` are aliases for the legacy `default`
+    // option, matching the names puter.js accepts in showFontPicker().
+    const defaultFont = options.defaultValue || options.defaultFont || options.default;
 
     return new Promise(async (resolve) => {
         let h = '';
@@ -55,7 +58,7 @@ async function UIWindowFontPicker (options) {
         h += '<div style="padding: 20px; border-bottom: 1px solid #ced7e1; width: 100%; box-sizing: border-box;">';
         h += '<div class="font-list" style="margin-bottom: 10px; height: 200px; overflow-y: scroll; background-color: white; padding: 0 10px;">';
         fontAvailable.forEach(element => {
-            h += `<p class="font-selector disable-user-select ${options.default === element ? 'font-selector-active' : ''}" style="font-family: '${html_encode(element)}';" data-font-family="${html_encode(element)}">${html_encode(element)}</p>`; // 👉️ one, two, three, four
+            h += `<p class="font-selector disable-user-select ${defaultFont === element ? 'font-selector-active' : ''}" style="font-family: '${html_encode(element)}';" data-font-family="${html_encode(element)}">${html_encode(element)}</p>`; // 👉️ one, two, three, four
         });
         h += '</div>';
 

--- a/src/puter-js/src/modules/UI.js
+++ b/src/puter-js/src/modules/UI.js
@@ -177,6 +177,7 @@ import { checkPermissions } from './perms/lib/holds.js';
  *
  * @typedef {Object} FontPickerOptions
  * @property {string} [defaultFont] The font initially selected when the picker opens.
+ * @property {string} [defaultValue] Alias for `defaultFont`.
  */
 
 /**
@@ -1285,23 +1286,27 @@ export class UIModule extends EventListener {
 
     /**
      * Shows a font picker. Resolves to the chosen font. Accepts either a
-     * default font name or an options object. `default` is a legacy alias for
-     * `defaultFont`.
+     * default font name or an options object. `default` and `defaultFont`
+     * are legacy aliases for `defaultValue`.
      *
-     * @param {string | (FontPickerOptions & { default?: string })} [options]
+     * @param {string | (FontPickerOptions & { default?: string, defaultValue?: string })} [options]
      * @returns {Promise<{ fontFamily: string }>}
      */
     showFontPicker (options) {
+        // `default` and `defaultFont` are legacy aliases for `defaultValue`;
+        // normalize here so both the app-embedded window (below) and the
+        // standalone web component read the same effective value.
+        const opts = typeof options === 'string' ? { defaultValue: options } : (options ?? {});
+        const defaultFont = opts.defaultValue || opts.defaultFont || opts.default || 'System UI';
+
         if ( this.messageTarget ) {
             return new Promise((resolve) => {
-                this.#postMessageWithCallback('showFontPicker', resolve, { options: options ?? {} });
+                this.#postMessageWithCallback('showFontPicker', resolve, { options: { ...opts, defaultValue: defaultFont } });
             });
         }
         // Standalone fallback: render web component
         return new Promise((resolve) => {
-            const opts = typeof options === 'string' ? { defaultFont: options } : (options ?? {});
             const el = document.createElement('puter-font-picker');
-            const defaultFont = opts.defaultFont || opts.default || 'System UI';
             el.setAttribute('default-font', defaultFont);
             el.addEventListener('response', (e) => resolve(e.detail));
             document.body.appendChild(el);


### PR DESCRIPTION
Fixes #2896

`puter.ui.showFontPicker({ defaultValue })` only worked when the SDK
fell back to the standalone `<puter-font-picker>` web component. When
the app runs embedded in the Puter desktop (env=app), the call is
forwarded over postMessage to `IPC.js`, which opens
`UIWindowFontPicker` directly — and that window only ever read
`options.default`, never `defaultFont` or `defaultValue`, so the
pre-selected font was always lost in that environment.

- `src/puter-js/src/modules/UI.js`: `showFontPicker()` now resolves
  `defaultValue`/`defaultFont`/`default` to a single effective value
  once, up front, and uses it identically for both the app (postMessage)
  and standalone (web component) code paths — mirroring the alias
  pattern `showColorPicker()` already uses.
- `src/gui/src/UI/UIWindowFontPicker.js`: now reads
  `options.defaultValue || options.defaultFont || options.default`
  instead of only `options.default`, so the app-embedded picker window
  honors the same aliases the SDK documents.

No behavior change for existing callers using `default`/`defaultFont`.

Tests: `src/gui/**` has no CI test coverage in this repo (verified
against `.github/workflows/*.yaml|yml` — none filter on that path);
verified `src/puter-js` changes with `npm run check:puterjs:types`
and `npm run test:puterjs` locally. Manually traced both the app and
web code paths by hand (no existing test in `components.suite.ts`
covers the font picker's default value either way).
