### PR TITLE
Fix sharing indicator in file picker

### DIFF
--- a/src/gui/src/css/style.css
+++ b/src/gui/src/css/style.css
@@ -692,6 +692,15 @@ span.header-sort-icon img {
     pointer-events: all;
 }
 
+.item-container-list .item-shared-marker,
+.item-container-details .item-shared-marker {
+    width: 7px;
+    height: 7px;
+    right: 0px;
+    bottom: 0px;
+    box-shadow: 0 0 0 1px white;
+}
+
 .item-name, .item-name-editor, .item-name-shadow {
     font-size: 12px;
     color: white;

--- a/src/gui/src/helpers/sharedBadge.js
+++ b/src/gui/src/helpers/sharedBadge.js
@@ -34,7 +34,9 @@ export const has_direct_share = (shares) =>
  */
 export const mark_item_shared = (path, is_shared) => {
     if ( ! path ) return;
-    const $items = $(`.item[data-path="${html_encode(path)}" i]`);
+    const $items = $('.item').filter(function() {
+        return ($(this).attr('data-path') || '').toLowerCase() === path.toLowerCase();
+    });
     $items.attr('data-is_shared', is_shared ? 1 : 0);
     $items
         .find('.item-shared-marker')


### PR DESCRIPTION
## Summary

Fixes #3649.

- Fix the sharing indicator size in list and details views.
- Fix the sharing indicator not updating immediately after sharing/unsharing.
- Avoid encoded-path issues when locating items in the DOM.

## Testing

- Tested sharing an item without refreshing.
- Tested unsharing an item without refreshing.
- Verified the sharing indicator appears/disappears immediately.