### PR TITLE
feat: scoped app access to notifications (PUT-1684)

### DIFF
--- a/src/backend/drivers/notification/NotificationDriver.test.ts
+++ b/src/backend/drivers/notification/NotificationDriver.test.ts
@@ -19,7 +19,7 @@
 
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { v4 as uuidv4 } from 'uuid';
-import type { Actor } from '../../core/actor.js';
+import { makeActor, type Actor } from '../../core/actor.js';
 import { runWithContext } from '../../core/context.js';
 import { PuterServer } from '../../server.js';
 import { setupTestServer } from '../../testUtil.js';
@@ -57,7 +57,7 @@ const makeUser = async (): Promise<{ actor: Actor; userId: number }> => {
     const refreshed = (await server.stores.user.getById(created.id))!;
     return {
         userId: refreshed.id,
-        actor: {
+        actor: makeActor({
             user: {
                 id: refreshed.id,
                 uuid: refreshed.uuid,
@@ -65,9 +65,38 @@ const makeUser = async (): Promise<{ actor: Actor; userId: number }> => {
                 email: refreshed.email ?? null,
                 email_confirmed: true,
             } as Actor['user'],
-        },
+        }),
     };
 };
+
+const makeApp = async (
+    ownerUserId: number,
+): Promise<{ id: number; uid: string }> => {
+    const name = `nd-app-${Math.random().toString(36).slice(2, 10)}`;
+    return (await server.stores.app.create(
+        {
+            name,
+            title: 'Notification driver test',
+            index_url: `https://${name}.test/`,
+        },
+        { ownerUserId },
+    )) as { id: number; uid: string };
+};
+
+/** The holder's token as issued to an app it is running. */
+const asApp = (holder: Actor, app: { id: number; uid: string }): Actor =>
+    makeActor({ user: holder.user, app: { uid: app.uid, id: app.id } });
+
+/** An access token an app minted: `effectiveApp` arrives through the issuer. */
+const asIssuedToken = (holder: Actor, issuer: Actor): Actor =>
+    makeActor({
+        user: holder.user,
+        accessToken: {
+            uid: `tok-${Math.random().toString(36).slice(2)}`,
+            issuer,
+            authorized: null,
+        },
+    });
 
 const withActor = async <T>(actor: Actor, fn: () => Promise<T>): Promise<T> =>
     runWithContext({ actor }, fn);
@@ -115,13 +144,26 @@ describe('NotificationDriver.create', () => {
 
     it('rejects an app-actor with 403', async () => {
         const { actor } = await makeUser();
-        const appActor: Actor = {
-            ...actor,
+        const appActor = makeActor({
+            user: actor.user,
             app: { uid: 'some-app', id: 1 },
-        };
+        });
         await expect(
             withActor(appActor, () =>
                 driver.create({ object: { value: { title: 'app' } } }),
+            ),
+        ).rejects.toMatchObject({ statusCode: 403 });
+    });
+
+    it('rejects a token an app issued with 403', async () => {
+        const { actor } = await makeUser();
+        const issued = asIssuedToken(
+            actor,
+            makeActor({ user: actor.user, app: { uid: 'some-app', id: 1 } }),
+        );
+        await expect(
+            withActor(issued, () =>
+                driver.create({ object: { value: { title: 'token' } } }),
             ),
         ).rejects.toMatchObject({ statusCode: 403 });
     });
@@ -200,13 +242,11 @@ describe('NotificationDriver.select', () => {
         // SQLite's `created_at` is second-precision so two rapid inserts
         // can tie on the ORDER BY column — assert membership, not order.
         expect(result.length).toBe(2);
-        const values = result.map(
-            (r) => (r.value as { i: number }).i,
-        );
+        const values = result.map((r) => (r.value as { i: number }).i);
         expect(values.sort()).toEqual([1, 2]);
     });
 
-    it('does not leak other users\' notifications', async () => {
+    it("does not leak other users' notifications", async () => {
         const a = await makeUser();
         const b = await makeUser();
         await withActor(a.actor, () =>
@@ -227,10 +267,7 @@ describe('NotificationDriver.select', () => {
             driver.create({ object: { value: { i: 'unseen' } } }),
         )) as Record<string, unknown>;
 
-        await server.stores.notification.markShown(
-            seen.uid as string,
-            userId,
-        );
+        await server.stores.notification.markShown(seen.uid as string, userId);
 
         const result = (await withActor(actor, () =>
             driver.select({ predicate: 'unseen' }),
@@ -331,5 +368,367 @@ describe('NotificationDriver.mark_shown / mark_acknowledged', () => {
         // silent no-op. The driver reports the store's `affected = 0`
         // verbatim as `success: false`.
         expect(result.success).toBe(false);
+    });
+});
+
+// ── Audience scoping ────────────────────────────────────────────────
+//
+// One mailbox holding a row per audience, read through each token shape.
+// The rule under test: the holder is shown all of it, an actor holding an
+// app is shown only what that app is the subject of, and `account` rows
+// reach no app at all.
+
+/** Seed a row the way the service writes one, scope columns and all. */
+const seed = async (
+    userId: number,
+    row: {
+        type?: string;
+        audience?: string;
+        appUid?: string | null;
+        value?: unknown;
+    },
+): Promise<string> => {
+    const created = await server.stores.notification.create({
+        userId,
+        value: row.value ?? { title: row.type ?? 'legacy' },
+        type: row.type ?? '',
+        audience: row.audience ?? 'account',
+        appUid: row.appUid ?? null,
+    });
+    return created!.uid as string;
+};
+
+const uidsOf = (rows: unknown): string[] =>
+    (rows as Array<Record<string, unknown>>).map((r) => String(r.uid));
+
+const selectUids = async (
+    actor: Actor,
+    args: Record<string, unknown> = {},
+): Promise<string[]> =>
+    uidsOf(await withActor(actor, () => driver.select(args)));
+
+/**
+ * The holder owns `ownApp` and merely uses `otherApp`; their mailbox has one
+ * row for every (audience, app) combination the matrix asks about.
+ */
+const mailbox = async () => {
+    const holder = await makeUser();
+    const stranger = await makeUser();
+    const ownApp = await makeApp(holder.userId);
+    const otherApp = await makeApp(stranger.userId);
+
+    const rows = {
+        account: await seed(holder.userId, {
+            type: 'share.received',
+            audience: 'account',
+        }),
+        appUser: await seed(holder.userId, {
+            type: 'app.events.ended',
+            audience: 'app-user',
+            appUid: ownApp.uid,
+        }),
+        appUserOfOther: await seed(holder.userId, {
+            type: 'app.events.ended',
+            audience: 'app-user',
+            appUid: otherApp.uid,
+        }),
+        appUserUnattributed: await seed(holder.userId, {
+            type: 'app.events.ended',
+            audience: 'app-user',
+        }),
+        developer: await seed(holder.userId, {
+            type: 'app.events.suspended',
+            audience: 'developer',
+            appUid: ownApp.uid,
+        }),
+        developerOfOther: await seed(holder.userId, {
+            type: 'app.events.suspended',
+            audience: 'developer',
+            appUid: otherApp.uid,
+        }),
+    };
+
+    return {
+        holder,
+        stranger,
+        ownApp,
+        otherApp,
+        rows,
+        ownAppActor: asApp(holder.actor, ownApp),
+        otherAppActor: asApp(holder.actor, otherApp),
+    };
+};
+
+describe('NotificationDriver — select per token type', () => {
+    it('the holder sees every audience and every app', async () => {
+        const box = await mailbox();
+        expect((await selectUids(box.holder.actor)).sort()).toEqual(
+            Object.values(box.rows).sort(),
+        );
+    });
+
+    it('an app token sees its own app-user rows, and its developer rows when the holder owns it', async () => {
+        const box = await mailbox();
+        expect((await selectUids(box.ownAppActor)).sort()).toEqual(
+            [box.rows.appUser, box.rows.developer].sort(),
+        );
+    });
+
+    it('a token that app issued reads exactly as the app does', async () => {
+        const box = await mailbox();
+        const issued = asIssuedToken(box.holder.actor, box.ownAppActor);
+        expect((await selectUids(issued)).sort()).toEqual(
+            [box.rows.appUser, box.rows.developer].sort(),
+        );
+    });
+
+    it('an app the holder does not own yields no developer rows, and no refusal', async () => {
+        const box = await mailbox();
+        expect(await selectUids(box.otherAppActor)).toEqual([
+            box.rows.appUserOfOther,
+        ]);
+    });
+
+    it('an app token held by another user sees nothing of this mailbox', async () => {
+        const box = await mailbox();
+        const theirs = asApp(box.stranger.actor, box.ownApp);
+        expect(await selectUids(theirs)).toEqual([]);
+    });
+
+    it("an app-user row naming no app is the holder's alone", async () => {
+        const box = await mailbox();
+        expect(await selectUids(box.holder.actor)).toContain(
+            box.rows.appUserUnattributed,
+        );
+        expect(await selectUids(box.ownAppActor)).not.toContain(
+            box.rows.appUserUnattributed,
+        );
+        expect(await selectUids(box.otherAppActor)).not.toContain(
+            box.rows.appUserUnattributed,
+        );
+    });
+
+    it('rejects an anonymous caller with 401', async () => {
+        await expect(driver.select({})).rejects.toMatchObject({
+            statusCode: 401,
+        });
+    });
+});
+
+describe('NotificationDriver — subject expansion', () => {
+    it('expands the two-segment form from the actor', async () => {
+        const box = await mailbox();
+        expect(
+            await selectUids(box.ownAppActor, { subject: 'notif:app-user' }),
+        ).toEqual([box.rows.appUser]);
+        expect(
+            await selectUids(box.ownAppActor, { subject: 'notif:developer' }),
+        ).toEqual([box.rows.developer]);
+        expect(
+            await selectUids(box.holder.actor, { subject: 'notif:account' }),
+        ).toEqual([box.rows.account]);
+    });
+
+    it('an app naming another app uid gets an empty list', async () => {
+        const box = await mailbox();
+        expect(
+            await selectUids(box.ownAppActor, {
+                subject: `notif:${box.otherApp.uid}:app-user`,
+            }),
+        ).toEqual([]);
+        expect(
+            await selectUids(box.ownAppActor, {
+                subject: `notif:${box.otherApp.uid}:developer`,
+            }),
+        ).toEqual([]);
+    });
+
+    it("an app naming the holder's own mailbox still gets no account rows", async () => {
+        const box = await mailbox();
+        // The SQL scope selects the row; the predicate is what drops it.
+        expect(
+            await selectUids(box.ownAppActor, {
+                subject: `notif:${box.holder.actor.user.uuid}:account`,
+            }),
+        ).toEqual([]);
+    });
+
+    it('a non-owner asking for developer rows gets an empty list, not a refusal', async () => {
+        const box = await mailbox();
+        expect(
+            await selectUids(box.otherAppActor, { subject: 'notif:developer' }),
+        ).toEqual([]);
+    });
+});
+
+describe('NotificationDriver — read per token type', () => {
+    const readUid = (actor: Actor, uid: string) =>
+        withActor(actor, () => driver.read({ uid }));
+
+    it('the holder reads every row of their mailbox', async () => {
+        const box = await mailbox();
+        for (const uid of Object.values(box.rows)) {
+            expect(await readUid(box.holder.actor, uid)).toMatchObject({ uid });
+        }
+    });
+
+    it('an app reads only what it is the subject of', async () => {
+        const box = await mailbox();
+        expect(await readUid(box.ownAppActor, box.rows.appUser)).toMatchObject({
+            uid: box.rows.appUser,
+        });
+        expect(
+            await readUid(box.ownAppActor, box.rows.developer),
+        ).toMatchObject({ uid: box.rows.developer });
+
+        for (const uid of [
+            box.rows.account,
+            box.rows.appUserOfOther,
+            box.rows.appUserUnattributed,
+            box.rows.developerOfOther,
+        ]) {
+            await expect(readUid(box.ownAppActor, uid)).rejects.toMatchObject({
+                statusCode: 404,
+            });
+        }
+    });
+
+    it('a token that app issued reads as the app does', async () => {
+        const box = await mailbox();
+        const issued = asIssuedToken(box.holder.actor, box.ownAppActor);
+        expect(await readUid(issued, box.rows.appUser)).toMatchObject({
+            uid: box.rows.appUser,
+        });
+        await expect(readUid(issued, box.rows.account)).rejects.toMatchObject({
+            statusCode: 404,
+        });
+    });
+
+    it('a developer row is not found for an app the holder does not own', async () => {
+        const box = await mailbox();
+        await expect(
+            readUid(box.otherAppActor, box.rows.developerOfOther),
+        ).rejects.toMatchObject({ statusCode: 404 });
+    });
+
+    it('a named subject the row is outside of reads as not found', async () => {
+        const box = await mailbox();
+        await expect(
+            withActor(box.holder.actor, () =>
+                driver.read({
+                    uid: box.rows.account,
+                    subject: 'notif:app-user',
+                }),
+            ),
+        ).rejects.toMatchObject({ statusCode: 404 });
+    });
+});
+
+describe('NotificationDriver — marking is bounded by reading', () => {
+    const markShown = (actor: Actor, uid: string) =>
+        withActor(actor, () => driver.mark_shown({ uid })) as Promise<{
+            success: boolean;
+        }>;
+    const markAck = (actor: Actor, uid: string) =>
+        withActor(actor, () => driver.mark_acknowledged({ uid })) as Promise<{
+            success: boolean;
+        }>;
+
+    it('an app marks the rows it can read', async () => {
+        const box = await mailbox();
+        expect(await markShown(box.ownAppActor, box.rows.appUser)).toEqual({
+            success: true,
+        });
+        expect(await markAck(box.ownAppActor, box.rows.developer)).toEqual({
+            success: true,
+        });
+    });
+
+    it('an account row cannot be marked by an app, and stays unmarked', async () => {
+        const box = await mailbox();
+        expect(await markShown(box.ownAppActor, box.rows.account)).toEqual({
+            success: false,
+        });
+        expect(await markAck(box.ownAppActor, box.rows.account)).toEqual({
+            success: false,
+        });
+
+        const row = await server.stores.notification.getByUid(
+            box.rows.account,
+            { userId: box.holder.userId },
+        );
+        expect(row?.shown ?? null).toBeNull();
+        expect(row?.acknowledged ?? null).toBeNull();
+    });
+
+    it("another app's row cannot be marked", async () => {
+        const box = await mailbox();
+        expect(await markShown(box.otherAppActor, box.rows.appUser)).toEqual({
+            success: false,
+        });
+        expect(await markAck(box.ownAppActor, box.rows.appUserOfOther)).toEqual(
+            { success: false },
+        );
+    });
+
+    it('a developer row is unmarkable by an app the holder does not own', async () => {
+        const box = await mailbox();
+        expect(
+            await markShown(box.otherAppActor, box.rows.developerOfOther),
+        ).toEqual({ success: false });
+    });
+
+    it('the holder marks any row of their own mailbox', async () => {
+        const box = await mailbox();
+        for (const uid of Object.values(box.rows)) {
+            expect(await markShown(box.holder.actor, uid)).toEqual({
+                success: true,
+            });
+        }
+    });
+});
+
+describe('NotificationDriver — rows written before the scope columns', () => {
+    /** The shape a pre-migration row has: no type, and the default audience. */
+    const legacyRow = async () => {
+        const holder = await makeUser();
+        const app = await makeApp(holder.userId);
+        const uid = await seed(holder.userId, {
+            value: { source: 'sharing', title: 'shared with you' },
+        });
+        return { holder, app, uid, appActor: asApp(holder.actor, app) };
+    };
+
+    it('defaults to the account audience, so no driver op reaches it as an app', async () => {
+        const { holder, uid, appActor } = await legacyRow();
+
+        expect(await selectUids(appActor)).toEqual([]);
+        expect(
+            await selectUids(appActor, { subject: 'notif:app-user' }),
+        ).toEqual([]);
+        expect(
+            await selectUids(appActor, {
+                subject: `notif:${holder.actor.user.uuid}:account`,
+            }),
+        ).toEqual([]);
+
+        await expect(
+            withActor(appActor, () => driver.read({ uid })),
+        ).rejects.toMatchObject({ statusCode: 404 });
+
+        expect(
+            await withActor(appActor, () => driver.mark_shown({ uid })),
+        ).toEqual({ success: false });
+        expect(
+            await withActor(appActor, () => driver.mark_acknowledged({ uid })),
+        ).toEqual({ success: false });
+
+        // Still the holder's, and still unmarked by the attempts above.
+        const row = await server.stores.notification.getByUid(uid, {
+            userId: holder.userId,
+        });
+        expect(row?.shown ?? null).toBeNull();
+        expect(row?.acknowledged ?? null).toBeNull();
+        expect(await selectUids(holder.actor)).toEqual([uid]);
     });
 });

--- a/src/backend/drivers/notification/NotificationDriver.ts
+++ b/src/backend/drivers/notification/NotificationDriver.ts
@@ -17,17 +17,40 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+import { assertResolvedActor } from '../../core/actor.js';
 import { Context } from '../../core/context.js';
 import { HttpError } from '../../core/http/HttpError.js';
+import { resolveNotifFetch } from '../../services/events/notifFetch.js';
 import {
     DEFAULT_FREE_SUBSCRIPTION,
     DEFAULT_TEMP_SUBSCRIPTION,
 } from '../../services/metering/consts.js';
+import {
+    APP_READABLE_AUDIENCES,
+    canViewNotification,
+    notificationRowScope,
+    ownedAppUids,
+} from '../../services/notification/notificationAudience.js';
 import { PuterDriver } from '../types.js';
 import type { Actor } from '../../core/actor.js';
 import type { DriverConcurrentConfig, DriverRateLimitConfig } from '../meta.js';
 
 const MAX_SELECT_LIMIT = 200;
+
+/** The mailbox slice a call named, in the terms the query takes it. */
+interface MailboxScope {
+    audiences: readonly string[];
+    appUid: string | null;
+}
+
+/** Whether a row belongs to the slice, as the same SQL scope selected it. */
+const inScope = (
+    row: Record<string, unknown>,
+    scope: MailboxScope,
+): boolean => {
+    const { audience, appUid } = notificationRowScope(row);
+    return scope.audiences.includes(audience) && appUid === scope.appUid;
+};
 
 /**
  * Driver exposing the `puter-notifications` interface.
@@ -42,8 +65,17 @@ const MAX_SELECT_LIMIT = 200;
  *
  * Permission model:
  *
- * - Strictly owner-limited — each user can only see their own notifications
- * - No app-actor access (user tokens only)
+ * - Strictly owner-limited — each user can only see their own notifications.
+ * - The holder reads their whole mailbox; an actor holding an app reads the
+ *   `app-user` rows naming that app, plus its `developer` rows when the holder
+ *   owns the app. `account` rows never reach an actor holding an app, and no
+ *   grant changes that. A slice an actor may not see comes back empty rather
+ *   than refused — the mailbox is not an oracle.
+ * - `create` stays holder-only.
+ *
+ * `read` and `select` also take an optional `subject` naming one slice
+ * (`notif:<appUid>:<audience>`); the two-segment form expands from the actor's
+ * own app, so an app never names an app uid.
  *
  * Predicates:
  *
@@ -101,17 +133,18 @@ export class NotificationDriver extends PuterDriver {
     }
 
     async read(args: Record<string, unknown>): Promise<unknown> {
-        const actor = this.#requireUserActor();
+        const actor = this.#requireActor();
         const uid = (args.uid ?? args.id) as string | undefined;
         if (!uid)
             throw new HttpError(400, 'Missing `uid`', {
                 legacyCode: 'bad_request',
             });
 
+        const scope = this.#resolveScope(actor, args.subject);
         const row = await this.stores.notification.getByUid(String(uid), {
             userId: actor.user.id,
         });
-        if (!row)
+        if (!row || !(await this.#readable(actor, row, scope)))
             throw new HttpError(404, 'Notification not found', {
                 legacyCode: 'not_found',
             });
@@ -119,7 +152,7 @@ export class NotificationDriver extends PuterDriver {
     }
 
     async select(args: Record<string, unknown>): Promise<unknown[]> {
-        const actor = this.#requireUserActor();
+        const actor = this.#requireActor();
         const limit = Math.min(
             Number(args.limit ?? MAX_SELECT_LIMIT),
             MAX_SELECT_LIMIT,
@@ -130,47 +163,35 @@ export class NotificationDriver extends PuterDriver {
             ? predicate[0]
             : predicate;
 
-        // Route predicate → store query params
-        let rows: Array<Record<string, unknown>>;
+        const scope = this.#resolveScope(actor, args.subject);
+        const query: {
+            limit: number;
+            scope: MailboxScope | null;
+            filter?: string;
+            onlyUnacknowledged?: boolean;
+        } = { limit, scope };
+
         switch (predicateName) {
             case 'unseen':
-                rows = await this.stores.notification.listByUserId(
-                    actor.user.id,
-                    {
-                        limit,
-                        filter: 'unseen',
-                    },
-                );
+                query.filter = 'unseen';
                 break;
             case 'unacknowledged':
             case 'unacknowledge': // client compat alias
-                rows = await this.stores.notification.listByUserId(
-                    actor.user.id,
-                    {
-                        limit,
-                        onlyUnacknowledged: true,
-                    },
-                );
+                query.onlyUnacknowledged = true;
                 break;
             case 'acknowledged':
             case 'acknowledge': // client compat alias
-                rows = await this.stores.notification.listByUserId(
-                    actor.user.id,
-                    {
-                        limit,
-                        filter: 'acknowledged',
-                    },
-                );
-                break;
-            default:
-                rows = await this.stores.notification.listByUserId(
-                    actor.user.id,
-                    { limit },
-                );
+                query.filter = 'acknowledged';
                 break;
         }
 
-        return rows.map((r) => this.#toClient(r));
+        const rows = await this.stores.notification.listByUserId(
+            actor.user.id,
+            query,
+        );
+        const visible =
+            scope === null ? rows : await this.#visibleRows(actor, rows);
+        return visible.map((r) => this.#toClient(r));
     }
 
     /**
@@ -179,34 +200,28 @@ export class NotificationDriver extends PuterDriver {
      * needs a way to mark what it read.
      */
     async mark_shown(args: Record<string, unknown>): Promise<unknown> {
-        const actor = this.#requireUserActor();
-        const uid = String(args.uid ?? '');
-        if (!uid)
-            throw new HttpError(400, 'Missing `uid`', {
-                legacyCode: 'bad_request',
-            });
-        const ok = await this.stores.notification.markShown(uid, actor.user.id);
-        return { success: ok };
+        const { actor, uid, markable } = await this.#resolveMark(args);
+        const ok =
+            markable &&
+            (await this.stores.notification.markShown(uid, actor.user.id));
+        return { success: !!ok };
     }
 
     /** Mark a notification as acknowledged (user dismissed it), same surface. */
     async mark_acknowledged(args: Record<string, unknown>): Promise<unknown> {
-        const actor = this.#requireUserActor();
-        const uid = String(args.uid ?? '');
-        if (!uid)
-            throw new HttpError(400, 'Missing `uid`', {
-                legacyCode: 'bad_request',
-            });
-        const ok = await this.stores.notification.markAcknowledged(
-            uid,
-            actor.user.id,
-        );
-        return { success: ok };
+        const { actor, uid, markable } = await this.#resolveMark(args);
+        const ok =
+            markable &&
+            (await this.stores.notification.markAcknowledged(
+                uid,
+                actor.user.id,
+            ));
+        return { success: !!ok };
     }
 
     // -- Permissions -------------------------------------------------
 
-    #requireUserActor(): Actor & {
+    #requireActor(): Actor & {
         user: { id: number; uuid: string; username: string };
     } {
         const actor = Context.get('actor') as Actor | undefined;
@@ -218,13 +233,105 @@ export class NotificationDriver extends PuterDriver {
             throw new HttpError(403, 'User actor required', {
                 legacyCode: 'forbidden',
             });
-        // App-under-user actors are not allowed for notifications.
-        if (actor.app)
-            throw new HttpError(403, 'App actors cannot access notifications', {
-                legacyCode: 'forbidden',
-            });
+        // Unresolved is not "no app", and reading it that way here is what
+        // would hand an app the account-wide mailbox.
+        assertResolvedActor(actor);
         return actor as Actor & {
             user: { id: number; uuid: string; username: string };
+        };
+    }
+
+    /** Writing a notification stays the holder's, per the token table. */
+    #requireUserActor(): Actor & {
+        user: { id: number; uuid: string; username: string };
+    } {
+        const actor = this.#requireActor();
+        if (actor.effectiveApp)
+            throw new HttpError(403, 'App actors cannot create notifications', {
+                legacyCode: 'forbidden',
+            });
+        return actor;
+    }
+
+    /**
+     * The slice a call named, or `null` for the holder's whole mailbox. An
+     * actor holding an app always has a slice — its own — so `null` only ever
+     * means the holder asked for everything of theirs.
+     */
+    #resolveScope(actor: Actor, subject: unknown): MailboxScope | null {
+        const appUid = actor.effectiveApp?.uid ?? null;
+        if (subject !== undefined && subject !== null && subject !== '') {
+            const named = resolveNotifFetch(String(subject), {
+                userUuid: String(actor.user.uuid),
+                appUid,
+            });
+            return { audiences: [named.audience], appUid: named.appUid };
+        }
+        if (appUid === null) return null;
+        return { audiences: APP_READABLE_AUDIENCES, appUid };
+    }
+
+    /** The audience predicate over a page, with the developer fact resolved. */
+    async #visibleRows(
+        actor: Actor,
+        rows: Array<Record<string, unknown>>,
+    ): Promise<Array<Record<string, unknown>>> {
+        if (rows.length === 0) return rows;
+        const scopes = rows.map(notificationRowScope);
+        const owned = await ownedAppUids(
+            this.stores.app,
+            Number(actor.user.id),
+            scopes.flatMap((s) =>
+                s.audience === 'developer' && s.appUid ? [s.appUid] : [],
+            ),
+        );
+
+        return rows.filter((_row, i) =>
+            canViewNotification(scopes[i], actor, {
+                recipientOwnsApp: owned.has(scopes[i].appUid ?? ''),
+            }),
+        );
+    }
+
+    /**
+     * Whether one row may be shown. A `null` scope is the holder asking for
+     * their own mailbox with nothing named — all of it is theirs, and the
+     * audience rule is about what an app may be shown.
+     */
+    async #readable(
+        actor: Actor,
+        row: Record<string, unknown>,
+        scope: MailboxScope | null,
+    ): Promise<boolean> {
+        if (scope === null) return true;
+        if (!inScope(row, scope)) return false;
+        return (await this.#visibleRows(actor, [row])).length === 1;
+    }
+
+    /**
+     * A mark is bounded by what the same actor could read: a row it may not be
+     * shown reads as absent, which is the answer marking a uid that does not
+     * exist already gives.
+     */
+    async #resolveMark(args: Record<string, unknown>): Promise<{
+        actor: Actor & { user: { id: number } };
+        uid: string;
+        markable: boolean;
+    }> {
+        const actor = this.#requireActor();
+        const uid = String(args.uid ?? '');
+        if (!uid)
+            throw new HttpError(400, 'Missing `uid`', {
+                legacyCode: 'bad_request',
+            });
+        const row = await this.stores.notification.getByUid(uid, {
+            userId: actor.user.id,
+        });
+        const scope = this.#resolveScope(actor, undefined);
+        return {
+            actor,
+            uid,
+            markable: !!row && (await this.#readable(actor, row, scope)),
         };
     }
 

--- a/src/backend/services/events/EventsService.ts
+++ b/src/backend/services/events/EventsService.ts
@@ -83,7 +83,11 @@ import {
 import type { AclMode, ResourceDescriptor } from '../acl/ACLService.js';
 import { resolveNode } from '../fs/resolveNode.js';
 import { assertActorHasCredits } from '../metering/enforcement.js';
-import { canViewNotification } from '../notification/notificationAudience.js';
+import {
+    canViewNotification,
+    notificationRowScope,
+    ownedAppUids,
+} from '../notification/notificationAudience.js';
 import { notificationsFoldInEnabled } from '../notification/notificationSocket.js';
 import {
     appSocketRoom,
@@ -1426,14 +1430,9 @@ export class EventsService extends PuterService {
                 : false;
 
         return rows.filter((row) =>
-            canViewNotification(
-                {
-                    audience: String(row.audience ?? 'account'),
-                    appUid: (row.app_uid as string | null) ?? null,
-                },
-                actor,
-                { recipientOwnsApp: ownsApp },
-            ),
+            canViewNotification(notificationRowScope(row), actor, {
+                recipientOwnsApp: ownsApp,
+            }),
         );
     }
 
@@ -2488,15 +2487,8 @@ export class EventsService extends PuterService {
 
     /** Whether the mailbox's owner is the owner of the app a row names. */
     async #recipientOwnsApp(userId: number, appUid: string): Promise<boolean> {
-        try {
-            const app = await this.stores.app.getByUid(appUid);
-            return (
-                Number((app as { owner_user_id?: unknown })?.owner_user_id) ===
-                Number(userId)
-            );
-        } catch {
-            return false;
-        }
+        const owned = await ownedAppUids(this.stores.app, userId, [appUid]);
+        return owned.has(appUid);
     }
 
     async #route<C extends EventContextBase, P extends ProjectedEvent>(

--- a/src/backend/services/notification/notificationAudience.ts
+++ b/src/backend/services/notification/notificationAudience.ts
@@ -25,6 +25,16 @@ export interface NotificationRowScope {
     appUid: string | null;
 }
 
+/**
+ * Audiences an actor holding an app can ever be shown, and therefore the only
+ * ones worth querying for it. `account` is absent by construction — the SQL
+ * scope and the predicate have to agree on that, or one of them is decorative.
+ */
+export const APP_READABLE_AUDIENCES: readonly string[] = Object.freeze([
+    'app-user',
+    'developer',
+]);
+
 export interface NotificationVisibilityFacts {
     /**
      * Whether the row's recipient owns the app it names — the `developer`
@@ -68,4 +78,43 @@ export const canViewNotification = (
 
     if (viewingApp !== null && viewingApp !== scope.appUid) return false;
     return scope.audience === 'app-user' || facts.recipientOwnsApp === true;
+};
+
+/** The predicate's input, read off a stored row. */
+export const notificationRowScope = (
+    row: Record<string, unknown>,
+): NotificationRowScope => ({
+    audience: String(row.audience ?? 'account'),
+    appUid: (row.app_uid as string | null) ?? null,
+});
+
+/** The `apps` lookup the developer-audience fact needs. */
+export interface AppOwnerLookup {
+    getByUids: (
+        uids: string[],
+    ) => Promise<Map<string, { owner_user_id?: unknown } | undefined>>;
+}
+
+/**
+ * Which of `appUids` the recipient owns — the fact `developer` rows turn on. A
+ * lookup that fails owns nothing, so the audience stays denied.
+ */
+export const ownedAppUids = async (
+    apps: AppOwnerLookup,
+    userId: number,
+    appUids: readonly string[],
+): Promise<Set<string>> => {
+    const wanted = [...new Set(appUids.filter((uid) => !!uid))];
+    if (wanted.length === 0) return new Set();
+    try {
+        const found = await apps.getByUids(wanted);
+        return new Set(
+            wanted.filter(
+                (uid) =>
+                    Number(found.get(uid)?.owner_user_id) === Number(userId),
+            ),
+        );
+    } catch {
+        return new Set();
+    }
 };

--- a/src/backend/stores/notification/NotificationStore.js
+++ b/src/backend/stores/notification/NotificationStore.js
@@ -37,29 +37,62 @@ export class NotificationStore extends PuterStore {
     }
 
     /**
-     * @param {number} userId @param {{ limit?: number, onlyUnacknowledged?:
-     *   boolean, filter?: string }} [opts]
+     * A mailbox, newest first. `scope` narrows to one audience/app slice on the
+     * way out of the database — `appUid: null` means the rows naming no app,
+     * which is not the same question as "any app".
+     *
+     * @param {number} userId
+     * @param {{
+     *     limit?: number;
+     *     onlyUnacknowledged?: boolean;
+     *     filter?: string;
+     *     scope?: {
+     *         audiences: readonly string[];
+     *         appUid: string | null;
+     *     } | null;
+     * }} [opts]
      */
     async listByUserId(
         userId,
-        { limit = 200, onlyUnacknowledged = false, filter = undefined } = {},
+        {
+            limit = 200,
+            onlyUnacknowledged = false,
+            filter = undefined,
+            scope = null,
+        } = {},
     ) {
-        let extraWhere = '';
+        const where = ['`user_id` = ?'];
+        const params = [userId];
+
         if (onlyUnacknowledged || filter === 'unacknowledged') {
-            extraWhere = 'AND `acknowledged` IS NULL';
+            where.push('`acknowledged` IS NULL');
         } else if (filter === 'unseen') {
-            extraWhere = 'AND `shown` IS NULL AND `acknowledged` IS NULL';
+            where.push('`shown` IS NULL', '`acknowledged` IS NULL');
         } else if (filter === 'acknowledged') {
-            extraWhere = 'AND `acknowledged` IS NOT NULL';
+            where.push('`acknowledged` IS NOT NULL');
         }
+
+        if (scope) {
+            if (scope.audiences.length === 0) return [];
+            const placeholders = scope.audiences.map(() => '?').join(', ');
+            where.push(`\`audience\` IN (${placeholders})`);
+            params.push(...scope.audiences);
+            if (scope.appUid === null) {
+                where.push('`app_uid` IS NULL');
+            } else {
+                where.push('`app_uid` = ?');
+                params.push(scope.appUid);
+            }
+        }
+
         const n = Number(limit);
         const safeLimit = Number.isFinite(n) ? Math.max(0, Math.floor(n)) : 200;
         const rows = await this.clients.db.read(
             `SELECT * FROM \`notification\`
-             WHERE \`user_id\` = ? ${extraWhere}
+             WHERE ${where.join(' AND ')}
              ORDER BY \`created_at\` DESC, \`id\` DESC
              LIMIT ?`,
-            [userId, safeLimit],
+            [...params, safeLimit],
         );
         return rows.map((r) => this.#normalizeRow(r));
     }

--- a/src/backend/stores/notification/NotificationStore.test.js
+++ b/src/backend/stores/notification/NotificationStore.test.js
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2024-present Puter Technologies Inc.
  *
  * This file is part of Puter.
@@ -208,6 +208,64 @@ describe('NotificationStore', () => {
         ).toEqual([acked.uid]);
     });
 
+    it('narrows a listing to one audience/app slice', async () => {
+        const u = await makeUser();
+        const appUid = `app-${uuidv4()}`;
+        const account = await store.create({ userId: u.id, value: {} });
+        const mine = await store.create({
+            userId: u.id,
+            value: {},
+            audience: 'app-user',
+            appUid,
+        });
+        const unattributed = await store.create({
+            userId: u.id,
+            value: {},
+            audience: 'app-user',
+        });
+
+        const uids = (rows) => rows.map((r) => r.uid).sort();
+
+        expect(
+            uids(
+                await store.listByUserId(u.id, {
+                    scope: { audiences: ['app-user'], appUid },
+                }),
+            ),
+        ).toEqual([mine.uid]);
+        // `null` asks for the rows naming no app, not for any app.
+        expect(
+            uids(
+                await store.listByUserId(u.id, {
+                    scope: { audiences: ['app-user'], appUid: null },
+                }),
+            ),
+        ).toEqual([unattributed.uid]);
+        expect(
+            uids(
+                await store.listByUserId(u.id, {
+                    scope: {
+                        audiences: ['app-user', 'developer'],
+                        appUid: null,
+                    },
+                    filter: 'unseen',
+                }),
+            ),
+        ).toEqual([unattributed.uid]);
+        expect(
+            uids(
+                await store.listByUserId(u.id, {
+                    scope: { audiences: ['account'], appUid: null },
+                }),
+            ),
+        ).toEqual([account.uid]);
+        expect(
+            await store.listByUserId(u.id, {
+                scope: { audiences: [], appUid: null },
+            }),
+        ).toEqual([]);
+    });
+
     it('ignores an unrecognised filter and returns everything', async () => {
         const u = await makeUser();
         await store.create({ userId: u.id, value: {} });
@@ -287,7 +345,10 @@ describe('NotificationStore', () => {
         const u = await makeUser();
         const old = await store.create({ userId: u.id, value: { n: 'old' } });
         const alsoOld = await store.create({ userId: u.id, value: { n: '2' } });
-        const recent = await store.create({ userId: u.id, value: { n: 'new' } });
+        const recent = await store.create({
+            userId: u.id,
+            value: { n: 'new' },
+        });
         await backdate(old.uid, 20);
         await backdate(alsoOld.uid, 15);
         await backdate(recent.uid, 13);


### PR DESCRIPTION
An actor holding an app reads the `app-user` rows naming that app, plus its
`developer` rows when the holder owns it. `account` rows reach no app, and a
slice an actor may not see comes back empty rather than refused. The audience
predicate becomes the enforced read path in the same change that lifts the
blanket app-actor 403, layered behind an audience/app_uid SQL scope; two-segment
`notif:` subjects expand server-side from the actor's own app, so an app can
never name another app's uid.

No feature flag: `audience` defaults to 'account', so every pre-registry row is
default-denied to app actors and the backfill can only narrow.

---
Stacked on `DS/put-1681` — review only this PR's diff; merges bottom-up.