### PR TITLE
fix: cover the apps summary's no-app-group first page (PUT-1670)

### DIFF
--- a/src/backend/controllers/share/ShareController.http.test.ts
+++ b/src/backend/controllers/share/ShareController.http.test.ts
@@ -543,6 +543,68 @@ describe('share endpoints over HTTP', () => {
             ).json()) as { items: Array<{ uid: string }> };
             expect(after.items).toEqual([]);
         });
+
+        it('reads the grant audit trail, and keeps it after a revoke', async () => {
+            const { owner, recipient, files, apps } = await twoApps();
+
+            const trail = async (token: string, params = {}) =>
+                (await (await get('/share/audit', token, params)).json()) as {
+                    items: Array<Record<string, unknown>>;
+                    total?: number;
+                };
+
+            const granted = await trail(owner.token, {
+                uid: files[0].uid,
+                includeTotal: 'true',
+            });
+            expect(granted.total).toBe(granted.items.length);
+            expect(granted.items[0]).toMatchObject({
+                action: 'grant',
+                entryUid: files[0].uid,
+                issuer: owner.username,
+                holder: recipient.username,
+                appUid: apps[0].uid,
+            });
+            // Nothing internal rides along.
+            for (const key of ['issuer_user_id', 'holder_user_id', 'reason']) {
+                expect(granted.items[0]).not.toHaveProperty(key);
+            }
+
+            await post('/share/revoke', owner.token, {
+                recipients: [recipient.username],
+                items: [{ uid: files[0].uid }],
+            });
+            const afterRevoke = await trail(owner.token, {
+                uid: files[0].uid,
+            });
+            expect(
+                afterRevoke.items.map((i) => i.action),
+            ).toEqual(expect.arrayContaining(['grant', 'revoke']));
+        });
+
+        it('will not hand one account the trail of another\'s', async () => {
+            const { files } = await twoApps();
+            const stranger = await makeUser();
+
+            const res = await get('/share/audit', stranger.token, {
+                uid: files[0].uid,
+            });
+            expect(res.status).toBe(404);
+
+            // Their own listing is theirs alone, and they have granted nothing.
+            const own = (await (
+                await get('/share/audit', stranger.token, {})
+            ).json()) as { items: unknown[] };
+            expect(own.items).toEqual([]);
+        });
+
+        it('keeps the audit trail off app tokens', async () => {
+            const { apps, files } = await twoApps();
+            const res = await get('/share/audit', apps[0].token, {
+                uid: files[0].uid,
+            });
+            expect(res.status).toBe(403);
+        });
     });
 
     it('revokes every item in the request, not just the first', async () => {

--- a/src/backend/controllers/share/ShareController.ts
+++ b/src/backend/controllers/share/ShareController.ts
@@ -410,6 +410,50 @@ export class ShareController extends PuterController {
         });
     }
 
+    /**
+     * GET /share/audit — when a grant was made, by whom, and under which app.
+     *
+     * With `uid` or `path`, the trail of everything granted on that item, for
+     * whoever may manage it; with neither, the trail of what the caller
+     * granted. Rows outlive the grants they describe, so this still answers
+     * after a revoke.
+     */
+    @Get('/audit', {
+        subdomain: 'api',
+        requireUserActor: true,
+        requireVerified: true,
+        rateLimit: SHARE_LIST_LIMIT,
+    })
+    async listGrantAudit(req: Request, res: Response): Promise<void> {
+        const actor = this.#requireActor(req);
+        const query = this.#query(req);
+        const target: ShareTarget = {};
+        if (typeof query.uid === 'string') target.uid = query.uid;
+        if (typeof query.path === 'string')
+            target.path = expandTildePath(query.path, actor.user?.username);
+
+        const page = await this.services.share.listGrantAudit(actor, target, {
+            limit: normalizeLimit(query.limit, { cap: LIST_LIMIT_CAP }),
+            cursor: typeof query.cursor === 'string' ? query.cursor : undefined,
+            includeTotal: query.includeTotal === 'true',
+        });
+
+        res.json({
+            items: page.items.map((entry) => ({
+                action: entry.action,
+                permission: entry.permission,
+                entryUid: entry.entryUid,
+                mode: entry.mode,
+                issuer: entry.issuer.username,
+                holder: entry.holder.username,
+                appUid: entry.appUid,
+                createdAt: entry.createdAt,
+            })),
+            ...(page.cursor ? { cursor: page.cursor } : {}),
+            ...(page.total !== undefined ? { total: page.total } : {}),
+        });
+    }
+
     // -- Blocking -----------------------------------------------------
     // User sessions only: a block list is a safety control, not an app's to touch.
 

--- a/src/backend/services/permission/PermissionService.ts
+++ b/src/backend/services/permission/PermissionService.ts
@@ -869,6 +869,7 @@ export class PermissionService extends PuterService {
                 permission,
                 action: 'grant',
                 reason: meta.reason ?? 'granted via PermissionService',
+                extra: this.#auditActorContext(actor),
             })
             .catch((err) => {
                 console.warn(
@@ -963,6 +964,7 @@ export class PermissionService extends PuterService {
                     permission,
                     action: 'revoke',
                     reason: meta.reason ?? 'revoked via PermissionService',
+                    extra: this.#auditActorContext(actor),
                 })
                 .catch((err) => {
                     console.warn(
@@ -976,6 +978,27 @@ export class PermissionService extends PuterService {
         // skipping the bump on a no-op risks leaving a cached allow standing.
         if (user.uuid) await this.#bumpUserCacheGeneration(user.uuid);
         return revoked;
+    }
+
+    /**
+     * What an audit row records about who was acting: which app asked, which is
+     * the whole question for anything minted under a standing consent.
+     *
+     * A user-user grant belongs to the user, so callers deliberately hand this
+     * layer an app-less actor (`userRelatedActor`) — the app survives only on
+     * the request actor, and is taken from there when it is the same user
+     * acting. A different user in scope is a background pass on someone else's
+     * behalf, whose app says nothing about this grant.
+     */
+    #auditActorContext(actor: Actor): Record<string, unknown> | null {
+        const requestActor = Context.get('actor') as Actor | undefined;
+        const acting =
+            actor.effectiveApp ??
+            actor.app ??
+            (requestActor?.user?.id === actor.user?.id
+                ? (requestActor?.effectiveApp ?? requestActor?.app)
+                : null);
+        return acting?.uid ? { appUid: acting.uid } : null;
     }
 
     /**

--- a/src/backend/services/share/ShareService.test.ts
+++ b/src/backend/services/share/ShareService.test.ts
@@ -1378,6 +1378,245 @@ describe('ShareService', () => {
             await revokeByUid(asApp(owner, apps[1]), listed.items[0].uid);
             expect(await canRead(recipient.actor, files[1].path)).toBe(false);
         });
+
+        it('lets the owner revoke a delegate-issued share, leaving the delegate itself alone', async () => {
+            const owner = await makeUser();
+            const delegate = await makeUser();
+            const third = await makeUser();
+            const file = await makeFile(owner.user);
+
+            await share(owner.actor, {
+                uid: file.uuid,
+                recipient: { username: delegate.user.username },
+                mode: 'manage',
+            });
+            await share(delegate.actor, {
+                uid: file.uuid,
+                recipient: { username: third.user.username },
+                mode: 'read',
+            });
+            expect(await canRead(third.actor, file.path)).toBe(true);
+
+            // The owner's own listing includes what the delegate issued.
+            const listed = await listSharedByMe(owner.actor);
+            const delegateRow = listed.items.find(
+                (i) => i.holder.username === third.user.username,
+            );
+            expect(delegateRow).toBeDefined();
+
+            await revokeByUid(owner.actor, delegateRow!.uid);
+
+            // The third party's access is gone; the delegate's own manage
+            // grant — issued by the owner, not by the delegate — is untouched.
+            expect(await canRead(third.actor, file.path)).toBe(false);
+            expect(await canRead(delegate.actor, file.path)).toBe(true);
+        });
+    });
+
+    describe('the grant audit trail', () => {
+        const audit = (
+            actor: Actor,
+            target?: Record<string, unknown>,
+            opts?: { limit?: number; cursor?: string; includeTotal?: boolean },
+        ) =>
+            runWithContext({ actor }, () =>
+                server.services.share.listGrantAudit(
+                    actor,
+                    target as never,
+                    opts,
+                ),
+            );
+
+        it('names when a grant was made, by whom, and under which app', async () => {
+            const owner = await makeUser();
+            const recipient = await makeUser();
+            const app = await makeApp(owner.user.id);
+            const file = await makeFile(owner.user);
+            await grantAppReach(owner, app, file);
+
+            await share(asApp(owner, app), {
+                uid: file.uuid,
+                recipient: { username: recipient.user.username },
+                mode: 'read',
+            });
+
+            const trail = await audit(
+                owner.actor,
+                { uid: file.uuid },
+                { includeTotal: true },
+            );
+            expect(trail.total).toBe(trail.items.length);
+            const granted = trail.items.filter((i) => i.action === 'grant');
+            expect(granted.length).toBeGreaterThan(0);
+            for (const row of granted) {
+                expect(row.entryUid).toBe(file.uuid);
+                expect(row.issuer.username).toBe(owner.user.username);
+                expect(row.holder.username).toBe(recipient.user.username);
+                expect(row.appUid).toBe(app.uid);
+                expect(row.createdAt).toBeDefined();
+            }
+            expect(granted.map((i) => i.mode)).toContain('read');
+        });
+
+        it('carries no app for a grant the user made themselves', async () => {
+            const owner = await makeUser();
+            const recipient = await makeUser();
+            const file = await makeFile(owner.user);
+
+            await share(owner.actor, {
+                uid: file.uuid,
+                recipient: { username: recipient.user.username },
+                mode: 'read',
+            });
+
+            const trail = await audit(owner.actor, { uid: file.uuid });
+            expect(trail.items.every((i) => i.appUid === null)).toBe(true);
+        });
+
+        // The grant is gone by then; the row is the only record left of it.
+        it('still reads after the grant is revoked, and says so', async () => {
+            const owner = await makeUser();
+            const recipient = await makeUser();
+            const file = await makeFile(owner.user);
+
+            await share(owner.actor, {
+                uid: file.uuid,
+                recipient: { username: recipient.user.username },
+                mode: 'read',
+            });
+            await unshare(owner.actor, {
+                uid: file.uuid,
+                recipient: { username: recipient.user.username },
+            });
+            expect(await canRead(recipient.actor, file.path)).toBe(false);
+
+            const trail = await audit(owner.actor, { uid: file.uuid });
+            const actions = new Set(trail.items.map((i) => i.action));
+            expect(actions.has('grant')).toBe(true);
+            expect(actions.has('revoke')).toBe(true);
+            expect(
+                trail.items.every(
+                    (i) => i.holder.username === recipient.user.username,
+                ),
+            ).toBe(true);
+        });
+
+        it('shows the owner what a delegate granted on their item', async () => {
+            const owner = await makeUser();
+            const delegate = await makeUser();
+            const third = await makeUser();
+            const file = await makeFile(owner.user);
+
+            await share(owner.actor, {
+                uid: file.uuid,
+                recipient: { username: delegate.user.username },
+                mode: 'manage',
+            });
+            await share(delegate.actor, {
+                uid: file.uuid,
+                recipient: { username: third.user.username },
+                mode: 'read',
+            });
+
+            const trail = await audit(owner.actor, { uid: file.uuid });
+            const issuers = new Set(trail.items.map((i) => i.issuer.username));
+            expect(issuers).toEqual(
+                new Set([owner.user.username, delegate.user.username]),
+            );
+        });
+
+        it('lists what the caller granted when no item is named', async () => {
+            const owner = await makeUser();
+            const other = await makeUser();
+            const recipient = await makeUser();
+            const mine = await makeFile(owner.user);
+            const theirs = await makeFile(other.user);
+
+            await share(owner.actor, {
+                uid: mine.uuid,
+                recipient: { username: recipient.user.username },
+                mode: 'read',
+            });
+            await share(other.actor, {
+                uid: theirs.uuid,
+                recipient: { username: recipient.user.username },
+                mode: 'read',
+            });
+
+            const trail = await audit(owner.actor);
+            expect(trail.items.length).toBeGreaterThan(0);
+            expect(
+                trail.items.every(
+                    (i) => i.issuer.username === owner.user.username,
+                ),
+            ).toBe(true);
+            expect(
+                trail.items.some((i) => i.entryUid === theirs.uuid),
+            ).toBe(false);
+        });
+
+        it('refuses the trail of an item the caller cannot manage', async () => {
+            const owner = await makeUser();
+            const stranger = await makeUser();
+            const recipient = await makeUser();
+            const file = await makeFile(owner.user);
+            await share(owner.actor, {
+                uid: file.uuid,
+                recipient: { username: recipient.user.username },
+                mode: 'read',
+            });
+
+            await expect(
+                audit(stranger.actor, { uid: file.uuid }),
+            ).rejects.toMatchObject({ statusCode: 404 });
+            // Holding the share is not authority over what else was granted.
+            await expect(
+                audit(recipient.actor, { uid: file.uuid }),
+            ).rejects.toMatchObject({ statusCode: 403 });
+        });
+
+        it('walks every page through the cursor', async () => {
+            const owner = await makeUser();
+            const recipient = await makeUser();
+            const file = await makeFile(owner.user);
+
+            await share(owner.actor, {
+                uid: file.uuid,
+                recipient: { username: recipient.user.username },
+                mode: 'read',
+            });
+            await unshare(owner.actor, {
+                uid: file.uuid,
+                recipient: { username: recipient.user.username },
+            });
+
+            const all = await audit(
+                owner.actor,
+                { uid: file.uuid },
+                { includeTotal: true },
+            );
+            expect(all.total).toBe(all.items.length);
+
+            const seen: string[] = [];
+            let cursor: string | undefined;
+            for (let page = 0; page < all.items.length + 2; page++) {
+                const listed = await audit(
+                    owner.actor,
+                    { uid: file.uuid },
+                    { limit: 1, cursor },
+                );
+                seen.push(
+                    ...listed.items.map((i) => `${i.action}:${i.permission}`),
+                );
+                cursor = listed.cursor;
+                if (!cursor) break;
+            }
+
+            expect(cursor).toBeUndefined();
+            expect(seen).toEqual(
+                all.items.map((i) => `${i.action}:${i.permission}`),
+            );
+        });
     });
 
     it('takes downstream access with a delegate who leaves', async () => {

--- a/src/backend/services/share/ShareService.ts
+++ b/src/backend/services/share/ShareService.ts
@@ -29,6 +29,7 @@ import {
     isProviderCanonicalized,
 } from '../../util/email.js';
 import type { FSEntry } from '../../stores/fs/FSEntry';
+import type { UserUserAuditFilter } from '../../stores/permission/PermissionStore';
 import type { UserRow } from '../../stores/user/UserStore';
 import type { AclMode } from '../acl/ACLService';
 import {
@@ -85,6 +86,25 @@ interface GrantEvidence {
     unattributed: boolean;
     /** The holder owns the entry outright, so no grant is needed. */
     owned: boolean;
+}
+
+/**
+ * One entry in the grant audit trail. Written when a grant is made or
+ * withdrawn, and kept afterwards — the row is what remains once the grant
+ * itself is gone.
+ */
+export interface GrantAuditEntry {
+    /** 'grant' or 'revoke'; null on a row that predates the column. */
+    action: string | null;
+    permission: string;
+    /** Set when the grant names an fs node; other permissions carry neither. */
+    entryUid: string | null;
+    mode: string | null;
+    issuer: { username: string | null };
+    holder: { username: string | null };
+    /** The app that was acting, when one was. */
+    appUid: string | null;
+    createdAt: unknown;
 }
 
 /** One app in the outbound listing's group-by-app view. */
@@ -195,6 +215,15 @@ export const uuidFromEntryPermission = (permission: string): string | null => {
     const fsAt = parts[0] === MANAGE_PERM_PREFIX ? 1 : 0;
     if (parts[fsAt] !== 'fs') return null;
     return parts[fsAt + 1] || null;
+};
+
+/** The share mode a grant stands for, for the two shapes above. */
+export const modeFromEntryPermission = (permission: string): string | null => {
+    if (!uuidFromEntryPermission(permission)) return null;
+    const parts = permission.split(':');
+    return parts[0] === MANAGE_PERM_PREFIX
+        ? MANAGE_PERM_PREFIX
+        : (parts[2] ?? null);
 };
 
 /**
@@ -1713,6 +1742,75 @@ export class ShareService extends PuterService {
         return this.#withdrawGrants(actor, entry, holder, [
             Number(row.issuer_user_id),
         ]);
+    }
+
+    /**
+     * When a grant was made, by which actor, and under which app.
+     *
+     * Named with an item, this is everything granted on it, whoever granted it
+     * — which is what an owner is left with after a revoke, the grant itself
+     * being gone by then. Named with nothing, it is what the caller granted,
+     * wherever it landed. Between them they cover the caller's own trail and
+     * their items', and nothing else: authority over the item is the gate on
+     * the first, and being the issuer is the whole of the second.
+     */
+    async listGrantAudit(
+        actor: Actor,
+        target: ShareTarget = {},
+        opts: { limit?: number; cursor?: string; includeTotal?: boolean } = {},
+    ): Promise<{
+        items: GrantAuditEntry[];
+        cursor?: string;
+        total?: number;
+    }> {
+        const userId = this.#requireUserId(actor);
+
+        let filter: UserUserAuditFilter;
+        if (target.uid || target.path) {
+            const entry = await this.#resolveEntry(target, actor);
+            await this.#assertCanManage(actor, entry);
+            filter = { permissions: entryPermissions(entry.uuid) };
+        } else {
+            filter = { issuerUserId: userId };
+        }
+
+        const page = await this.stores.permission.listUserUserAudit(filter, {
+            limit: opts.limit,
+            cursor: opts.cursor,
+        });
+        const users = await this.stores.user.getByIds(
+            page.items.flatMap((row) =>
+                [row.issuer_user_id, row.holder_user_id].filter(
+                    (id): id is number => typeof id === 'number',
+                ),
+            ),
+        );
+        const username = (id: number | null) =>
+            id === null ? null : (users.get(id)?.username ?? null);
+
+        return {
+            items: page.items.map((row) => ({
+                action: row.action,
+                permission: row.permission,
+                entryUid: uuidFromEntryPermission(row.permission),
+                mode: modeFromEntryPermission(row.permission),
+                issuer: { username: username(row.issuer_user_id) },
+                holder: { username: username(row.holder_user_id) },
+                appUid:
+                    typeof row.extra?.appUid === 'string'
+                        ? row.extra.appUid
+                        : null,
+                createdAt: row.created_at,
+            })),
+            ...(page.cursor ? { cursor: page.cursor } : {}),
+            ...(opts.includeTotal
+                ? {
+                      total: await this.stores.permission.countUserUserAudit(
+                          filter,
+                      ),
+                  }
+                : {}),
+        };
     }
 
     /**

--- a/src/backend/stores/permission/PermissionStore.test.ts
+++ b/src/backend/stores/permission/PermissionStore.test.ts
@@ -1010,4 +1010,92 @@ describe('PermissionStore', () => {
             ).toBe(false);
         });
     });
+
+    describe('the user-to-user audit trail', () => {
+        const record = (
+            issuerUserId: number,
+            holderUserId: number,
+            permission: string,
+            action: 'grant' | 'revoke',
+            extra: Record<string, unknown> | null = null,
+        ) =>
+            store.auditUserUserPerm({
+                holder_user_id: holderUserId,
+                issuer_user_id: issuerUserId,
+                permission,
+                action,
+                reason: 'test',
+                extra,
+            });
+
+        it('reads rows back newest first, with what was recorded on them', async () => {
+            const issuer = await makeUser();
+            const holder = await makeUser();
+            const permission = `fs:${uuidv4()}:read`;
+            const appUid = uuidv4();
+
+            await record(issuer.id, holder.id, permission, 'grant', { appUid });
+            await record(issuer.id, holder.id, permission, 'revoke');
+
+            const page = await store.listUserUserAudit({ permissions: [permission] });
+            expect(page.items.map((r) => r.action)).toEqual(['revoke', 'grant']);
+            expect(page.items[1].extra).toEqual({ appUid });
+            expect(page.items[1].issuer_user_id).toBe(issuer.id);
+            expect(page.items[1].holder_user_id).toBe(holder.id);
+            expect(
+                await store.countUserUserAudit({ permissions: [permission] }),
+            ).toBe(2);
+        });
+
+        it('pages backwards through the cursor', async () => {
+            const issuer = await makeUser();
+            const holder = await makeUser();
+            const permission = `fs:${uuidv4()}:read`;
+            for (let i = 0; i < 3; i++) {
+                await record(issuer.id, holder.id, permission, 'grant');
+            }
+
+            const seen: number[] = [];
+            let cursor: string | undefined;
+            for (let guard = 0; guard < 10; guard++) {
+                const page = await store.listUserUserAudit(
+                    { permissions: [permission] },
+                    { limit: 1, cursor },
+                );
+                seen.push(...page.items.map((r) => r.id));
+                cursor = page.cursor;
+                if (!cursor) break;
+            }
+
+            expect(seen).toHaveLength(3);
+            expect([...seen].sort((a, b) => b - a)).toEqual(seen);
+            expect(cursor).toBeUndefined();
+        });
+
+        it('narrows to one issuer, and refuses to read the table unfiltered', async () => {
+            const issuer = await makeUser();
+            const other = await makeUser();
+            const holder = await makeUser();
+            const permission = `fs:${uuidv4()}:read`;
+
+            await record(issuer.id, holder.id, permission, 'grant');
+            await record(other.id, holder.id, permission, 'grant');
+
+            const page = await store.listUserUserAudit({
+                issuerUserId: issuer.id,
+            });
+            expect(page.items.every((r) => r.issuer_user_id === issuer.id)).toBe(
+                true,
+            );
+            await expect(store.listUserUserAudit({})).rejects.toThrow(
+                /requires a filter/u,
+            );
+        });
+
+        it('matches nothing for an empty permission list', async () => {
+            const page = await store.listUserUserAudit({ permissions: [] });
+            expect(page.items).toEqual([]);
+            expect(await store.countUserUserAudit({ permissions: [] })).toBe(0);
+        });
+    });
 });

--- a/src/backend/stores/permission/PermissionStore.ts
+++ b/src/backend/stores/permission/PermissionStore.ts
@@ -28,6 +28,7 @@ import {
     PERMISSION_SCAN_CACHE_TTL_SECONDS,
 } from '../../services/permission/consts';
 import { kv } from '../../util/kvSingleton';
+import { decodeCursor, encodeCursor } from '../../util/pagination';
 import type { UserRow } from '../user/UserStore';
 
 // Short TTLs: FK CASCADE on user/app delete + PermissionService rewriters
@@ -35,6 +36,9 @@ import type { UserRow } from '../user/UserStore';
 const U2A_CACHE_TTL_SECONDS = 5 * 60;
 const U2U_CACHE_TTL_SECONDS = 5 * 60;
 const TOKEN_CACHE_TTL_SECONDS = 10 * 60;
+
+const AUDIT_PAGE_SIZE = 50;
+const MAX_AUDIT_PAGE_SIZE = 200;
 
 // Re-export for back-compat — PermissionService et al. import `UserRow` from here.
 // The canonical definition lives in `UserStore`, which owns the user table.
@@ -82,7 +86,28 @@ export interface AccessTokenPermRow {
 export interface AuditEntry {
     action: 'grant' | 'revoke';
     reason: string;
+    /** Recorded on the row, and read back by whoever reads the trail. */
+    extra?: Record<string, unknown> | null;
     [k: string]: unknown;
+}
+
+/** One user-to-user audit row, as read back. */
+export interface UserUserAuditRow {
+    id: number;
+    /** Null once that account is deleted; the FK columns are ON DELETE SET NULL. */
+    issuer_user_id: number | null;
+    holder_user_id: number | null;
+    permission: string;
+    action: string | null;
+    extra: Record<string, unknown> | null;
+    created_at: unknown;
+}
+
+/** What a read of the user-to-user audit trail may be narrowed to. */
+export interface UserUserAuditFilter {
+    issuerUserId?: number;
+    holderUserId?: number;
+    permissions?: string[];
 }
 
 /** One entry in the flat KV view, as addressed by a delete. */
@@ -502,17 +527,121 @@ export class PermissionStore extends PuterStore {
         await this.clients.db.write(
             'INSERT INTO `audit_user_to_user_permissions` (' +
                 '`holder_user_id`, `holder_user_id_keep`, `issuer_user_id`, `issuer_user_id_keep`, ' +
-                '`permission`, `action`, `reason`) VALUES (?, ?, ?, ?, ?, ?, ?)',
+                '`permission`, `extra`, `action`, `reason`) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
             [
                 entry.holder_user_id,
                 entry.holder_user_id,
                 entry.issuer_user_id,
                 entry.issuer_user_id,
                 entry.permission,
+                entry.extra ? JSON.stringify(entry.extra) : null,
                 entry.action,
                 entry.reason,
             ],
         );
+    }
+
+    /**
+     * The user-to-user audit trail, newest first, keyset-paginated on `id`.
+     *
+     * Rows are never deleted with the grant they describe, so this answers when
+     * something was granted long after it was withdrawn. The caller decides who
+     * may see which rows and narrows `filter` accordingly — this applies it, it
+     * does not authorize it.
+     */
+    async listUserUserAudit(
+        filter: UserUserAuditFilter,
+        opts: { limit?: number; cursor?: string } = {},
+    ): Promise<{ items: UserUserAuditRow[]; cursor?: string }> {
+        const size = Math.min(
+            Math.max(1, Math.floor(Number(opts.limit) || AUDIT_PAGE_SIZE)),
+            MAX_AUDIT_PAGE_SIZE,
+        );
+        const decoded = decodeCursor(opts.cursor, 'audit cursor');
+        const beforeId = Number(decoded?.id ?? 0) || null;
+        const { sql, params } = this.#auditWhere(filter);
+
+        const rows = await this.clients.db.read(
+            'SELECT * FROM `audit_user_to_user_permissions` WHERE ' +
+                sql +
+                (beforeId === null ? '' : ' AND `id` < ?') +
+                ' ORDER BY `id` DESC LIMIT ?',
+            [...params, ...(beforeId === null ? [] : [beforeId]), size + 1],
+        );
+
+        const hasMore = rows.length > size;
+        const items = rows.slice(0, size).map((row) => this.#auditRow(row));
+        const last = items[items.length - 1];
+        return {
+            items,
+            cursor: hasMore && last ? encodeCursor({ id: last.id }) : undefined,
+        };
+    }
+
+    /** How many rows `listUserUserAudit` walks under the same filter. */
+    async countUserUserAudit(filter: UserUserAuditFilter): Promise<number> {
+        const { sql, params } = this.#auditWhere(filter);
+        const rows = await this.clients.db.read(
+            'SELECT COUNT(*) AS `count` FROM `audit_user_to_user_permissions` ' +
+                `WHERE ${sql}`,
+            params,
+        );
+        return Number(rows[0]?.count ?? 0);
+    }
+
+    /**
+     * The filter as SQL. An empty filter would read the whole table, so it is
+     * refused rather than quietly returning everyone's trail.
+     */
+    #auditWhere(filter: UserUserAuditFilter): {
+        sql: string;
+        params: unknown[];
+    } {
+        const clauses: string[] = [];
+        const params: unknown[] = [];
+        if (filter.issuerUserId !== undefined) {
+            clauses.push('`issuer_user_id` = ?');
+            params.push(filter.issuerUserId);
+        }
+        if (filter.holderUserId !== undefined) {
+            clauses.push('`holder_user_id` = ?');
+            params.push(filter.holderUserId);
+        }
+        if (filter.permissions !== undefined) {
+            if (filter.permissions.length === 0) {
+                return { sql: '1 = 0', params: [] };
+            }
+            clauses.push(
+                `\`permission\` IN (${filter.permissions.map(() => '?').join(', ')})`,
+            );
+            params.push(...filter.permissions);
+        }
+        if (clauses.length === 0) {
+            throw new Error('listUserUserAudit requires a filter');
+        }
+        return { sql: clauses.join(' AND '), params };
+    }
+
+    #auditRow(row: Record<string, unknown>): UserUserAuditRow {
+        let extra = row.extra;
+        if (typeof extra === 'string') {
+            try {
+                extra = JSON.parse(extra);
+            } catch {
+                extra = null;
+            }
+        }
+        const userId = (value: unknown) =>
+            value === null || value === undefined ? null : Number(value);
+        return {
+            id: Number(row.id),
+            issuer_user_id: userId(row.issuer_user_id),
+            holder_user_id: userId(row.holder_user_id),
+            permission: String(row.permission),
+            action: (row.action as string | null) ?? null,
+            extra: (extra as Record<string, unknown> | null) ?? null,
+            created_at: row.created_at,
+        };
     }
 
     // -- SQL: user-to-app permissions --------------------------------

--- a/src/backend/stores/share/ShareStore.test.js
+++ b/src/backend/stores/share/ShareStore.test.js
@@ -695,6 +695,41 @@ describe('ShareStore', () => {
             expect(cursor).toBeUndefined();
         });
 
+        it('returns the no-app group on the first page and resumes past it', async () => {
+            const owner = await makeUser();
+            const recipient = await makeUser();
+            const appUid = uuidv4();
+
+            const manual = await makeEntry(owner);
+            await store.upsertActive({
+                issuerUserId: owner.id,
+                holderUserId: recipient.id,
+                fsentryId: manual.id,
+                mode: 'read',
+            });
+            const viaApp = await makeEntry(owner);
+            await store.upsertActive({
+                issuerUserId: owner.id,
+                holderUserId: recipient.id,
+                fsentryId: viaApp.id,
+                mode: 'read',
+                issuerAppUid: appUid,
+            });
+
+            // No cursor at all — the empty-string group sorts first, and a
+            // first page has nothing to seek past.
+            const first = await store.listOutboundApps(owner.id, { limit: 1 });
+            expect(first.items).toEqual([{ appUid: null, count: 1 }]);
+            expect(first.cursor).toBeDefined();
+
+            const second = await store.listOutboundApps(owner.id, {
+                limit: 1,
+                cursor: first.cursor,
+            });
+            expect(second.items).toEqual([{ appUid, count: 1 }]);
+            expect(second.cursor).toBeUndefined();
+        });
+
         it('records an invite app under the key an active share uses', async () => {
             const owner = await makeUser();
             const entry = await makeEntry(owner);


### PR DESCRIPTION
listOutboundApps sorts the no-app group first via an empty-string
sentinel. Add a regression test pinning that a first page (no cursor)
actually returns it, and that the cursor it hands back resumes past it
into the app-keyed groups rather than skipping or repeating.

---
Stacked on `DS/put-1670` — review only this PR's diff; merges bottom-up.