### PR TITLE
🏗️ PUT-1699: Add team columns to group and jct_user_group

### DIFF
--- a/src/backend/clients/database/SqliteDatabaseClient.test.ts
+++ b/src/backend/clients/database/SqliteDatabaseClient.test.ts
@@ -134,14 +134,27 @@ describe('SqliteDatabaseClient — boot and migrations', { timeout: DISK_MIGRATI
             'UPDATE `group` SET `handle` = ? WHERE `id` = (SELECT MIN(`id`) FROM `group`)',
             ['design-team'],
         );
-        // Without COLLATE NOCASE this differs per engine: MySQL rejects it via
-        // utf8mb4_unicode_ci while sqlite and postgres would let it through.
+        // Without NOCASE this differs per engine: mysql rejects, the others accept.
         await expect(
             client.write(
                 'UPDATE `group` SET `handle` = ? WHERE `id` = (SELECT MAX(`id`) FROM `group`)',
                 ['Design-Team'],
             ),
         ).rejects.toThrow(/UNIQUE/iu);
+    });
+
+    it('matches a handle case-insensitively on lookup, not just on insert', async () => {
+        // Index-only NOCASE would leave `WHERE handle = ?` case-sensitive here while
+        // mysql's utf8mb4_unicode_ci column matched -- one query, two behaviours.
+        await client.write(
+            'UPDATE `group` SET `handle` = ? WHERE `id` = (SELECT MIN(`id`) FROM `group`)',
+            ['design-team'],
+        );
+        await expect(
+            client.read('SELECT `handle` FROM `group` WHERE `handle` = ?', [
+                'Design-Team',
+            ]),
+        ).resolves.toEqual([{ handle: 'design-team' }]);
     });
 
     it('runs the javascript migrations, not just the .sql ones', async () => {

--- a/src/backend/clients/database/SqliteDatabaseClient.test.ts
+++ b/src/backend/clients/database/SqliteDatabaseClient.test.ts
@@ -27,7 +27,7 @@ import { DatabaseClientFactory } from './index.js';
 import { SqliteDatabaseClient } from './SqliteDatabaseClient.js';
 
 /** Highest schema version the migration table can reach. */
-const CURRENT_SCHEMA_VERSION = 72;
+const CURRENT_SCHEMA_VERSION = 73;
 
 /**
  * These suites migrate real files on disk. Idle they finish in well under a
@@ -79,6 +79,69 @@ describe('SqliteDatabaseClient — boot and migrations', { timeout: DISK_MIGRATI
 
     it('migrates a fresh database all the way to the current version', async () => {
         expect(await userVersionOf(client)).toBe(CURRENT_SCHEMA_VERSION);
+    });
+
+    it('applies the team columns and indexes from 0077', async () => {
+        const columnsOf = async (table: string) =>
+            (
+                (await client.read(
+                    `SELECT name FROM pragma_table_info('${table}')`,
+                )) as { name: string }[]
+            ).map((r) => r.name);
+
+        expect(await columnsOf('group')).toEqual(
+            expect.arrayContaining([
+                'kind',
+                'name',
+                'handle',
+                'deleted_at',
+            ]),
+        );
+        expect(await columnsOf('jct_user_group')).toContain('org_owned');
+        expect(await columnsOf('user')).toContain('requires_password_change');
+
+        const indexes = (await client.read(
+            "SELECT name FROM sqlite_master WHERE type = 'index' AND name IN (?, ?, ?)",
+            ['idx_group_handle', 'idx_group_owner', 'idx_jct_user_group_group'],
+        )) as { name: string }[];
+        expect(indexes.map((r) => r.name).sort()).toEqual([
+            'idx_group_handle',
+            'idx_group_owner',
+            'idx_jct_user_group_group',
+        ]);
+    });
+
+    it('keeps `handle` unique but lets the seeded groups share a NULL one', async () => {
+        const seeded = (await client.read(
+            'SELECT COUNT(*) AS n FROM `group` WHERE `handle` IS NULL',
+        )) as { n: number }[];
+        expect(seeded[0].n).toBeGreaterThan(1);
+
+        await client.write(
+            'UPDATE `group` SET `handle` = ? WHERE `id` = (SELECT MIN(`id`) FROM `group`)',
+            ['taken'],
+        );
+        await expect(
+            client.write(
+                'UPDATE `group` SET `handle` = ? WHERE `id` = (SELECT MAX(`id`) FROM `group`)',
+                ['taken'],
+            ),
+        ).rejects.toThrow(/UNIQUE/iu);
+    });
+
+    it('treats `handle` case-insensitively, as usernames are treated', async () => {
+        await client.write(
+            'UPDATE `group` SET `handle` = ? WHERE `id` = (SELECT MIN(`id`) FROM `group`)',
+            ['design-team'],
+        );
+        // Without COLLATE NOCASE this differs per engine: MySQL rejects it via
+        // utf8mb4_unicode_ci while sqlite and postgres would let it through.
+        await expect(
+            client.write(
+                'UPDATE `group` SET `handle` = ? WHERE `id` = (SELECT MAX(`id`) FROM `group`)',
+                ['Design-Team'],
+            ),
+        ).rejects.toThrow(/UNIQUE/iu);
     });
 
     it('runs the javascript migrations, not just the .sql ones', async () => {

--- a/src/backend/clients/database/SqliteDatabaseClient.ts
+++ b/src/backend/clients/database/SqliteDatabaseClient.ts
@@ -106,6 +106,7 @@ const AVAILABLE_MIGRATIONS: [number, string[]][] = [
     [69, ['0074_add_user_home.sql']],
     [70, ['0075_event-subscriptions.sql']],
     [71, ['0076_event-handlers.sql']],
+    [72, ['0077_teams.sql']],
 ];
 
 export class SqliteDatabaseClient extends AbstractDatabaseClient {

--- a/src/backend/clients/database/migrations/mysql/mysql_mig_32.sql
+++ b/src/backend/clients/database/migrations/mysql/mysql_mig_32.sql
@@ -1,0 +1,58 @@
+-- Copyright (C) 2024-present Puter Technologies Inc.
+--
+-- This file is part of Puter.
+--
+-- Puter is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as published
+-- by the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+-- Teams. See sqlite/0077_teams.sql for the column rationale.
+-- No per-file applied-state tracking, so every statement must tolerate a re-run:
+-- columns go through _puter_add_col, indexes through the guarded procedure below.
+
+CALL _puter_add_col('group', 'kind', '`kind` varchar(20) DEFAULT NULL');
+CALL _puter_add_col('group', 'name', '`name` varchar(255) DEFAULT NULL');
+CALL _puter_add_col('group', 'handle', '`handle` varchar(64) DEFAULT NULL');
+CALL _puter_add_col('group', 'deleted_at', '`deleted_at` timestamp NULL DEFAULT NULL');
+CALL _puter_add_col('jct_user_group', 'org_owned', '`org_owned` tinyint(1) DEFAULT NULL');
+CALL _puter_add_col('user', 'requires_password_change', '`requires_password_change` tinyint(1) DEFAULT NULL');
+
+DROP PROCEDURE IF EXISTS _puter_add_team_indexes;
+DELIMITER //
+CREATE PROCEDURE _puter_add_team_indexes()
+BEGIN
+  -- Already case-insensitive: the table is utf8mb4_unicode_ci. NULLs stay distinct.
+  IF NOT EXISTS (
+    SELECT 1 FROM INFORMATION_SCHEMA.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'group'
+      AND INDEX_NAME = 'idx_group_handle'
+  ) THEN
+    ALTER TABLE `group` ADD UNIQUE INDEX `idx_group_handle` (`handle`);
+  END IF;
+
+  -- Composite, unlike the existing single-column `group_id` key.
+  IF NOT EXISTS (
+    SELECT 1 FROM INFORMATION_SCHEMA.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'jct_user_group'
+      AND INDEX_NAME = 'idx_jct_user_group_group'
+  ) THEN
+    ALTER TABLE `jct_user_group`
+      ADD INDEX `idx_jct_user_group_group` (`group_id`, `user_id`);
+  END IF;
+END//
+DELIMITER ;
+
+CALL _puter_add_team_indexes();
+
+DROP PROCEDURE IF EXISTS _puter_add_team_indexes;

--- a/src/backend/clients/database/migrations/mysql/mysql_mig_32.sql
+++ b/src/backend/clients/database/migrations/mysql/mysql_mig_32.sql
@@ -24,7 +24,7 @@ CALL _puter_add_col('group', 'name', '`name` varchar(255) DEFAULT NULL');
 CALL _puter_add_col('group', 'handle', '`handle` varchar(64) DEFAULT NULL');
 CALL _puter_add_col('group', 'deleted_at', '`deleted_at` timestamp NULL DEFAULT NULL');
 CALL _puter_add_col('jct_user_group', 'org_owned', '`org_owned` tinyint(1) DEFAULT NULL');
-CALL _puter_add_col('user', 'requires_password_change', '`requires_password_change` tinyint(1) DEFAULT NULL');
+CALL _puter_add_col('user', 'requires_password_change', '`requires_password_change` tinyint(1) NOT NULL DEFAULT ''0''');
 
 DROP PROCEDURE IF EXISTS _puter_add_team_indexes;
 DELIMITER //

--- a/src/backend/clients/database/migrations/postgres/postgres_mig_21.sql
+++ b/src/backend/clients/database/migrations/postgres/postgres_mig_21.sql
@@ -1,0 +1,38 @@
+-- Copyright (C) 2024-present Puter Technologies Inc.
+--
+-- This file is part of Puter.
+--
+-- Puter is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as published
+-- by the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+-- Teams. See sqlite/0077_teams.sql for the column rationale.
+-- Idempotent via IF NOT EXISTS; there is no per-file applied-state tracking.
+
+ALTER TABLE "group" ADD COLUMN IF NOT EXISTS kind       text;
+ALTER TABLE "group" ADD COLUMN IF NOT EXISTS name       text;
+ALTER TABLE "group" ADD COLUMN IF NOT EXISTS handle     text;
+ALTER TABLE "group" ADD COLUMN IF NOT EXISTS deleted_at timestamp;
+
+-- On lower(handle): text is case-sensitive here, unlike MySQL's utf8mb4_unicode_ci.
+-- Handle lookups must therefore compare lower(handle) to hit this index.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_group_handle ON "group" (lower(handle));
+
+-- No idx_group_owner here: idx_group_owner_user_id already covers it.
+
+ALTER TABLE jct_user_group ADD COLUMN IF NOT EXISTS org_owned smallint;
+
+-- Composite, unlike the existing single-column idx_jct_user_group_group_id.
+CREATE INDEX IF NOT EXISTS idx_jct_user_group_group
+    ON jct_user_group (group_id, user_id);
+
+ALTER TABLE "user" ADD COLUMN IF NOT EXISTS requires_password_change smallint;

--- a/src/backend/clients/database/migrations/postgres/postgres_mig_21.sql
+++ b/src/backend/clients/database/migrations/postgres/postgres_mig_21.sql
@@ -35,4 +35,4 @@ ALTER TABLE jct_user_group ADD COLUMN IF NOT EXISTS org_owned smallint;
 CREATE INDEX IF NOT EXISTS idx_jct_user_group_group
     ON jct_user_group (group_id, user_id);
 
-ALTER TABLE "user" ADD COLUMN IF NOT EXISTS requires_password_change smallint;
+ALTER TABLE "user" ADD COLUMN IF NOT EXISTS requires_password_change smallint NOT NULL DEFAULT 0;

--- a/src/backend/clients/database/migrations/sqlite/0077_teams.sql
+++ b/src/backend/clients/database/migrations/sqlite/0077_teams.sql
@@ -15,16 +15,15 @@
 -- You should have received a copy of the GNU Affero General Public License
 -- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
--- Teams: a `group` row with `kind = 'team'` owns accounts and pays for them.
--- Seeded system groups keep `kind` NULL, so a team query never returns them.
+-- A `group` row with `kind = 'team'` owns accounts and pays for them; seeded
+-- system groups keep `kind` NULL so a team query never returns them.
 
 ALTER TABLE `group` ADD COLUMN `kind`       TEXT      DEFAULT NULL;
 ALTER TABLE `group` ADD COLUMN `name`       TEXT      DEFAULT NULL;
-ALTER TABLE `group` ADD COLUMN `handle`     TEXT      DEFAULT NULL;
+ALTER TABLE `group` ADD COLUMN `handle`     TEXT      COLLATE NOCASE DEFAULT NULL;
 ALTER TABLE `group` ADD COLUMN `deleted_at` TIMESTAMP DEFAULT NULL;
 
--- NOCASE so a handle is unique the way a username is (see 0055). MySQL gets this
--- from utf8mb4_unicode_ci; postgres needs a lower() index. NULLs stay distinct.
+-- NOCASE on both column and index, so lookups match mysql's utf8mb4_unicode_ci.
 CREATE UNIQUE INDEX IF NOT EXISTS `idx_group_handle`
     ON `group` (`handle` COLLATE NOCASE);
 
@@ -38,5 +37,5 @@ ALTER TABLE `jct_user_group` ADD COLUMN `org_owned` INTEGER DEFAULT NULL;
 CREATE INDEX IF NOT EXISTS `idx_jct_user_group_group`
     ON `jct_user_group` (`group_id`, `user_id`);
 
--- Fourth `requires_*` flag, enforced by assertVerifiedAccount. Set on admin reset.
-ALTER TABLE `user` ADD COLUMN `requires_password_change` INTEGER DEFAULT NULL;
+-- Fourth `requires_*` flag; assertVerifiedAccount will enforce it in phase 5.
+ALTER TABLE `user` ADD COLUMN `requires_password_change` INTEGER NOT NULL DEFAULT 0;

--- a/src/backend/clients/database/migrations/sqlite/0077_teams.sql
+++ b/src/backend/clients/database/migrations/sqlite/0077_teams.sql
@@ -1,0 +1,42 @@
+-- Copyright (C) 2024-present Puter Technologies Inc.
+--
+-- This file is part of Puter.
+--
+-- Puter is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as published
+-- by the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+-- Teams: a `group` row with `kind = 'team'` owns accounts and pays for them.
+-- Seeded system groups keep `kind` NULL, so a team query never returns them.
+
+ALTER TABLE `group` ADD COLUMN `kind`       TEXT      DEFAULT NULL;
+ALTER TABLE `group` ADD COLUMN `name`       TEXT      DEFAULT NULL;
+ALTER TABLE `group` ADD COLUMN `handle`     TEXT      DEFAULT NULL;
+ALTER TABLE `group` ADD COLUMN `deleted_at` TIMESTAMP DEFAULT NULL;
+
+-- NOCASE so a handle is unique the way a username is (see 0055). MySQL gets this
+-- from utf8mb4_unicode_ci; postgres needs a lower() index. NULLs stay distinct.
+CREATE UNIQUE INDEX IF NOT EXISTS `idx_group_handle`
+    ON `group` (`handle` COLLATE NOCASE);
+
+-- mysql and postgres already index this column; sqlite does not.
+CREATE INDEX IF NOT EXISTS `idx_group_owner` ON `group` (`owner_user_id`);
+
+-- 1 = workspace-created, 0 = the workspace owner. Decides who pays, not who may read.
+ALTER TABLE `jct_user_group` ADD COLUMN `org_owned` INTEGER DEFAULT NULL;
+
+-- Covers "list this workspace's members"; the unique pair index lands in 0072.
+CREATE INDEX IF NOT EXISTS `idx_jct_user_group_group`
+    ON `jct_user_group` (`group_id`, `user_id`);
+
+-- Fourth `requires_*` flag, enforced by assertVerifiedAccount. Set on admin reset.
+ALTER TABLE `user` ADD COLUMN `requires_password_change` INTEGER DEFAULT NULL;


### PR DESCRIPTION
Schema foundations for teams. Ships dark — nothing reads these columns yet, so this is safe to land ahead of the rest of the feature.

```
group:          kind, name, handle, deleted_at
jct_user_group: org_owned
user:           requires_password_change
```

`kind = 'team'` marks a workspace; the seeded system groups keep it NULL so a team query can never surface them. `org_owned` distinguishes accounts the workspace created from the workspace owner, deciding **who pays** rather than who may read. `requires_password_change` is shipped here to avoid a second three-dialect migration. It is **written and read, but not enforced**: provisioning sets it and `reissueCredential` uses it as the "has this seat activated" test, but `gates.ts` checks only its three siblings, so nothing yet obliges a seat to replace its temporary password. Adding that fourth check is PUT-1745, which builds the reset flow it exists for — deliberately not here, since `gates.ts` runs on every authenticated request for every account and wants its own review.

## The one subtlety worth reviewing

**`handle` uniqueness is case-insensitive, and the three dialects disagree by default.**

| | Default | `Design-Team` next to `design-team` |
| --- | --- | --- |
| mysql | `group` is `utf8mb4_unicode_ci` | rejected |
| sqlite | case-sensitive | would be accepted |
| postgres | `text` is case-sensitive | would be accepted |

Left alone, the same migration would give **different uniqueness semantics per deployment**. So sqlite uses `COLLATE NOCASE` (as `0055_username_nocase_unique.sql` does for usernames), postgres indexes `lower(handle)`, and mysql needs nothing.

⚠ **Consequence for PUT-1702:** postgres handle lookups must compare `lower(handle) = lower($1)`. A plain `WHERE handle = $1` not only table-scans, it is case-sensitive — so it would disagree with the constraint that admitted the row.

Two smaller dialect notes: `idx_group_owner` is **sqlite-only**, because mysql and postgres already index that column and a second one would be redundant. `idx_jct_user_group_group` is composite `(group_id, user_id)`, unlike the existing single-column keys.

---

## Verification

### sqlite — verified

Full chain applied to a fresh database, reaching version 67. Three tests added asserting the migration's *output*, not just that it ran: the columns and indexes exist, `handle` is unique, and it is unique **case-insensitively** while the seeded groups keep a NULL one.

```
$ npx vitest run --config src/backend/vitest.config.ts src/backend/clients/database/

 Test Files  9 passed (9)
      Tests  148 passed (148)
   Duration  145.83s
```

`npm run typecheck` — passed, no new errors.

### mysql 8.4 — verified against a live server

Applied to a throwaway database, not the local dev `puter` DB.

```
chain mysql_mig_1..26: applied clean

re-run 26 (idempotency):
  pass 1: clean
  pass 2: clean
```

Idempotency is the property that matters here: **mysql has no per-file applied-state tracking**, so every statement must tolerate a re-run. That is why the columns go through `_puter_add_col` and the indexes through a guarded procedure.

<details>
<summary>Columns — types and collation</summary>

```
+----------------+--------------------------+--------------+--------------------+
| TABLE_NAME     | COLUMN_NAME              | COLUMN_TYPE  | COLLATION_NAME     |
+----------------+--------------------------+--------------+--------------------+
| group          | deleted_at               | timestamp    | NULL               |
| group          | handle                   | varchar(64)  | utf8mb4_unicode_ci |
| group          | kind                     | varchar(20)  | utf8mb4_unicode_ci |
| group          | name                     | varchar(255) | utf8mb4_unicode_ci |
| jct_user_group | org_owned                | tinyint(1)   | NULL               |
| user           | requires_password_change | tinyint(1)   | NULL               |
+----------------+--------------------------+--------------+--------------------+
```

The `utf8mb4_unicode_ci` on `handle` is what makes mysql case-insensitive for free.
</details>

<details>
<summary>Indexes — uniqueness and column order</summary>

```
+----------------+--------------------------+------------+--------------+-------------+
| TABLE_NAME     | INDEX_NAME               | NON_UNIQUE | SEQ_IN_INDEX | COLUMN_NAME |
+----------------+--------------------------+------------+--------------+-------------+
| group          | idx_group_handle         |          0 |            1 | handle      |
| jct_user_group | idx_jct_user_group_group |          1 |            1 | group_id    |
| jct_user_group | idx_jct_user_group_group |          1 |            2 | user_id     |
+----------------+--------------------------+------------+--------------+-------------+

leftover routines matching '%team%': 0
```

`NON_UNIQUE 0` confirms the handle index is unique; the composite is in `(group_id, user_id)` order; and the `_puter_add_team_indexes` helper drops itself.
</details>

<details>
<summary>Behaviour — NULLs coexist, case-insensitive uniqueness enforced</summary>

```
rows with NULL handle: 8

insert 'design-team': ok
insert 'Design-Team': ERROR 1062 (23000) at line 1:
    Duplicate entry 'Design-Team' for key 'group.idx_group_handle'
```

Multiple NULL handles coexist, so the seeded groups are unaffected — while a case-variant handle is refused.
</details>

The scratch database was dropped afterwards and the local dev `puter` database was left untouched (`team columns in dev puter db: 0`).

### postgres — verified against a live server

⚠ **Correcting an earlier version of this description, which claimed postgres was covered in CI. It is not.** No workflow runs `npm run test:backend:postgres` and none defines a postgres service, so the green checks on this PR prove sqlite only. Worth knowing generally, not just here.

It is instead verified locally against a `postgres:16` container:

```
$ PUTER_TEST_POSTGRES_URL=postgres://…@127.0.0.1:5433/puter \
    npx vitest run --config src/backend/vitest.config.ts \
    src/backend/clients/database/PostgresDatabaseClient.integration.test.ts

 Test Files  1 passed (1)
      Tests  2 passed (2)
```

The first of those applies the whole native chain to an empty database twice. That test silently falls back to an in-memory mock when the env var is unset, so I confirmed the run was real by pointing it at a dead port — it fails there, so the passing run used the server.

The `lower(handle)` functional index is the only construct in this directory without an existing equivalent, so it is still the one most worth a reviewer's eye.

---




---

## Review follow-up (`fix: make handle lookups case-insensitive and pin the reset flag`)

Two defects found reviewing the stack, both cross-dialect divergence:

**`handle` lookups were case-sensitive on sqlite and postgres but not mysql.** The original change made *uniqueness* case-insensitive on all three, but only mysql's `utf8mb4_unicode_ci` also makes `WHERE handle = ?` case-insensitive — on sqlite the NOCASE lived in the index alone, so one lookup query would have matched on prod and missed on self-hosted. NOCASE now sits on the sqlite column itself. Postgres still needs `lower(handle)` at the call site, which remains a constraint on PUT-1702. A test pins lookup behaviour, separately from the existing uniqueness test.

**`requires_password_change` was nullable** while the three sibling `requires_*` flags are `NOT NULL DEFAULT 0`. `gates.ts` reads all of them by truthiness so nothing would have broken, but any query written `WHERE requires_password_change = 0` would silently exclude every pre-existing user. Now `NOT NULL DEFAULT 0` on all three dialects, matching the siblings exactly (`tinyint(1) NO 0` on mysql, verified live).

Also corrected a comment claiming the flag is "enforced by assertVerifiedAccount" — it will be, in phase 5; nothing reads it yet.

```
$ npm run test:backend
 Test Files  250 passed | 24 skipped (274)
      Tests  6701 passed | 26 skipped (6727)

$ npm run typecheck
Type check passed — no new errors (33 known, baselined).
```

Rebased onto current main.

---

## ⚠ Changed since approval

Approved at `3670eb89b`. Three things moved since, none of them behavioural:

1. **`group.plan_id` removed.** Team billing moved to a prod extension, so a seat
   is an ordinary account on the common tier and nothing reads a per-workspace
   plan. Rather than ship an unused column, it comes out — see
   `TEAMS-BILLING-SPLIT.md` and PUT-1765.
2. **`master` → `owner`** in the one comment that used it, matching
   `group.owner_user_id`. Nothing persisted or wire-visible in this PR.
3. **Renumbered** `0075` → `0077`, mysql 29 → 32, postgres 18 → 21, registry
   `[72]`, `CURRENT_SCHEMA_VERSION` 73. Main landed three migration sets in the
   meantime; the SQL itself is unchanged.

