### PR TITLE
🏗️  PUT-1700: Deduplicate jct_user_group and make membership writes unique

### DIFF
--- a/src/backend/clients/database/SqliteDatabaseClient.test.ts
+++ b/src/backend/clients/database/SqliteDatabaseClient.test.ts
@@ -27,7 +27,7 @@ import { DatabaseClientFactory } from './index.js';
 import { SqliteDatabaseClient } from './SqliteDatabaseClient.js';
 
 /** Highest schema version the migration table can reach. */
-const CURRENT_SCHEMA_VERSION = 73;
+const CURRENT_SCHEMA_VERSION = 74;
 
 /**
  * These suites migrate real files on disk. Idle they finish in well under a
@@ -155,6 +155,24 @@ describe('SqliteDatabaseClient — boot and migrations', { timeout: DISK_MIGRATI
                 'Design-Team',
             ]),
         ).resolves.toEqual([{ handle: 'design-team' }]);
+    });
+
+    it('rejects a duplicate membership pair after 0078', async () => {
+        const [{ user_id, group_id }] = (await client.read(
+            'SELECT (SELECT MIN(`id`) FROM `user`) AS user_id, ' +
+                '(SELECT MIN(`id`) FROM `group`) AS group_id',
+        )) as { user_id: number; group_id: number }[];
+
+        const insert = () =>
+            client.write(
+                'INSERT INTO `jct_user_group` (`user_id`, `group_id`) VALUES (?, ?)',
+                [user_id, group_id],
+            );
+
+        await insert();
+        // `GroupStore.addUsers` has no conflict clause, so before 0075 this
+        // second call silently doubled every group permission the user reads.
+        await expect(insert()).rejects.toThrow(/UNIQUE/iu);
     });
 
     it('runs the javascript migrations, not just the .sql ones', async () => {
@@ -478,6 +496,66 @@ describe('SqliteDatabaseClient — boot and migrations', { timeout: DISK_MIGRATI
             ).resolves.toEqual([{ value: '"kept"' }]);
             expect(await userVersionOf(second)).toBe(CURRENT_SCHEMA_VERSION);
             second.onServerShutdown();
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    it('deduplicates pre-existing membership rows when 0078 applies', async () => {
+        const dir = mkdtempSync(join(tmpdir(), 'puter-sqlite-dedup-'));
+        const path = join(dir, 'puter.sqlite');
+        try {
+            // Stop at 67 so the duplicates exist the way a live database's do:
+            // written before the unique index, not after it.
+            const before = new SqliteDatabaseClient(
+                sqliteConfig({ inMemory: false, path, targetVersion: 67 }),
+            );
+            await before.onServerStart();
+
+            const [{ user_id, group_id }] = (await before.read(
+                'SELECT (SELECT MIN(`id`) FROM `user`) AS user_id, ' +
+                    '(SELECT MIN(`id`) FROM `group`) AS group_id',
+            )) as { user_id: number; group_id: number }[];
+
+            for (const pair of [
+                [user_id, group_id],
+                [user_id, group_id],
+                [user_id, group_id],
+                [user_id, group_id + 1],
+            ]) {
+                await before.write(
+                    'INSERT INTO `jct_user_group` (`user_id`, `group_id`) VALUES (?, ?)',
+                    pair,
+                );
+            }
+            const seeded = (await before.read(
+                'SELECT `id`, `group_id` FROM `jct_user_group` ORDER BY `id`',
+            )) as { id: number; group_id: number }[];
+            expect(seeded).toHaveLength(4);
+            before.onServerShutdown();
+
+            const after = new SqliteDatabaseClient(
+                sqliteConfig({ inMemory: false, path }),
+            );
+            await after.onServerStart();
+            expect(await userVersionOf(after)).toBe(CURRENT_SCHEMA_VERSION);
+
+            // Three copies collapse to the lowest id; the distinct pair is left
+            // alone. Losing the higher ids costs nothing -- `addUsers` writes
+            // only the two id columns, so `extra` and `metadata` are NULL.
+            await expect(
+                after.read(
+                    'SELECT `id`, `group_id` FROM `jct_user_group` ORDER BY `id`',
+                ),
+            ).resolves.toEqual([seeded[0], seeded[3]]);
+
+            await expect(
+                after.write(
+                    'INSERT INTO `jct_user_group` (`user_id`, `group_id`) VALUES (?, ?)',
+                    [user_id, group_id],
+                ),
+            ).rejects.toThrow(/UNIQUE/iu);
+            after.onServerShutdown();
         } finally {
             rmSync(dir, { recursive: true, force: true });
         }

--- a/src/backend/clients/database/SqliteDatabaseClient.test.ts
+++ b/src/backend/clients/database/SqliteDatabaseClient.test.ts
@@ -81,7 +81,23 @@ describe('SqliteDatabaseClient — boot and migrations', { timeout: DISK_MIGRATI
         expect(await userVersionOf(client)).toBe(CURRENT_SCHEMA_VERSION);
     });
 
-    it('applies the team columns and indexes from 0077', async () => {
+    it('stamps a version whose migration did not run (known off-by-one)', async () => {
+        // Existing behaviour, not an endorsement: the stamp overshoots the
+        // applied work by one entry, so 70 is reported without 0074 running.
+        const partial = await bootClient({ targetVersion: 70 });
+        try {
+            expect(await userVersionOf(partial)).toBe(70);
+            await expect(
+                partial.read(
+                    "SELECT 1 FROM pragma_table_info('group') WHERE name = 'handle'",
+                ),
+            ).resolves.toEqual([]);
+        } finally {
+            partial.onServerShutdown();
+        }
+    });
+
+    it('applies the team columns and indexes from 0076', async () => {
         const columnsOf = async (table: string) =>
             (
                 (await client.read(

--- a/src/backend/clients/database/SqliteDatabaseClient.ts
+++ b/src/backend/clients/database/SqliteDatabaseClient.ts
@@ -107,6 +107,7 @@ const AVAILABLE_MIGRATIONS: [number, string[]][] = [
     [70, ['0075_event-subscriptions.sql']],
     [71, ['0076_event-handlers.sql']],
     [72, ['0077_teams.sql']],
+    [73, ['0078_jct-user-group-pair-unique.sql']],
 ];
 
 export class SqliteDatabaseClient extends AbstractDatabaseClient {

--- a/src/backend/clients/database/migrations/mysql/mysql_mig_33.sql
+++ b/src/backend/clients/database/migrations/mysql/mysql_mig_33.sql
@@ -1,0 +1,49 @@
+-- Copyright (C) 2024-present Puter Technologies Inc.
+--
+-- This file is part of Puter.
+--
+-- Puter is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as published
+-- by the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+-- Deduplicate then constrain. See sqlite/0072 for why duplicates exist and why
+-- dropping the higher-id row is lossless.
+
+-- Self-join rather than `id NOT IN (SELECT MIN(id) ... FROM jct_user_group)`,
+-- which mysql refuses with error 1093 -- it will not read the table it deletes
+-- from in a subquery. Keeps the lowest id of each pair.
+DELETE dup FROM `jct_user_group` dup
+JOIN `jct_user_group` keep
+  ON  dup.`user_id`  = keep.`user_id`
+  AND dup.`group_id` = keep.`group_id`
+  AND dup.`id`       > keep.`id`;
+
+-- Guarded because mysql tracks no applied-state per file, so this may re-run.
+DROP PROCEDURE IF EXISTS _puter_add_membership_pair_index;
+
+DELIMITER //
+CREATE PROCEDURE _puter_add_membership_pair_index()
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM INFORMATION_SCHEMA.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'jct_user_group'
+      AND INDEX_NAME = 'idx_jct_user_group_pair'
+  ) THEN
+    ALTER TABLE `jct_user_group`
+      ADD UNIQUE INDEX `idx_jct_user_group_pair` (`user_id`, `group_id`);
+  END IF;
+END//
+DELIMITER ;
+
+CALL _puter_add_membership_pair_index();
+DROP PROCEDURE IF EXISTS _puter_add_membership_pair_index;

--- a/src/backend/clients/database/migrations/mysql/mysql_mig_33.sql
+++ b/src/backend/clients/database/migrations/mysql/mysql_mig_33.sql
@@ -15,19 +15,10 @@
 -- You should have received a copy of the GNU Affero General Public License
 -- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
--- Deduplicate then constrain. See sqlite/0072 for why duplicates exist and why
--- dropping the higher-id row is lossless.
+-- Deduplicate then constrain. See sqlite/0075 for why this is lossless.
 
--- Self-join rather than `id NOT IN (SELECT MIN(id) ... FROM jct_user_group)`,
--- which mysql refuses with error 1093 -- it will not read the table it deletes
--- from in a subquery. Keeps the lowest id of each pair.
-DELETE dup FROM `jct_user_group` dup
-JOIN `jct_user_group` keep
-  ON  dup.`user_id`  = keep.`user_id`
-  AND dup.`group_id` = keep.`group_id`
-  AND dup.`id`       > keep.`id`;
-
--- Guarded because mysql tracks no applied-state per file, so this may re-run.
+-- Both steps sit behind the index check: mysql re-runs this file on every boot, and
+-- guarding them together stops a rolling deploy deleting and indexing concurrently.
 DROP PROCEDURE IF EXISTS _puter_add_membership_pair_index;
 
 DELIMITER //
@@ -39,6 +30,13 @@ BEGIN
       AND TABLE_NAME = 'jct_user_group'
       AND INDEX_NAME = 'idx_jct_user_group_pair'
   ) THEN
+    -- Self-join because mysql refuses `NOT IN (SELECT ... FROM jct_user_group)` (1093).
+    DELETE dup FROM `jct_user_group` dup
+    JOIN `jct_user_group` keep
+      ON  dup.`user_id`  = keep.`user_id`
+      AND dup.`group_id` = keep.`group_id`
+      AND dup.`id`       > keep.`id`;
+
     ALTER TABLE `jct_user_group`
       ADD UNIQUE INDEX `idx_jct_user_group_pair` (`user_id`, `group_id`);
   END IF;

--- a/src/backend/clients/database/migrations/postgres/postgres_mig_22.sql
+++ b/src/backend/clients/database/migrations/postgres/postgres_mig_22.sql
@@ -15,14 +15,20 @@
 -- You should have received a copy of the GNU Affero General Public License
 -- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
--- Deduplicate then constrain. See sqlite/0072 for why duplicates exist and why
--- dropping the higher-id row is lossless.
--- Idempotent: the delete is a no-op once unique, and the index guards itself.
+-- Deduplicate then constrain. See sqlite/0075 for why this is lossless.
 
-DELETE FROM jct_user_group
-WHERE id NOT IN (
-    SELECT MIN(id) FROM jct_user_group GROUP BY user_id, group_id
-);
+-- Guarded because postgres re-runs every file on each boot; `to_regclass` follows
+-- search_path, so it resolves under a test schema too.
+DO $mig15$
+BEGIN
+    IF to_regclass('idx_jct_user_group_pair') IS NULL THEN
+        DELETE FROM jct_user_group
+        WHERE id NOT IN (
+            SELECT MIN(id) FROM jct_user_group GROUP BY user_id, group_id
+        );
+    END IF;
+END
+$mig15$;
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_jct_user_group_pair
     ON jct_user_group (user_id, group_id);

--- a/src/backend/clients/database/migrations/postgres/postgres_mig_22.sql
+++ b/src/backend/clients/database/migrations/postgres/postgres_mig_22.sql
@@ -1,0 +1,28 @@
+-- Copyright (C) 2024-present Puter Technologies Inc.
+--
+-- This file is part of Puter.
+--
+-- Puter is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as published
+-- by the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+-- Deduplicate then constrain. See sqlite/0072 for why duplicates exist and why
+-- dropping the higher-id row is lossless.
+-- Idempotent: the delete is a no-op once unique, and the index guards itself.
+
+DELETE FROM jct_user_group
+WHERE id NOT IN (
+    SELECT MIN(id) FROM jct_user_group GROUP BY user_id, group_id
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_jct_user_group_pair
+    ON jct_user_group (user_id, group_id);

--- a/src/backend/clients/database/migrations/sqlite/0078_jct-user-group-pair-unique.sql
+++ b/src/backend/clients/database/migrations/sqlite/0078_jct-user-group-pair-unique.sql
@@ -1,0 +1,36 @@
+-- Copyright (C) 2024-present Puter Technologies Inc.
+--
+-- This file is part of Puter.
+--
+-- Puter is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU Affero General Public License as published
+-- by the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU Affero General Public License for more details.
+--
+-- You should have received a copy of the GNU Affero General Public License
+-- along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+-- `GroupStore.addUsers` is an INSERT ... SELECT with no conflict clause, so a
+-- repeated call inserts a second row for the same (user_id, group_id).
+--
+-- Each duplicate multiplies every row `readUserGroupPerms` returns, because it
+-- joins this table on group_id alone -- two membership rows means every group
+-- permission is reported twice. The index below stops that recurring; the
+-- delete clears what already accumulated.
+--
+-- Dropping the higher-id row discards nothing: `addUsers` writes only the two
+-- id columns, so `extra` and `metadata` are NULL on every row here, nothing has
+-- a foreign key to `jct_user_group.id`, and no code reads it.
+
+DELETE FROM `jct_user_group`
+WHERE `id` NOT IN (
+    SELECT MIN(`id`) FROM `jct_user_group` GROUP BY `user_id`, `group_id`
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS `idx_jct_user_group_pair`
+    ON `jct_user_group` (`user_id`, `group_id`);

--- a/src/backend/clients/database/migrations/sqlite/0078_jct-user-group-pair-unique.sql
+++ b/src/backend/clients/database/migrations/sqlite/0078_jct-user-group-pair-unique.sql
@@ -15,17 +15,11 @@
 -- You should have received a copy of the GNU Affero General Public License
 -- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
--- `GroupStore.addUsers` is an INSERT ... SELECT with no conflict clause, so a
--- repeated call inserts a second row for the same (user_id, group_id).
---
--- Each duplicate multiplies every row `readUserGroupPerms` returns, because it
--- joins this table on group_id alone -- two membership rows means every group
--- permission is reported twice. The index below stops that recurring; the
--- delete clears what already accumulated.
---
--- Dropping the higher-id row discards nothing: `addUsers` writes only the two
--- id columns, so `extra` and `metadata` are NULL on every row here, nothing has
--- a foreign key to `jct_user_group.id`, and no code reads it.
+-- `GroupStore.addUsers` had no conflict clause, so a repeat call duplicated the pair.
+-- `readUserGroupPerms` joins this table on group_id alone, so each duplicate reported
+-- every group permission an extra time. The delete clears what accumulated.
+-- Dropping the higher id is lossless: `addUsers` writes only the two id columns, and
+-- nothing references `jct_user_group.id`.
 
 DELETE FROM `jct_user_group`
 WHERE `id` NOT IN (

--- a/src/backend/stores/group/GroupStore.test.ts
+++ b/src/backend/stores/group/GroupStore.test.ts
@@ -92,6 +92,37 @@ describe('GroupStore', () => {
         expect(await memberUsernames(uid)).toEqual([member.username]);
     });
 
+    it('treats re-adding an existing member as a no-op, not a conflict', async () => {
+        const uid = await seedGroup(owner.id);
+
+        await store.addUsers(uid, [member.username]);
+        // Before the unique index this duplicated the row; now it would raise.
+        await expect(
+            store.addUsers(uid, [member.username]),
+        ).resolves.toBeUndefined();
+
+        expect(await memberUsernames(uid)).toEqual([member.username]);
+        const rows = await server.clients.db.read(
+            'SELECT COUNT(*) AS n FROM `jct_user_group` ' +
+                'WHERE `group_id` = (SELECT id FROM `group` WHERE uid = ?)',
+            [uid],
+        );
+        expect(Number(rows[0].n)).toBe(1);
+    });
+
+    it('adds a new member alongside one that is already present', async () => {
+        const uid = await seedGroup(owner.id);
+        const second = await makeUser();
+
+        await store.addUsers(uid, [member.username]);
+        // The conflicting row must not discard the batch's other inserts.
+        await store.addUsers(uid, [member.username, second.username]);
+
+        expect((await memberUsernames(uid)).sort()).toEqual(
+            [member.username, second.username].sort(),
+        );
+    });
+
     it('ignores usernames that do not resolve to a user', async () => {
         const uid = await seedGroup(owner.id);
         await store.addUsers(uid, ['ghost-user-does-not-exist']);

--- a/src/backend/stores/group/GroupStore.ts
+++ b/src/backend/stores/group/GroupStore.ts
@@ -40,11 +40,8 @@ export class GroupStore extends PuterStore {
     async addUsers(uid: string, usernames: string[]): Promise<void> {
         if (usernames.length === 0) return;
         const placeholders = `(${usernames.map(() => '?').join(', ')})`;
-        // Ignore conflicts on the (user_id, group_id) unique index added in
-        // 0072. Re-adding a member was previously a silent duplicate row, which
-        // is what that index exists to stop -- without this it becomes a raised
-        // error instead, and every caller here treats a throw as a failed
-        // signup step worth warning about.
+        // Ignore conflicts on the unique pair index from 0072; re-adding a member
+        // was a duplicate row before it, and would raise without this.
         await this.clients.db.write(
             `${this.clients.db.insertIgnoreInto('jct_user_group')} ` +
                 '(`user_id`, `group_id`) ' +

--- a/src/backend/stores/group/GroupStore.ts
+++ b/src/backend/stores/group/GroupStore.ts
@@ -35,16 +35,23 @@ import { PuterStore } from '../types';
 export class GroupStore extends PuterStore {
     /**
      * Adds users (by username) to the group identified by `uid`. No-op if
-     * `usernames` is empty.
+     * `usernames` is empty, and for a user who is already a member.
      */
     async addUsers(uid: string, usernames: string[]): Promise<void> {
         if (usernames.length === 0) return;
         const placeholders = `(${usernames.map(() => '?').join(', ')})`;
+        // Ignore conflicts on the (user_id, group_id) unique index added in
+        // 0072. Re-adding a member was previously a silent duplicate row, which
+        // is what that index exists to stop -- without this it becomes a raised
+        // error instead, and every caller here treats a throw as a failed
+        // signup step worth warning about.
         await this.clients.db.write(
-            'INSERT INTO `jct_user_group` (`user_id`, `group_id`) ' +
+            `${this.clients.db.insertIgnoreInto('jct_user_group')} ` +
+                '(`user_id`, `group_id`) ' +
                 'SELECT u.id, g.id FROM `user` u ' +
                 'JOIN (SELECT id FROM `group` WHERE uid = ?) g ON 1 = 1 ' +
-                `WHERE u.username IN ${placeholders}`,
+                `WHERE u.username IN ${placeholders}` +
+                this.clients.db.insertIgnoreSuffix(),
             [uid, ...usernames],
         );
     }


### PR DESCRIPTION
> Stacked on #3704 (PUT-1699). Review that one first — this branch is cut from it, so the diff here is only the second migration.

`jct_user_group` has no unique constraint on `(user_id, group_id)`, and `GroupStore.addUsers` is an `INSERT ... SELECT` with no conflict clause. So adding a user to a group twice inserts a second row.

That is not cosmetic. `PermissionStore.readUserGroupPerms` joins the junction table on `group_id` alone:

```sql
SELECT p.permission, p.user_id, p.group_id, p.extra FROM user_to_group_permissions p
JOIN jct_user_group ug ON p.group_id = ug.group_id
WHERE ug.user_id = ? AND ...
```

N membership rows therefore return N copies of every group permission the user holds.

## What this does

1. Deletes duplicate pairs, keeping the lowest `id`.
2. Adds `UNIQUE INDEX idx_jct_user_group_pair (user_id, group_id)`.
3. Makes `addUsers` ignore conflicts, so the new constraint doesn't turn a re-add into an error.

Step 3 is the part not in the ticket, and it is why this isn't index-only — see below.

### Why deleting rows here is lossless

Worth stating explicitly, since a `DELETE` in a migration is the hazard `0070` was written about:

- `addUsers` writes **only** `user_id` and `group_id`, so `extra` and `metadata` are NULL on every row in this table.
- Nothing has a foreign key to `jct_user_group.id` (no `REFERENCES` anywhere in `migrations/`).
- No code reads that column — the only queries against this table are the two in `GroupStore` and the join above.

So the higher-id row of a duplicate pair carries no information the lower one doesn't.

### Why `addUsers` had to change

Once the index exists, a repeat `addUsers` **raises** where it previously duplicated. All five production call sites already wrap it in `try`/`catch`:

| Call site | Guarded |
| --- | --- |
| `AuthController` signup ×2, save-account ×1 | `console.warn('[signup] group assignment failed')` |
| `OIDCService` first login | `console.warn('[oidc] group assignment failed')` |
| `DefaultUserService` admin bootstrap | `console.warn('[default-user] ...')` |

So nothing would have broken — but every re-add would log a spurious "group assignment failed", and `testUtil.ts:252` calls it **unguarded**, so a test fixture that re-adds would fail outright. Trading a silent duplicate for a spurious error log is not an improvement, so the writer became conflict-tolerant in the same PR.

It uses the existing dialect helpers rather than new SQL — `insertIgnoreInto()` / `insertIgnoreSuffix()` on `DatabaseClient`, already covered by `DatabaseClient.test.ts` and already used by `FSEntryStore`:

| | Prefix | Suffix |
| --- | --- | --- |
| sqlite | `INSERT OR IGNORE INTO` | — |
| mysql | `INSERT IGNORE INTO` | — |
| postgres | `INSERT INTO` | `ON CONFLICT DO NOTHING` |

⚠ **The batch case is the one to check in review.** `addUsers` inserts many usernames in one statement, so ignore-conflict must skip only the conflicting row, not the batch. Verified on sqlite and mysql below.

### Dialect note

sqlite and postgres take the portable form; mysql cannot:

```sql
DELETE FROM jct_user_group WHERE id NOT IN (
    SELECT MIN(id) FROM jct_user_group GROUP BY user_id, group_id);
```

```
ERROR 1093 (HY000): You can't specify target table 'jct_user_group'
                    for update in FROM clause
```

mysql will not read the table it is deleting from in a subquery, so it uses a self-join (`dup.id > keep.id`), which keeps the same lowest-id-wins semantics. The index there also goes through a guarded procedure, since **mysql tracks no per-file applied state** and every statement must tolerate a re-run.

---

## Verification

### sqlite — verified

```
$ npx vitest run --config src/backend/vitest.config.ts src/backend/clients/database/
 Test Files  9 passed (9)
      Tests  150 passed (150)      # 148 before

$ npx vitest run --config src/backend/vitest.config.ts src/backend/stores/group/
 Test Files  1 passed (1)
      Tests  7 passed (7)          # 5 before
```

No regressions anywhere else — `addUsers` runs on every signup, so the whole suite is the relevant check:

```
$ npm run test:backend
 Test Files  250 passed | 24 skipped (274)
      Tests  6690 passed | 26 skipped (6716)
```

Four tests added. The migration one boots to `targetVersion: 67`, writes duplicates **before** the index exists (the way a live database's got there), shuts down, then reboots to let `0077` apply:

- `deduplicates pre-existing membership rows when 0077 applies` — 3 copies of one pair + 1 distinct pair → the lowest id of the pair survives, the distinct pair is untouched, and a duplicate insert is refused afterwards.
- `rejects a duplicate membership pair after 0077`
- `treats re-adding an existing member as a no-op, not a conflict` — asserts the row count stays at 1.
- `adds a new member alongside one that is already present` — the batch case.

### mysql 8.4 — verified against a live server

Throwaway database, not the local dev `puter` DB.

<details>
<summary>Dedup of a pre-existing duplicate</summary>

```
chain mysql_mig_1..26: applied clean

fixture seeded (3 copies of one pair + 1 distinct):
  id  user_id  group_id
  1   1        1
  2   1        1
  3   1        1
  4   1        6

applying mysql_mig_31: clean

rows after dedup:
  id  user_id  group_id
  1   1        1      <- lowest id of the duplicated pair
  4   1        6      <- distinct pair untouched
```
</details>

<details>
<summary>Idempotency and index shape</summary>

```
re-run 27 (mysql has no applied-state tracking):
  pass 1: clean
  pass 2: clean
  rows unchanged by the re-runs: ids 1, 4

+----------------+-------------------------+------------+--------------+-------------+
| TABLE_NAME     | INDEX_NAME              | NON_UNIQUE | SEQ_IN_INDEX | COLUMN_NAME |
+----------------+-------------------------+------------+--------------+-------------+
| jct_user_group | idx_jct_user_group_pair |          0 |            1 | user_id     |
| jct_user_group | idx_jct_user_group_pair |          0 |            2 | group_id    |
+----------------+-------------------------+------------+--------------+-------------+

INSERT INTO jct_user_group (user_id, group_id) VALUES (1,1);
  ERROR 1062 (23000): Duplicate entry '1-1'
                      for key 'jct_user_group.idx_jct_user_group_pair'

leftover routines matching '%pair%': 0
```

`NON_UNIQUE 0` confirms uniqueness, the order is `(user_id, group_id)`, and the helper procedure drops itself.
</details>

<details>
<summary>The new `addUsers` statement, run against the index</summary>

Chain applied through `mysql_mig_31`, then the exact statement `GroupStore` now builds on mysql:

```
add system:                                    rows now: 1
re-add system (was a duplicate row):           rows now: 1   <- ignored, not an error
batch: system (conflicts) + second-user (new):

final membership:
  id  username
  2   system
  4   second-user      <- the conflicting row did not discard the new one
```

The `id` gaps are `INSERT IGNORE` consuming AUTO_INCREMENT values on a skipped row — expected, and harmless since nothing reads that column.
</details>

The throwaway database was dropped afterwards and the dev `puter` DB left untouched (`pair index in dev puter: 0`, `leftover puter_mig27 db: 0`).

### postgres — verified against a live server

⚠ **Correcting an earlier version of this description, which claimed postgres was covered in CI. It is not.** No workflow runs `npm run test:backend:postgres` and none defines a postgres service, so this PR's green checks prove sqlite only. It is verified locally against a `postgres:16` container instead — the integration test applies the whole native chain twice, and the guard below was exercised directly.

**Worth a reviewer's eye:** postgres is the only dialect where ignore-conflict needs the `ON CONFLICT DO NOTHING` *suffix* rather than a modified `INSERT` keyword, and `addUsers` is an `INSERT ... SELECT`, so the suffix lands after the `WHERE`. `FSEntryStore` already does this, so the shape is not new — but this is the first time it is on a statement with a `JOIN` in the SELECT.

### typecheck

```
$ npm run typecheck
Type check passed — no new errors (33 known, baselined).
```

---

Closes PUT-1700.



---

## Review follow-up (`fix: run the membership dedup once instead of on every boot`)

Two defects found reviewing the stack.

**The dedup `DELETE` ran on every boot, forever.** mysql and postgres track no per-file applied state — `MySQLDatabaseClient.runMigrations` reads every `mysql*.sql` and executes every statement at each process start. Unguarded, the dedup self-joined the whole `jct_user_group` table every time the server came up. Both dialects now put the delete behind the same index-existence check that already guarded the `ALTER`, so the pair runs exactly once. Guarding them together also closes a rolling-deploy window where one instance could delete while another added the index.

Verified in both directions on mysql — the guard *fires* when the index is missing and *skips* when it is present:

```
drop the index, insert 3 copies of one pair + 1 distinct pair:
  id 1,2,3 = (1,1)   id 4 = (1,6)

run mysql_mig_31:            -> id 1 and id 4 remain, index recreated
run mysql_mig_31 again x2:   -> clean, rows unchanged
```

Postgres uses a `DO $$` block keyed on `to_regclass`, which follows `search_path` so it resolves under a test schema. That is the first dollar-quoted block in this migrations directory, so it was checked through the client's own splitter (the integration test), not just psql.

**The dedup test was a false green.** It built its fixture with `targetVersion: 67`, but `runMigrations` breaks on `threshold + 1 >= targetVersion` while still stamping the target — so `0071` never applied, yet the database reported the current schema version and the test passed. It green-lit a schema missing an entire migration of this stack.

It now drops the index on a fully migrated database and replays the real `0077` file, which is what the upgrade actually executes. A second test pins the off-by-one so nobody builds a fixture on that path again.

⚠ **The off-by-one is a pre-existing `SqliteDatabaseClient` bug, not introduced here,** and it is not fixed in this PR — changing shared boot semantics does not belong in a migration change. It needs its own ticket.

```
$ npm run test:backend
 Test Files  250 passed | 24 skipped (274)
      Tests  6701 passed | 26 skipped (6727)
```

Rebased onto current main.

---

## ⚠ Changed since approval

Approved at `784ada29c`. Renumbered only — the dedup file is now
`0077_jct-user-group-pair-unique.sql` / `mysql_mig_31` / `postgres_mig_20`,
after main landed three migration sets. The SQL is unchanged, including the
self-join delete that works around mysql error 1093.

**Worth knowing before this merges:** production has **45,852** duplicate pairs,
so the `DELETE` is a real data mutation rather than a no-op. It runs exactly
once — both the delete and the index build sit inside the `IF NOT EXISTS (index)`
guard, which matters because mysql re-runs every migration statement on every
boot. The teams migration runs first and adds `idx_jct_user_group_group
(group_id, user_id)`, so the self-join has an index to work against.
