### PR TITLE
🏗️ PUT-1704 + PUT-1707: TeamService — workspace lifecycle, disable and re-enable

### DIFF
--- a/src/backend/core/http/HttpError.ts
+++ b/src/backend/core/http/HttpError.ts
@@ -54,7 +54,10 @@ export type LegacyErrorCodes =
     | 'password_mismatch'
     | 'field_not_allowed_for_create'
     | 'account_is_not_verified'
-    | 'app_or_api_token_required';
+    | 'app_or_api_token_required'
+    | 'team_not_found'
+    | 'not_the_workspace_owner'
+    | 'not_an_org_account';
 
 /**
  * Copyright (C) 2024-present Puter Technologies Inc.

--- a/src/backend/services/index.ts
+++ b/src/backend/services/index.ts
@@ -40,6 +40,7 @@ import { PermissionService } from './permission/PermissionService';
 import { DefaultUserService } from './selfhosted/DefaultUserService';
 import { ShareNotificationService } from './share/ShareNotificationService';
 import { ShareService } from './share/ShareService';
+import { TeamService } from './team/TeamService';
 import { SocketService } from './socket/SocketService';
 import { SubdomainPermissionService } from './subdomain/SubdomainPermissionService';
 import type { IPuterServiceRegistry } from './types';
@@ -79,6 +80,7 @@ declare module './types' {
         homepage: PuterHomepageService;
         health: ServerHealthService;
         userAccount: UserAccountService;
+        team: TeamService;
     }
 }
 
@@ -110,6 +112,8 @@ export const puterServices = {
     // Declared after `fs` — account teardown tears the user's filesystem down
     // first.
     userAccount: UserAccountService,
+    // Leaf: team + user stores only.
+    team: TeamService,
     // AppPermissionService + SubdomainPermissionService register permission
     // rewriters/implicators only; no runtime state. Placed after fsEntry so
     // the FS rewriter runs first for `fs:/path` → `fs:<uuid>` before any

--- a/src/backend/services/team/TeamService.test.ts
+++ b/src/backend/services/team/TeamService.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Copyright (C) 2024-present Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { PuterServer } from '../../server.ts';
+import { setupTestServer } from '../../testUtil.ts';
+
+describe('TeamService', () => {
+    let server: PuterServer;
+    let service: PuterServer['services']['team'];
+    let owner: { id: number };
+
+    const makeUser = async (): Promise<{ id: number; username: string }> => {
+        const username = `svc-${Math.random().toString(36).slice(2, 10)}`;
+        const created = (await server.stores.user.create({
+            username,
+            uuid: uuidv4(),
+            password: null,
+            email: `${username}@test.local`,
+        })) as unknown as { id: number };
+        return { id: created.id, username };
+    };
+
+    const freeHandle = () => `ws-${Math.random().toString(36).slice(2, 10)}`;
+
+    /** A workspace with the owner admitted and one provisioned member. */
+    const makeWorkspace = async () => {
+        const team = await service.createWorkspace(owner.id, {
+            name: 'Acme',
+            handle: freeHandle(),
+        });
+        const member = await makeUser();
+        await server.stores.team.addMember(team.uid, member.id, {
+            orgOwned: true,
+        });
+        return { team, member };
+    };
+
+    const suspensionOf = async (userId: number) => {
+        const [row] = (await server.clients.db.read(
+            'SELECT `suspended`, `suspended_at`, `suspended_reason` FROM `user` WHERE `id` = ?',
+            [userId],
+        )) as {
+            suspended: number | null;
+            suspended_at: number | null;
+            suspended_reason: string | null;
+        }[];
+        return row;
+    };
+
+    beforeAll(async () => {
+        server = await setupTestServer();
+        service = server.services.team;
+        owner = await makeUser();
+    });
+
+    afterAll(async () => {
+        await server?.shutdown();
+    });
+
+    // -- creating a workspace -----------------------------------------
+
+    it('creates a workspace and admits its creator as the workspace owner', async () => {
+        const team = await service.createWorkspace(owner.id, {
+            name: 'Acme Design',
+            handle: freeHandle(),
+        });
+
+        expect(team.owner_user_id).toBe(owner.id);
+        const membership = await server.stores.team.getMembership(
+            team.uid,
+            owner.id,
+        );
+        // 0 is what makes the owner pay for itself.
+        expect(Number(membership?.org_owned)).toBe(0);
+    });
+
+    it('holds the owner invariant that no dialect can express', async () => {
+        const { team } = await makeWorkspace();
+        await expect(service.checkOwnerInvariant(team.uid)).resolves.toBe(true);
+    });
+
+    it('breaks the invariant if a second account is admitted as the payer', async () => {
+        const { team } = await makeWorkspace();
+        const other = await makeUser();
+        await server.stores.team.addMember(team.uid, other.id, {
+            orgOwned: false,
+        });
+
+        // The check exists precisely because the schema cannot refuse this.
+        await expect(service.checkOwnerInvariant(team.uid)).resolves.toBe(false);
+    });
+
+    // -- authority ----------------------------------------------------
+
+    it('refuses a member who is not the workspace owner', async () => {
+        const { team, member } = await makeWorkspace();
+        await expect(
+            service.requireOwner(team.uid, member.id),
+        ).rejects.toMatchObject({ statusCode: 403 });
+    });
+
+    it('gives a stranger 404 rather than 403, so it is not an oracle', async () => {
+        const { team } = await makeWorkspace();
+        const stranger = await makeUser();
+        await expect(
+            service.requireMembership(team.uid, stranger.id),
+        ).rejects.toMatchObject({ statusCode: 404 });
+        await expect(
+            service.requireOwner(team.uid, stranger.id),
+        ).rejects.toMatchObject({ statusCode: 404 });
+    });
+
+    it('refuses the workspace owner as the target of a member route', async () => {
+        const { team } = await makeWorkspace();
+        await expect(
+            service.requireOrgAccount(team.uid, owner.id),
+        ).rejects.toMatchObject({ statusCode: 404 });
+    });
+
+    // -- disable and re-enable ----------------------------------------
+
+    it('sets the column the request gate actually reads', async () => {
+        const { team, member } = await makeWorkspace();
+
+        await service.disableMember(team.uid, owner.id, member.id);
+
+        const row = await suspensionOf(member.id);
+        // `userProtected` rejects on `suspended`; the other two are its
+        // siblings and do not gate anything on their own.
+        expect(Boolean(row.suspended)).toBe(true);
+        expect(row.suspended_at).toBeGreaterThan(0);
+        expect(row.suspended_reason).toBe('disabled_by_workspace');
+    });
+
+    it('drops the disabled account\'s sessions', async () => {
+        const { team, member } = await makeWorkspace();
+        await server.clients.db.write(
+            'INSERT INTO `sessions` (`uuid`, `user_id`) VALUES (?, ?)',
+            [uuidv4(), member.id],
+        );
+
+        await service.disableMember(team.uid, owner.id, member.id);
+
+        // Revoked, not deleted: the row keeps `last_ip` / `last_user_agent`,
+        // which the member-facing audit view reads.
+        const live = await server.clients.db.read(
+            'SELECT COUNT(*) AS n FROM `sessions` WHERE `user_id` = ? AND `revoked_at` IS NULL',
+            [member.id],
+        );
+        expect(Number(live[0].n)).toBe(0);
+
+        const kept = await server.clients.db.read(
+            'SELECT COUNT(*) AS n FROM `sessions` WHERE `user_id` = ?',
+            [member.id],
+        );
+        expect(Number(kept[0].n)).toBe(1);
+    });
+
+    it('restores the account exactly as it was on re-enable', async () => {
+        const { team, member } = await makeWorkspace();
+        await service.disableMember(team.uid, owner.id, member.id);
+
+        await service.enableMember(team.uid, owner.id, member.id);
+
+        const row = await suspensionOf(member.id);
+        expect(Boolean(row.suspended)).toBe(false);
+        expect(row.suspended_at).toBeNull();
+        expect(row.suspended_reason).toBeNull();
+    });
+
+    it('leaves the disabled account\'s files alone', async () => {
+        const { team, member } = await makeWorkspace();
+        await server.clients.db.write(
+            'INSERT INTO `fsentries` (`uuid`, `name`, `user_id`, `modified`) VALUES (?, ?, ?, ?)',
+            [uuidv4(), 'kept.txt', member.id, 0],
+        );
+
+        await service.disableMember(team.uid, owner.id, member.id);
+
+        const rows = await server.clients.db.read(
+            'SELECT COUNT(*) AS n FROM `fsentries` WHERE `user_id` = ?',
+            [member.id],
+        );
+        expect(Number(rows[0].n)).toBe(1);
+    });
+
+    it('refuses to disable the workspace owner', async () => {
+        const { team } = await makeWorkspace();
+        await expect(
+            service.disableMember(team.uid, owner.id, owner.id),
+        ).rejects.toMatchObject({ statusCode: 404 });
+
+        expect(Boolean((await suspensionOf(owner.id)).suspended)).toBe(false);
+    });
+
+    it('refuses a disable ordered by someone who is not the owner', async () => {
+        const { team, member } = await makeWorkspace();
+        const other = await makeUser();
+        await server.stores.team.addMember(team.uid, other.id, {
+            orgOwned: true,
+        });
+
+        await expect(
+            service.disableMember(team.uid, other.id, member.id),
+        ).rejects.toMatchObject({ statusCode: 403 });
+        expect(Boolean((await suspensionOf(member.id)).suspended)).toBe(false);
+    });
+
+    it('refuses to disable a member of another workspace', async () => {
+        const a = await makeWorkspace();
+        const b = await makeWorkspace();
+
+        await expect(
+            service.disableMember(a.team.uid, owner.id, b.member.id),
+        ).rejects.toMatchObject({ statusCode: 404 });
+    });
+    it('refuses to lift a suspension the workspace did not impose', async () => {
+        const { team, member } = await makeWorkspace();
+        // What a platform abuse suspension looks like.
+        await server.stores.user.update(member.id, {
+            suspended: 1,
+            suspended_at: Math.floor(Date.now() / 1000),
+            suspended_reason: 'abuse_detected',
+        });
+
+        await expect(
+            service.enableMember(team.uid, owner.id, member.id),
+        ).rejects.toMatchObject({ statusCode: 409 });
+
+        const row = await suspensionOf(member.id);
+        expect(Boolean(row.suspended)).toBe(true);
+        expect(row.suspended_reason).toBe('abuse_detected');
+    });
+
+    it('lifts its own suspension normally', async () => {
+        const { team, member } = await makeWorkspace();
+        await service.disableMember(team.uid, owner.id, member.id);
+
+        await service.enableMember(team.uid, owner.id, member.id);
+        expect(Boolean((await suspensionOf(member.id)).suspended)).toBe(false);
+    });
+});

--- a/src/backend/services/team/TeamService.ts
+++ b/src/backend/services/team/TeamService.ts
@@ -1,0 +1,249 @@
+/*
+ * Copyright (C) 2024-present Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { HttpError } from '../../core/http/HttpError.js';
+import { checkHandle } from '../../stores/team/TeamStore.js';
+import type { TeamMemberRow, TeamRow } from '../../stores/team/TeamStore';
+import { PuterService } from '../types';
+
+/** Why an account was disabled. Free text in `0063`; this is the team one. */
+export const DISABLED_BY_WORKSPACE = 'disabled_by_workspace';
+
+export class TeamService extends PuterService {
+    // -- Authority ----------------------------------------------------
+    // Two checks, and between them the whole authorization model.
+
+    /** 404 to a non-member so the endpoint is not an existence oracle. */
+    async requireMembership(
+        teamUid: string,
+        actorUserId: number,
+    ): Promise<TeamRow> {
+        const team = await this.stores.team.getByUid(teamUid);
+        if (!team || !(await this.stores.team.isMember(teamUid, actorUserId))) {
+            throw new HttpError(404, 'Workspace not found', {
+                legacyCode: 'team_not_found',
+            });
+        }
+        return team;
+    }
+
+    /** Authority is one test: the caller is the account named by the workspace. */
+    async requireOwner(teamUid: string, actorUserId: number): Promise<TeamRow> {
+        const team = await this.requireMembership(teamUid, actorUserId);
+        if (team.owner_user_id !== actorUserId) {
+            throw new HttpError(403, 'Only the workspace owner can do that', {
+                legacyCode: 'not_the_workspace_owner',
+            });
+        }
+        return team;
+    }
+
+    /** The workspace owner is never a valid target of a member route. */
+    async requireOrgAccount(
+        teamUid: string,
+        targetUserId: number,
+    ): Promise<TeamMemberRow> {
+        const membership = await this.stores.team.getMembership(
+            teamUid,
+            targetUserId,
+        );
+        // Tested explicitly, never inferred from NULL.
+        if (!membership || Number(membership.org_owned) !== 1) {
+            throw new HttpError(404, 'Not an account of this workspace', {
+                legacyCode: 'not_an_org_account',
+            });
+        }
+        return membership;
+    }
+
+    // -- Workspace lifecycle ------------------------------------------
+
+    /** A rejected handle is 400, a taken one 409, never an unhandled 500. */
+    async assertHandleUsable(handle: string): Promise<void> {
+        const rejection = checkHandle(handle);
+        if (rejection) {
+            throw new HttpError(400, `Unusable handle: ${rejection}`, {
+                legacyCode: 'bad_request',
+            });
+        }
+        if (!(await this.stores.team.isHandleAvailable(handle))) {
+            throw new HttpError(409, 'That handle is taken', {
+                legacyCode: 'conflict',
+            });
+        }
+    }
+
+    /** The unique index is the arbiter, so a race still lands as a 409. */
+    async #asHttpErrors<T>(run: () => Promise<T>): Promise<T> {
+        try {
+            return await run();
+        } catch (e) {
+            if (e instanceof HttpError) throw e;
+            const message = String((e as Error)?.message ?? '');
+            if (/unusable team handle/iu.test(message)) {
+                throw new HttpError(400, message, {
+                    legacyCode: 'bad_request',
+                });
+            }
+            if (/unique|duplicate/iu.test(message)) {
+                throw new HttpError(409, 'That handle is taken', {
+                    legacyCode: 'conflict',
+                });
+            }
+            throw e;
+        }
+    }
+
+    /** Renames or re-handles a workspace, refusing an unusable handle. */
+    async updateWorkspace(
+        teamUid: string,
+        actorUserId: number,
+        changes: { name?: string; handle?: string | null },
+    ): Promise<TeamRow> {
+        await this.requireOwner(teamUid, actorUserId);
+        if (changes.handle) await this.assertHandleUsable(changes.handle);
+
+        const team = await this.#asHttpErrors(() =>
+            this.stores.team.update(teamUid, changes),
+        );
+        if (!team) {
+            throw new HttpError(404, 'Workspace not found', {
+                legacyCode: 'team_not_found',
+            });
+        }
+        return team;
+    }
+
+    /** Creates a workspace and admits its creator as the workspace owner. */
+    async createWorkspace(
+        ownerUserId: number,
+        input: { name: string; handle?: string | null },
+    ): Promise<TeamRow> {
+        const handle = input.handle ?? null;
+        if (handle !== null) await this.assertHandleUsable(handle);
+
+        const team = await this.#asHttpErrors(() =>
+            this.stores.team.create({
+                ownerUserId,
+                name: input.name,
+                handle,
+            }),
+        );
+
+        // 0 makes the owner pay for itself and stay an invalid route target.
+        // Unchecked, the owner could never reach their own workspace.
+        const admitted = await this.stores.team.addMember(
+            team.uid,
+            ownerUserId,
+            {
+                orgOwned: false,
+            },
+        );
+        if (!admitted) {
+            await this.stores.team.softDelete(team.uid);
+            throw new HttpError(500, 'Could not create the workspace', {
+                legacyCode: 'internal_error',
+            });
+        }
+        return team;
+    }
+
+    /** The owner is a member with `org_owned = 0`, and the only such member. */
+    async checkOwnerInvariant(teamUid: string): Promise<boolean> {
+        const team = await this.stores.team.getByUid(teamUid);
+        if (!team) return false;
+
+        const owner = await this.stores.team.getMembership(
+            teamUid,
+            team.owner_user_id,
+        );
+        if (!owner || Number(owner.org_owned) !== 0) return false;
+
+        const rows = (await this.clients.db.read(
+            'SELECT COUNT(*) AS n FROM `jct_user_group` ' +
+                'WHERE `group_id` = ? AND `org_owned` = 0',
+            [team.id],
+        )) as { n: number }[];
+        return Number(rows[0]?.n) === 1;
+    }
+
+    // -- Disable and re-enable ----------------------------------------
+    // The whole of offboarding: no removal, no transfer, no retention clock.
+
+    /** Rejects the account's next request; its files are untouched. */
+    async disableMember(
+        teamUid: string,
+        actorUserId: number,
+        targetUserId: number,
+    ): Promise<void> {
+        await this.requireOwner(teamUid, actorUserId);
+        await this.requireOrgAccount(teamUid, targetUserId);
+
+        // `suspended` is what `userProtected` enforces; the others are siblings.
+        await this.stores.user.update(targetUserId, {
+            suspended: 1,
+            suspended_at: Math.floor(Date.now() / 1000),
+            suspended_reason: DISABLED_BY_WORKSPACE,
+        });
+        await this.#dropSessions(targetUserId);
+    }
+
+    /** Nothing was destroyed, so the account returns as it was. */
+    async enableMember(
+        teamUid: string,
+        actorUserId: number,
+        targetUserId: number,
+    ): Promise<void> {
+        await this.requireOwner(teamUid, actorUserId);
+        await this.requireOrgAccount(teamUid, targetUserId);
+
+        // Forced read, as `userProtected` does: a cached row predates this.
+        const user = await this.stores.user.getByProperty('id', targetUserId, {
+            force: true,
+        });
+        // Only the workspace's own suspension; a platform one must not lift.
+        if (
+            user?.suspended &&
+            user.suspended_reason !== DISABLED_BY_WORKSPACE
+        ) {
+            throw new HttpError(409, 'That account was suspended by Puter', {
+                legacyCode: 'conflict',
+            });
+        }
+
+        await this.stores.user.update(targetUserId, {
+            suspended: 0,
+            suspended_at: null,
+            suspended_reason: null,
+        });
+        await this.stores.user.invalidateById(targetUserId);
+    }
+
+    /** Via the store: a raw DELETE leaves the session cache serving the row. */
+    async #dropSessions(userId: number): Promise<void> {
+        const rows = (await this.clients.db.read(
+            'SELECT `uuid` FROM `sessions` WHERE `user_id` = ? AND `revoked_at` IS NULL',
+            [userId],
+        )) as { uuid: string }[];
+        for (const row of rows) {
+            await this.stores.session.removeByUuid(row.uuid);
+        }
+        await this.stores.user.invalidateById(userId);
+    }
+}


### PR DESCRIPTION
> Sixth in the stack: #3704 → #3705 → #3708 → #3709 → #3710 → this. Review bottom-up.

Covers **PUT-1704** (create a workspace, admit the workspace owner) and **PUT-1707** (disable and re-enable) together — both are `TeamService` methods and neither is large enough to review alone.

```
createWorkspace(ownerUserId, { name, handle? })
checkOwnerInvariant(teamUid)

requireMembership(teamUid, actorUserId)     -> 404 to a stranger
requireOwner(teamUid, actorUserId)         -> 403 to a non-master member
requireOrgAccount(teamUid, targetUserId)    -> 404 for the workspace owner

disableMember(teamUid, actorUserId, targetUserId)
enableMember(teamUid, actorUserId, targetUserId)
```

## ⚠ A spec bug worth reading before the code

PUT-1707 said to set `user.suspended_at` / `suspended_reason` (`0061`, `0063`). Those are real columns — but **neither of them enforces anything**:

```ts
// core/http/middleware/userProtected.ts:175
if (user.suspended)
    throw new HttpError(403, 'Account is suspended', { … });
```

The enforced column is the older boolean `suspended` from `0001`. `suspended_at` and `suspended_reason` are its siblings; `0061`'s own comment calls it *"the timestamp sibling of the existing boolean `suspended` flag"*.

Implemented literally, disable would have written a perfect record of an offboarding that never happened — and since this design has no remove-from-workspace, no file transfer and no retention clock, **disable is the entire offboarding control**. All three columns are now written together, and the test is named for it: `sets the column the request gate actually reads`. Ticket and design doc corrected.

## The invariant no dialect can express

`createWorkspace` admits the creator with `org_owned = 0`. That single value is what makes the workspace owner pay for itself and stay an invalid target of every member route.

`checkOwnerInvariant` asserts what the schema cannot: the owner is a member with `org_owned = 0`, **and is the only such member**. There's a test that deliberately breaks it by admitting a second `org_owned = 0` account, because nothing in any dialect refuses that — which is the reason the check exists at all.

## Authority

Three checks, and between them the whole authorization model:

| Caller | Result |
| --- | --- |
| Not a member | **404** `team_not_found` — so the endpoint is not an existence oracle |
| Member, not the owner | **403** `not_the_workspace_owner` |
| The master, targeting itself | **404** `not_an_org_account` — `org_owned` is tested explicitly, never inferred from NULL |

Adds those three values to the `HttpError` legacy-code union, which is a closed type. PUT-1708's routes need the same three.

## What is deliberately not here

Stated rather than buried, since PUT-1707 lists them:

| Deferred | To |
| --- | --- |
| Billing events on disable / re-enable | phase 3, PUT-1712 |
| `invalidateActorSubscription` | phase 3 |
| Audit rows for both operations | PUT-1708, which owns audit writes |
| `outer.gui.*` push + member notification | needs a new event type and socket fan-out — design work belonging with the controller/GUI phase |

---

## Verification

```
$ npx vitest run --config src/backend/vitest.config.ts src/backend/services/team/
 Test Files  1 passed (1)
      Tests  13 passed (13)

$ PUTER_TEST_DB_ENGINE=postgres npx vitest run --config src/backend/vitest.config.ts src/backend/services/team/
 Test Files  1 passed (1)
      Tests  13 passed (13)

$ npm run test:backend
 Test Files  252 passed | 24 skipped (276)
      Tests  6743 passed | 26 skipped (6769)      # +13, no regressions

$ npm run typecheck
Type check passed — no new errors (33 known, baselined).
```

The disable tests assert the observable consequences rather than the write: sessions are gone, `fsentries` are untouched, re-enable clears all three columns, the workspace owner cannot be disabled even by itself, a non-master's disable order is refused, and a member of another workspace cannot be reached.

<details>
<summary>A detail that cost six red tests</summary>

`HttpError` exposes `statusCode`, not `status`. My first assertions used `toMatchObject({ status: 404 })`, which fails against every `HttpError` regardless of what it actually contains — so all six rejection tests failed while the seven behavioural ones passed. Worth knowing before writing the controller tests in PUT-1708, where nearly every assertion is a rejection.
</details>

---

Closes PUT-1704 and PUT-1707.

