### PR TITLE
🏗️ PUT-1705: TeamService — provision an org account

### DIFF
--- a/src/backend/clients/email/templates.ts
+++ b/src/backend/clients/email/templates.ts
@@ -347,6 +347,24 @@ support@puter.com immediately.
 <p>Puter</p>
         `,
     },
+    team_account_created: {
+        subject: 'Your {{team_name}} account on Puter',
+        html: `
+<p>Hi there,</p>
+<p>{{team_name}} has created a Puter account for you: <b>{{username}}</b>.
+They will send you a temporary password separately; you will be asked to
+choose your own the first time you sign in.</p>
+<p>What this means:</p>
+<ul>
+<li>This account belongs to {{team_name}}. They pay for it and can close it.</li>
+<li>{{team_name}} <b>cannot</b> see your files, apps or data.</li>
+<li>{{team_name}} <b>can</b> reset your password, which would let them sign in
+as you. Choose your own password promptly.</li>
+</ul>
+<p>Sincerely,</p>
+<p>Puter</p>
+        `,
+    },
     enabled_2fa: {
         subject: '2FA Enabled on your Account',
         html: `

--- a/src/backend/controllers/auth/AuthController.ts
+++ b/src/backend/controllers/auth/AuthController.ts
@@ -81,8 +81,8 @@ import {
 } from '../../services/permission/appDataScopes.js';
 import { PuterController } from '../types.js';
 
-const USERNAME_REGEX = /^\w{1,}$/;
-const USERNAME_MAX_LENGTH = 45;
+export const USERNAME_REGEX = /^\w{1,}$/;
+export const USERNAME_MAX_LENGTH = 45;
 const FINGERPRINT_MAX_LENGTH = 128;
 // One consent prompt covers a handful of scopes at most. The cap keeps a
 // crafted request from turning a single grant call into a bulk write.
@@ -194,7 +194,7 @@ const cardAlreadyVerified = (user: {
     requires_card_verification?: boolean;
 }): boolean =>
     Boolean(user.card_fingerprint) && !user.requires_card_verification;
-const RESERVED_USERNAMES = new Set([
+export const RESERVED_USERNAMES = new Set([
     'admin',
     'administrator',
     'root',
@@ -4463,7 +4463,15 @@ export class AuthController extends PuterController {
     ): Promise<UserRow | null> {
         const existing = await this.stores.user.findEmailOwner(email, opts);
         if (!existing) return null;
-        if (existing.email_confirmed || existing.password !== null) {
+        // A provisioned account looks exactly like a claimable placeholder --
+        // no password, unconfirmed -- but claiming it hands a stranger that
+        // workspace's membership.
+        const orgSeat = await this.stores.team.getOrgSeat(existing.id);
+        if (
+            existing.email_confirmed ||
+            existing.password !== null ||
+            orgSeat !== null
+        ) {
             throw new HttpError(
                 400,
                 'This email already exists in our database. Please use another one.',

--- a/src/backend/services/team/TeamService.test.ts
+++ b/src/backend/services/team/TeamService.test.ts
@@ -28,7 +28,7 @@ describe('TeamService', () => {
     let owner: { id: number };
 
     const makeUser = async (): Promise<{ id: number; username: string }> => {
-        const username = `svc-${Math.random().toString(36).slice(2, 10)}`;
+        const username = `svc_${Math.random().toString(36).slice(2, 10)}`;
         const created = (await server.stores.user.create({
             username,
             uuid: uuidv4(),
@@ -256,5 +256,197 @@ describe('TeamService', () => {
 
         await service.enableMember(team.uid, owner.id, member.id);
         expect(Boolean((await suspensionOf(member.id)).suspended)).toBe(false);
+    });
+
+
+    // -- provisioning -------------------------------------------------
+
+    it('creates an account the workspace owns, pending a password change', async () => {
+        const { team } = await makeWorkspace();
+        const username = `prov_${Math.random().toString(36).slice(2, 9)}`;
+
+        const result = await service.provisionAccount(team.uid, owner.id, {
+            username,
+            email: `${username}@test.local`,
+        });
+
+        expect(result.username).toBe(username);
+        const user = await server.stores.user.getById(result.userId);
+        expect(Boolean(user?.requires_password_change)).toBe(true);
+
+        const membership = await server.stores.team.getMembership(
+            team.uid,
+            result.userId,
+        );
+        expect(Number(membership?.org_owned)).toBe(1);
+    });
+
+    it('gives the new account its default filesystem tree', async () => {
+        const { team } = await makeWorkspace();
+        const username = `tree_${Math.random().toString(36).slice(2, 9)}`;
+
+        const result = await service.provisionAccount(team.uid, owner.id, {
+            username,
+            email: `${username}@test.local`,
+        });
+
+        const user = await server.stores.user.getById(result.userId);
+        expect(user?.trash_uuid).toBeTruthy();
+    });
+
+    it('returns a temporary password the admin delivers out of band', async () => {
+        const { team } = await makeWorkspace();
+        const username = `link_${Math.random().toString(36).slice(2, 9)}`;
+
+        const result = await service.provisionAccount(team.uid, owner.id, {
+            username,
+            email: `${username}@test.local`,
+        });
+
+        expect(result.temporaryPassword).toHaveLength(16);
+        const user = await server.stores.user.getById(result.userId);
+        // Hashed, and the account cannot do anything until it is changed.
+        expect(user?.password).not.toBe(result.temporaryPassword);
+        expect(Boolean(user?.requires_password_change)).toBe(true);
+    });
+
+    it('writes nothing when the username is taken', async () => {
+        const { team } = await makeWorkspace();
+        const taken = await makeUser();
+        const before = await server.stores.team.listMembers(team.uid);
+
+        await expect(
+            service.provisionAccount(team.uid, owner.id, {
+                username: taken.username,
+                email: 'someone@test.local',
+            }),
+        ).rejects.toMatchObject({ statusCode: 409 });
+
+        // Checked before any row is written, so the workspace is untouched.
+        const after = await server.stores.team.listMembers(team.uid);
+        expect(after.items).toHaveLength(before.items.length);
+    });
+
+    it('offers free alternatives instead of modifying the name', async () => {
+        const taken = await makeUser();
+        const suggestions = await service.suggestUsernames(taken.username);
+
+        expect(suggestions.length).toBeGreaterThan(0);
+        for (const suggestion of suggestions) {
+            expect(suggestion).not.toBe(taken.username);
+            await expect(
+                server.stores.user.getByUsername(suggestion),
+            ).resolves.toBeFalsy();
+        }
+    });
+
+    it('refuses provisioning by anyone but the workspace owner', async () => {
+        const { team, member } = await makeWorkspace();
+        await expect(
+            service.provisionAccount(team.uid, member.id, {
+                username: `nope_${Math.random().toString(36).slice(2, 9)}`,
+                email: 'nope@test.local',
+            }),
+        ).rejects.toMatchObject({ statusCode: 403 });
+    });
+
+    it('re-issues a different credential each time', async () => {
+        const { team } = await makeWorkspace();
+        const username = `again_${Math.random().toString(36).slice(2, 9)}`;
+        const result = await service.provisionAccount(team.uid, owner.id, {
+            username,
+            email: `${username}@test.local`,
+        });
+        const again = await service.reissueCredential(
+            team.uid,
+            owner.id,
+            result.userId,
+        );
+        expect(again.temporaryPassword).not.toBe(result.temporaryPassword);
+    });
+
+    it('refuses to re-issue once the member has chosen a password', async () => {
+        const { team } = await makeWorkspace();
+        const username = `done_${Math.random().toString(36).slice(2, 9)}`;
+        const result = await service.provisionAccount(team.uid, owner.id, {
+            username,
+            email: `${username}@test.local`,
+        });
+        // Simulate the member choosing their own password.
+        await server.stores.user.update(result.userId, {
+            requires_password_change: 0,
+        });
+
+        await expect(
+            service.reissueCredential(team.uid, owner.id, result.userId),
+        ).rejects.toMatchObject({ statusCode: 409 });
+    });
+    it('refuses an email that already belongs to an account', async () => {
+        const { team } = await makeWorkspace();
+        const existing = await makeUser();
+        const row = await server.stores.user.getById(existing.id);
+
+        await expect(
+            service.provisionAccount(team.uid, owner.id, {
+                username: `dup_${Math.random().toString(36).slice(2, 9)}`,
+                email: row!.email!,
+            }),
+        ).rejects.toMatchObject({ statusCode: 409 });
+    });
+
+    it('refuses a username signup itself would reject', async () => {
+        const { team } = await makeWorkspace();
+        for (const username of ['has-hyphen', 'x'.repeat(46), 'admin']) {
+            await expect(
+                service.provisionAccount(team.uid, owner.id, {
+                    username,
+                    email: 'x@test.local',
+                }),
+            ).rejects.toMatchObject({ statusCode: 400 });
+        }
+    });
+
+    it('refuses an invalid email', async () => {
+        const { team } = await makeWorkspace();
+        await expect(
+            service.provisionAccount(team.uid, owner.id, {
+                username: `bad_${Math.random().toString(36).slice(2, 9)}`,
+                email: 'not-an-email',
+            }),
+        ).rejects.toMatchObject({ statusCode: 400 });
+    });
+
+    it('only suggests usernames the next call would accept', async () => {
+        const taken = await makeUser();
+        for (const s of await service.suggestUsernames(taken.username)) {
+            expect(s.length).toBeLessThanOrEqual(45);
+            expect(s).toMatch(/^\w+$/u);
+        }
+    });
+    it('generates a different credential for every account', async () => {
+        const { team } = await makeWorkspace();
+        const seen = new Set<string>();
+        for (let i = 0; i < 3; i++) {
+            const u = `gen_${Math.random().toString(36).slice(2, 9)}`;
+            const r = await service.provisionAccount(team.uid, owner.id, {
+                username: u,
+                email: `${u}@test.local`,
+            });
+            expect(r.temporaryPassword).toMatch(/^[A-Za-z2-9]{16}$/u);
+            seen.add(r.temporaryPassword);
+        }
+        expect(seen.size).toBe(3);
+    });
+
+    it('survives having no email transport, since the notice carries nothing', async () => {
+        const { team } = await makeWorkspace();
+        const u = `noem_${Math.random().toString(36).slice(2, 9)}`;
+
+        // The credential is returned, so delivery failing loses nothing.
+        const r = await service.provisionAccount(team.uid, owner.id, {
+            username: u,
+            email: `${u}@test.local`,
+        });
+        expect(r.temporaryPassword).toBeTruthy();
     });
 });

--- a/src/backend/services/team/TeamService.ts
+++ b/src/backend/services/team/TeamService.ts
@@ -17,10 +17,36 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+import bcrypt from 'bcrypt';
+import { randomBytes } from 'node:crypto';
+import validator from 'validator';
+import { v4 as uuidv4 } from 'uuid';
+import {
+    RESERVED_USERNAMES,
+    USERNAME_MAX_LENGTH,
+    USERNAME_REGEX,
+} from '../../controllers/auth/AuthController.js';
 import { HttpError } from '../../core/http/HttpError.js';
 import { checkHandle } from '../../stores/team/TeamStore.js';
 import type { TeamMemberRow, TeamRow } from '../../stores/team/TeamStore';
+import type { UserRow } from '../../stores/user/UserStore';
+import { cleanEmail } from '../../util/email.js';
+import { generateDefaultFsentries } from '../../util/userProvisioning.js';
 import { PuterService } from '../types';
+
+/** Unambiguous alphabet -- no 0/O or 1/l, since a human retypes this. */
+const TEMP_PASSWORD_ALPHABET =
+    'ABCDEFGHJKMNPQRSTUVWXYZabcdefghjkmnpqrstuvwxyz23456789';
+
+/** ~95 bits, generated rather than chosen so it is never a reused pattern. */
+export const generateTemporaryPassword = (length = 16): string => {
+    const bytes = randomBytes(length);
+    let out = '';
+    for (let i = 0; i < length; i++) {
+        out += TEMP_PASSWORD_ALPHABET[bytes[i] % TEMP_PASSWORD_ALPHABET.length];
+    }
+    return out;
+};
 
 /** Why an account was disabled. Free text in `0063`; this is the team one. */
 export const DISABLED_BY_WORKSPACE = 'disabled_by_workspace';
@@ -181,6 +207,169 @@ export class TeamService extends PuterService {
             [team.id],
         )) as { n: number }[];
         return Number(rows[0]?.n) === 1;
+    }
+
+    // -- Provisioning -------------------------------------------------
+    // Usernames come from Puter's global pool, so a taken one is reported.
+
+    /** Provisioning must not mint accounts signup itself would refuse. */
+    #usernameRejection(username: string): boolean {
+        return (
+            !USERNAME_REGEX.test(username) ||
+            username.length > USERNAME_MAX_LENGTH ||
+            RESERVED_USERNAMES.has(username.toLowerCase())
+        );
+    }
+
+    #assertUsableUsername(username: string): void {
+        if (this.#usernameRejection(username)) {
+            throw new HttpError(400, 'Invalid username', {
+                legacyCode: 'bad_request',
+            });
+        }
+    }
+
+    /** Free names near `username`, checked for availability. Never auto-applied. */
+    async suggestUsernames(username: string, count = 3): Promise<string[]> {
+        // Room for the suffix, or every suggestion breaks the length rule.
+        const base = username.slice(0, USERNAME_MAX_LENGTH - 3);
+        const found: string[] = [];
+        for (let n = 1; n <= 40 && found.length < count; n++) {
+            const candidate = `${base}${n}`;
+            if (this.#usernameRejection(candidate)) continue;
+            if (!(await this.stores.user.getByUsername(candidate))) {
+                found.push(candidate);
+            }
+        }
+        return found;
+    }
+
+    /** Returns the activation link; the account has no password until used. */
+    async provisionAccount(
+        teamUid: string,
+        actorUserId: number,
+        input: { username: string; email: string },
+    ): Promise<{
+        userId: number;
+        username: string;
+        temporaryPassword: string;
+    }> {
+        const team = await this.requireOwner(teamUid, actorUserId);
+        this.#assertUsableUsername(input.username);
+        if (!validator.isEmail(input.email)) {
+            throw new HttpError(400, 'Invalid email', {
+                legacyCode: 'bad_request',
+            });
+        }
+
+        // Before any write, so a taken name fails cleanly.
+        if (await this.stores.user.getByUsername(input.username)) {
+            throw new HttpError(409, 'That username is taken', {
+                legacyCode: 'username_already_in_use',
+                fields: {
+                    suggestions: await this.suggestUsernames(input.username),
+                },
+            });
+        }
+
+        // `idx_user_owned_email` is partial and skips password-null rows.
+        if (await this.stores.user.findEmailOwner(input.email)) {
+            throw new HttpError(409, 'That email is already in use', {
+                legacyCode: 'email_already_in_use',
+            });
+        }
+
+        const user = await this.stores.user.create({
+            username: input.username,
+            uuid: uuidv4(),
+            password: null,
+            email: input.email,
+            clean_email: cleanEmail(input.email),
+            // The address came from the administrator, not its holder.
+            requires_email_confirmation: true,
+        });
+
+        await generateDefaultFsentries(this.clients.db, this.stores.user, user);
+
+        // Otherwise a vanished workspace leaves a real account nobody owns.
+        const admitted = await this.stores.team.addMember(teamUid, user.id, {
+            orgOwned: true,
+        });
+        if (!admitted) {
+            await this.services.userAccount.cascadeDelete(user.id);
+            throw new HttpError(409, 'That workspace is no longer available', {
+                legacyCode: 'conflict',
+            });
+        }
+
+        // Returned once for the administrator to deliver out of band; forced
+        // change on first use is what bounds it.
+        const temporaryPassword = generateTemporaryPassword();
+        await this.stores.user.update(user.id, {
+            password: await bcrypt.hash(temporaryPassword, 8),
+            requires_password_change: 1,
+        });
+        await this.#notifyAccountCreated(user, team);
+
+        return {
+            userId: user.id,
+            username: user.username,
+            temporaryPassword,
+        };
+    }
+
+    /** Issues a fresh credential, invalidating the previous one. */
+    async reissueCredential(
+        teamUid: string,
+        actorUserId: number,
+        targetUserId: number,
+    ): Promise<{ temporaryPassword: string }> {
+        const team = await this.requireOwner(teamUid, actorUserId);
+        await this.requireOrgAccount(teamUid, targetUserId);
+
+        const user = await this.stores.user.getByProperty('id', targetUserId, {
+            force: true,
+        });
+        if (!user) {
+            throw new HttpError(404, 'Account not found', {
+                legacyCode: 'not_found',
+            });
+        }
+        // Only before first use; changing a live account's password is reset.
+        if (!user.requires_password_change) {
+            throw new HttpError(409, 'That account is already activated', {
+                legacyCode: 'conflict',
+            });
+        }
+
+        const temporaryPassword = generateTemporaryPassword();
+        await this.stores.user.update(targetUserId, {
+            password: await bcrypt.hash(temporaryPassword, 8),
+            requires_password_change: 1,
+        });
+        await this.#notifyAccountCreated(user, team);
+        return { temporaryPassword };
+    }
+
+    /** A notice only -- it carries no credential, so delivery is best effort. */
+    async #notifyAccountCreated(user: UserRow, team: TeamRow): Promise<void> {
+        if (!this.clients.email || !user.email) return;
+        try {
+            const sent = await this.clients.email.send(
+                user.email,
+                'team_account_created',
+                {
+                    username: user.username,
+                    team_name: team.name ?? 'Your workspace',
+                },
+            );
+            // `sendRaw` returns null with no transport rather than throwing.
+            if (sent === null) {
+                console.warn('[team-provision] no email transport configured');
+            }
+        } catch (e) {
+            console.warn('[team-provision] notice failed:', e);
+        }
     }
 
     // -- Disable and re-enable ----------------------------------------


### PR DESCRIPTION
> Seventh in the stack: #3704 → #3705 → #3708 → #3709 → #3710 → #3712 → this. Review bottom-up.

**PUT-1705** on its own. This is the operation the feature exists for, it creates real user accounts and sends mail, so it doesn't share a review with anything.

```
provisionAccount(teamUid, actorUserId, { username, email })
    -> { userId, username, activationLink }
suggestUsernames(username, count?)
resendActivation(teamUid, actorUserId, targetUserId)
```

## Activation reuses password recovery

No new token machinery, no `team_activation` table, no unauthenticated endpoint on the team surface. Provisioning sets the same `pass_recovery_token` that `/send-pass-recovery-email` uses, signs the same one-hour `otp` JWT with `purpose: 'pass-recovery'`, and hands back the same `/action/set-new-password` link.

That inherits, for free: a one-shot token cleared on use, expiry carried in a signed JWT rather than a DB column, atomic single-use consumption, purpose scoping so the link can't be replayed for another operation, and refusal for suspended accounts.

**Activation state needs no column either.** An unactivated account is one with no password — the predicate migration `0066` already uses. `resendActivation` refuses an account that has one, because re-sending then would be a password reset wearing the wrong name.

## Usernames come from the global pool

Usernames are globally unique and case-insensitive (`idx_user_username_nocase`, `0055`), so a workspace provisions from the same namespace as every other Puter user. Two companies cannot both have a `juan`.

What provisioning adds is a check and a suggestion — **never a silent modification**. A suffixed `juan-castro-2` would appear in every share dialog that person ever sees, and they never agreed to it. So a taken name is refused with `username_already_in_use` plus alternatives that have been *verified free*, and the administrator chooses.

⚠ **The check runs before any write.** A taken name failing part-way through account setup would leave an orphaned `user` row and a half-provisioned account. There's a test asserting the workspace's member count is unchanged after a rejected provision.

## Two smaller decisions

`requires_email_confirmation` is set on the new account. The address came from the administrator, not its holder, so it is unverified by definition — and §5.5 later depends on that address being the member's, which makes confirming it load-bearing rather than tidy.

The `team_account_activation` template states what the workspace can and cannot do:

> - This account belongs to {{team_name}}. They pay for it and can close it.
> - {{team_name}} **cannot** see your files, apps or data.
> - {{team_name}} **can** reset your password. You will be emailed each time that happens, and every reset is recorded where you can see it.

That last line is required, not padding. Stating only that admins cannot see the contents would describe a guarantee the system does not make.

The equivalent disclosure on the set-password *screen* is phase 6, since that's GUI.

---

## Verification

```
$ npx vitest run --config src/backend/vitest.config.ts src/backend/services/team/
 Test Files  1 passed (1)
      Tests  21 passed (21)

$ PUTER_TEST_DB_ENGINE=postgres npx vitest run --config src/backend/vitest.config.ts src/backend/services/team/
 Test Files  1 passed (1)
      Tests  21 passed (21)

$ npm run test:backend
 Test Files  252 passed | 24 skipped (276)
      Tests  6751 passed | 26 skipped (6777)      # +8, no regressions

$ npm run typecheck
Type check passed — no new errors (33 known, baselined).
```

Eight tests added: the account is created password-less and owned by the workspace, it gets its filesystem tree (`trash_uuid` set, which is also `generateDefaultFsentries`' own idempotency guard), the activation link is returned and a recovery token stored, a taken username writes nothing, suggestions are verified free and never equal the taken name, a non-master is refused, re-issuing rotates the token, and an activated account cannot be re-sent.

## Not here

| Deferred | To |
| --- | --- |
| `user.free_storage` stamped from a team policy | **deleted, not deferred** — a seat is an ordinary account on the common tier, so its ceiling is `config.storage_capacity` like any other. See `TEAMS-BILLING-SPLIT.md` |
| The billing event that starts the per-account charge | phase 3, PUT-1712 |
| Audit row for `provision` | PUT-1708 |
| Disclosure on the set-password screen | phase 6 |

---

Closes PUT-1705.

