### PR TITLE
fix: classify Replicate prediction failures instead of surfacing them as 500s

### DIFF
--- a/src/backend/drivers/ai-image/providers/replicate/ReplicateImageGenerationProvider.test.ts
+++ b/src/backend/drivers/ai-image/providers/replicate/ReplicateImageGenerationProvider.test.ts
@@ -392,3 +392,94 @@ describe('ReplicateImageGenerationProvider.generate go_fast pricing', () => {
         expect(outputMp?.costOverride).toBe(Math.round(1.2 * 1_000_000));
     });
 });
+
+// -- Upstream rejection handling --
+
+describe('ReplicateImageGenerationProvider.generate upstream rejections', () => {
+    const generate = () =>
+        withTestActor(() =>
+            makeProvider().generate({
+                model: 'black-forest-labs/flux-schnell',
+                prompt: 'hi',
+            }),
+        );
+
+    it('maps an NSFW refusal to 400 moderation_flagged without metering', async () => {
+        runMock.mockRejectedValueOnce(
+            new Error(
+                'Prediction failed: Error generating image: NSFW content detected.',
+            ),
+        );
+
+        await expect(generate()).rejects.toMatchObject({
+            statusCode: 400,
+            legacyCode: 'bad_request',
+            code: 'moderation_flagged',
+            message: 'Error generating image: NSFW content detected.',
+            fields: { provider: 'replicate' },
+        });
+        expect(incrementUsageSpy).not.toHaveBeenCalled();
+    });
+
+    it('maps a sensitive-content (E005) refusal to 400 moderation_flagged', async () => {
+        runMock.mockRejectedValueOnce(
+            new Error(
+                'Prediction failed: The input or output was flagged as sensitive. Please try again with different inputs. (E005)',
+            ),
+        );
+
+        await expect(generate()).rejects.toMatchObject({
+            statusCode: 400,
+            code: 'moderation_flagged',
+        });
+    });
+
+    it('maps any other failed prediction to 502 upstream_failed, keeping the cause', async () => {
+        const raw = new Error(
+            'Prediction failed: q_descale must have shape (batch_size, num_heads_k)',
+        );
+        runMock.mockRejectedValueOnce(raw);
+
+        await expect(generate()).rejects.toMatchObject({
+            statusCode: 502,
+            legacyCode: 'upstream_failed',
+            message: 'q_descale must have shape (batch_size, num_heads_k)',
+            fields: { provider: 'replicate' },
+            cause: raw,
+        });
+        expect(incrementUsageSpy).not.toHaveBeenCalled();
+    });
+
+    it('strips markup and bounds the message when upstream returns an HTML error page', async () => {
+        const page =
+            '<html><head><style>body{color:red}</style></head><body>' +
+            "<h1>Our services aren't available right now</h1>" +
+            `<p>${'x'.repeat(500)}</p></body></html>`;
+        runMock.mockRejectedValueOnce(
+            new Error(
+                `Prediction failed: Error generating image: Failed to generate: ${page}`,
+            ),
+        );
+
+        const err = await generate().catch((e) => e);
+        expect(err).toMatchObject({
+            statusCode: 502,
+            legacyCode: 'upstream_failed',
+        });
+        expect(err.message).toContain("Our services aren't available right now");
+        expect(err.message).not.toMatch(/<|body\{/);
+        expect(err.message.length).toBeLessThanOrEqual(300);
+    });
+
+    it('passes a rejection that carries an HTTP status through untouched for the driver boundary', async () => {
+        const apiError = Object.assign(
+            new Error(
+                'Request to https://api.replicate.com/v1/predictions failed with status 429 Too Many Requests',
+            ),
+            { name: 'ApiError', response: { status: 429 } },
+        );
+        runMock.mockRejectedValueOnce(apiError);
+
+        await expect(generate()).rejects.toBe(apiError);
+    });
+});

--- a/src/backend/drivers/ai-image/providers/replicate/ReplicateImageGenerationProvider.ts
+++ b/src/backend/drivers/ai-image/providers/replicate/ReplicateImageGenerationProvider.ts
@@ -33,6 +33,27 @@ import {
 const DEFAULT_MODEL = 'black-forest-labs/flux-schnell';
 const DEFAULT_RATIO = { w: 1024, h: 1024 };
 
+const PREDICTION_FAILED_PREFIX = 'Prediction failed:';
+const MAX_UPSTREAM_MESSAGE_LENGTH = 300;
+// Model-side content filters, as worded in failed-prediction errors.
+const CONTENT_FILTER_PATTERN =
+    /\bnsfw\b|flagged as sensitive|sensitive content|content policy|\bE005\b/i;
+
+/**
+ * Strips markup and bounds length so an upstream HTML error page never rides
+ * through into a response body or an alarm signature.
+ */
+const sanitizeUpstreamMessage = (raw: string): string => {
+    const text = raw
+        .replace(/<(style|script)[\s\S]*?<\/\1>/gi, ' ')
+        .replace(/<[^>]*>/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim();
+    return text.length > MAX_UPSTREAM_MESSAGE_LENGTH
+        ? `${text.slice(0, MAX_UPSTREAM_MESSAGE_LENGTH - 3)}...`
+        : text;
+};
+
 export class ReplicateImageGenerationProvider implements IImageProvider {
     static readonly #CORE_PARAMS: readonly string[] = [
         'prompt',
@@ -173,10 +194,15 @@ export class ReplicateImageGenerationProvider implements IImageProvider {
             singleImage,
         });
 
-        const output = await this.#client.run(
-            selectedModel.replicateId as `${string}/${string}`,
-            { input },
-        );
+        let output: unknown;
+        try {
+            output = await this.#client.run(
+                selectedModel.replicateId as `${string}/${string}`,
+                { input },
+            );
+        } catch (err) {
+            throw this.#translatePredictionFailure(err);
+        }
 
         const url = this.#extractUrl(output);
         if (!url) {
@@ -205,6 +231,42 @@ export class ReplicateImageGenerationProvider implements IImageProvider {
             (m) => m.id === model || m.aliases?.includes(model ?? ''),
         );
         return found ?? models.find((m) => m.id === DEFAULT_MODEL)!;
+    }
+
+    /**
+     * A prediction that ran and ended `failed` reaches us as a plain Error with
+     * no HTTP status, so the driver boundary cannot classify it and it would
+     * surface as an unhandled 500. Content-filter refusals are the caller's to
+     * act on; anything else is an upstream fault. Errors that do carry a status
+     * (the SDK's ApiError) pass through untouched so the boundary translator
+     * still sees it.
+     */
+    #translatePredictionFailure(err: unknown): unknown {
+        if (!(err instanceof Error)) return err;
+        if (!err.message.startsWith(PREDICTION_FAILED_PREFIX)) return err;
+
+        const detail = sanitizeUpstreamMessage(
+            err.message.slice(PREDICTION_FAILED_PREFIX.length),
+        );
+        const fields = { provider: 'replicate' };
+
+        if (CONTENT_FILTER_PATTERN.test(detail)) {
+            return new HttpError(
+                400,
+                detail || 'Prompt or output was rejected by the content filter',
+                {
+                    legacyCode: 'bad_request',
+                    code: 'moderation_flagged',
+                    fields,
+                    cause: err,
+                },
+            );
+        }
+        return new HttpError(502, detail || 'Replicate prediction failed', {
+            legacyCode: 'upstream_failed',
+            fields,
+            cause: err,
+        });
     }
 
     /**

--- a/src/docs/src/AI/txt2img.md
+++ b/src/docs/src/AI/txt2img.md
@@ -171,6 +171,18 @@ Absolute paths (`/username/Pictures/sunset.png`) and home-relative paths (`~/Pic
 
 A `Promise` that resolves to an `HTMLImageElement`. The element’s `src` points at a data URL containing the image.
 
+## Errors
+
+A rejection carries the error body as the backend sent it: `{ message, code }`, plus `errorCode` when a more specific code is available alongside a general one.
+
+| Code | Meaning |
+| --- | --- |
+| `errorCode: moderation_flagged` | The model's content filter refused the prompt or the generated image. Arrives as HTTP 400 with `code: bad_request`. Change the prompt rather than retrying it as-is. Not every provider reports refusals distinctly; when one does, this is how. |
+| `upstream_failed` | The provider accepted the request but generation failed on their side. Safe to retry. |
+| `insufficient_funds` | Your balance cannot cover the estimated cost of the image. Arrives as HTTP 402. |
+
+Other `upstream_*` codes mean the provider rejected the request or was unavailable; the `message` carries the provider's reason.
+
 ## Examples
 
 <strong class="example-title">Generate an image of a cat using AI</strong>


### PR DESCRIPTION
Closes PUT-1608.

## What

`await this.#client.run(...)` in the Replicate image provider had no error handling. A prediction that ran and ended `failed` is thrown by the Replicate SDK as a plain `Error("Prediction failed: …")` with no HTTP status, so the driver-boundary `translateProviderError` could not classify it. Every such failure became an unhandled 500, a `critical` alarm, and a page. This was the largest single alarmed-5xx bucket on the fleet, and most occurrences were the model's content filter refusing the user's prompt.

This PR wraps the call and classifies the failure in the provider:

- **Content-filter refusals** (NSFW, "flagged as sensitive", E005, "content policy") → **400** with `code: bad_request`, `errorCode: moderation_flagged`. Same shape the chat driver already uses for moderation refusals, so clients key on one code across both.
- **Anything else** (model runtime crashes, upstream 502 pages) → **502** with `code: upstream_failed`. The alarm gate skips 5xx carrying an `upstream_*` code, so it no longer pages.
- **Status-bearing rejections** (the SDK's `ApiError`) are rethrown untouched so the boundary translator keeps mapping them to `upstream_rate_limited` / `upstream_auth_failed` / etc. as it does today.
- Upstream messages are **stripped of markup and capped at 300 chars** before they go anywhere, so an Azure Front Door HTML page can never ride into a response body or an alarm signature again.
- Both new errors carry `fields: { provider: 'replicate' }` and the original error as `cause`, matching the BytePlus/Together providers.

The txt2img reference gains an **Errors** section documenting `moderation_flagged`, `upstream_failed`, and `insufficient_funds`, with the exact body shape puter.js hands to callers.

## Reviewer notes

- **502 vs 400 for upstream faults.** The ticket asks for 502, and BytePlus video already uses `status >= 500 ? 502 : 400`. The boundary translator, chat driver, and ElevenLabs expose upstream 5xx as a 400 `upstream_provider_unavailable` instead. Going with the ticket here; either is safe for paging.
- Classification lives in the provider rather than the controller translator because it depends on Replicate-specific message wording.
- The content-filter regex is deliberately conservative (no bare `safety`, which would match parameter-validation errors like `disable_safety_checker`).

## Verification

- Five regression tests added to the provider suite: NSFW and E005 refusals → 400 `moderation_flagged` with no metering; generic crash → 502 `upstream_failed` with `cause`; HTML page → tags stripped and length bounded; status-bearing error → passed through by identity. All five fail on `main`.
- Ran a throwaway end-to-end test (not committed) that booted the real server via `setupPuterTestEnv` with a Replicate key, mocked the SDK, and POSTed to `/drivers/call` over HTTP while spying on `clients.alarm.create`: the refusal returned 400 `moderation_flagged` with no alarm, the crash returned 502 `upstream_failed` with no alarm, and a control unclassified error still returned 500 and alarmed at `critical`.
- Full `src/backend/drivers/ai-image` tree: 203 passed. `eslint`, `prettier --check`, and `npm run typecheck` clean on the source file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
