### PR TITLE
🏗️ PUT-1761: tell the members when something is shared with the workspace

### DIFF
--- a/src/backend/services/share/ShareNotificationService.ts
+++ b/src/backend/services/share/ShareNotificationService.ts
@@ -40,7 +40,8 @@ import {
     shareDeepLink,
     sharedViewLink,
 } from './shareDeepLink';
-import type { ResolvedShare } from './ShareService';
+import { NOTIFY_FANOUT_CAP } from '../../stores/team/TeamStore';
+import { blocksAllShares, type ResolvedShare } from './ShareService';
 
 /**
  * How long one sharer stays quiet after reaching a recipient, and how long a
@@ -264,26 +265,28 @@ export class ShareNotificationService extends PuterService {
         const counts = new Map<number, number>();
         const named = new Map<number, DigestItem[]>();
         const targets = new Map<number, ShareNotificationTarget | null>();
-        for (const share of shares) {
-            if (share.pending) continue;
-            if (!share.isNew || !share.holderId) continue;
-            if (share.holderId === issuerId) continue;
-            counts.set(share.holderId, (counts.get(share.holderId) ?? 0) + 1);
+        // A team share has no holder of its own, so it is expanded here.
+        for (const { holderId, share } of await this.#recipientsOf(
+            shares,
+            issuerId,
+        )) {
+            counts.set(holderId, (counts.get(holderId) ?? 0) + 1);
             const item = this.#digestItem(share);
             if (item) {
-                const items = named.get(share.holderId) ?? [];
+                const items = named.get(holderId) ?? [];
                 if (items.length < DIGEST_NAMES_PER_SENDER) items.push(item);
-                named.set(share.holderId, items);
+                named.set(holderId, items);
             }
             // Only a lone item is worth pointing at; a second nulls it.
             const path = this.#targetPath(share);
             targets.set(
-                share.holderId,
-                targets.has(share.holderId) || !path
+                holderId,
+                targets.has(holderId) || !path
                     ? null
                     : { path, name: share.name as string },
             );
         }
+
 
         // Each recipient fails alone: one refused send must not cost the next
         // person their notification. Failures are logged, never thrown.
@@ -323,6 +326,95 @@ export class ShareNotificationService extends PuterService {
         } catch (err) {
             console.warn('[share-notify] could not email invites:', err);
         }
+    }
+
+    /**
+     * Who each share announces to. A user share is its own holder; a team
+     * share is every live member except the issuer, expanded at announcement
+     * time so the grant stays one row and only the telling fans out.
+     *
+     * A member who joins later resolves the grant through the scan but is never
+     * told: access follows the team, announcements describe a moment.
+     */
+    async #recipientsOf(
+        shares: ResolvedShare[],
+        issuerId: number,
+    ): Promise<Array<{ holderId: number; share: ResolvedShare }>> {
+        const out: Array<{ holderId: number; share: ResolvedShare }> = [];
+        const byGroup = new Map<number, number[]>();
+        const allowedByGroup = new Map<number, number[]>();
+        for (const share of shares) {
+            if (share.pending || !share.isNew) continue;
+
+            if (share.holderId) {
+                if (share.holderId === issuerId) continue;
+                out.push({ holderId: share.holderId, share });
+                continue;
+            }
+            if (!share.holderGroupId) continue;
+
+            // Cached per group: N items shared with one team is one read.
+            let members = byGroup.get(share.holderGroupId);
+            if (!members) {
+                try {
+                    members = await this.stores.team.listMemberIdsByGroupId(
+                        share.holderGroupId,
+                    );
+                } catch (err) {
+                    // Silence is this path's failure mode, so say so out loud.
+                    console.warn(
+                        '[share-notify] could not expand team',
+                        share.holderGroupId,
+                        err,
+                    );
+                    continue;
+                }
+                byGroup.set(share.holderGroupId, members);
+            }
+            // The store reads one past the cap, so `>` means it really did
+            // truncate; exactly the cap did not.
+            if (members.length > NOTIFY_FANOUT_CAP) {
+                members = members.slice(0, NOTIFY_FANOUT_CAP);
+                byGroup.set(share.holderGroupId, members);
+                console.warn(
+                    '[share-notify] team fan-out hit the cap; some members were not told',
+                    { groupId: share.holderGroupId, cap: NOTIFY_FANOUT_CAP },
+                );
+            }
+            // A block refuses contact, and this is the contact: the group grant
+            // is one row so it cannot exclude a member, but the telling can.
+            // Cached with the member list -- block state is per pair, not per item.
+            let allowed = allowedByGroup.get(share.holderGroupId);
+            if (!allowed) {
+                allowed = await this.#unblocked(members, issuerId);
+                allowedByGroup.set(share.holderGroupId, allowed);
+            }
+            for (const holderId of allowed) {
+                if (holderId === issuerId) continue;
+                out.push({ holderId, share });
+            }
+        }
+        return out;
+    }
+
+    /** Members who have not refused shares from this issuer. */
+    async #unblocked(members: number[], issuerId: number): Promise<number[]> {
+        const kept = await Promise.all(
+            members.map(async (id) => {
+                try {
+                    const user = await this.stores.user.getById(id);
+                    if (blocksAllShares(user)) return null;
+                    return (await this.stores.userBlock.isBlocked(id, issuerId))
+                        ? null
+                        : id;
+                } catch (err) {
+                    // Failing open would announce to someone who refused it.
+                    console.warn('[share-notify] block check failed', id, err);
+                    return null;
+                }
+            }),
+        );
+        return kept.filter((id): id is number => id !== null);
     }
 
     /**

--- a/src/backend/services/share/TeamShareNotify.test.ts
+++ b/src/backend/services/share/TeamShareNotify.test.ts
@@ -1,0 +1,317 @@
+/*
+ * Copyright (C) 2024-present Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import {
+    afterAll,
+    afterEach,
+    beforeAll,
+    beforeEach,
+    describe,
+    expect,
+    it,
+    vi,
+} from 'vitest';
+import type { Actor } from '../../core/actor';
+import {
+    setupTwoTeams,
+    type TwoTeams,
+} from '../../testFixtures/twoTeams.js';
+
+/**
+ * A team share names no holder, so every map in `notifyShared` used to skip
+ * it and the call succeeded having told nobody. The failure mode is silence:
+ * the share is created, resolves and lists correctly, and nothing errors. Only
+ * a test that counts notifications catches it.
+ */
+describe('announcing a team share', () => {
+    let fx: TwoTeams;
+
+    const actorFor = async (userId: number): Promise<Actor> => {
+        const user = await fx.env.server.stores.user.getById(userId);
+        return { user } as unknown as Actor;
+    };
+
+    const makeFile = async (ownerId: number) => {
+        const uid = crypto.randomUUID();
+        const name = `n_${uid.slice(0, 8)}.txt`;
+        const owner = await fx.env.server.stores.user.getById(ownerId);
+        const path = `/${owner!.username}/${name}`;
+        await fx.env.server.clients.db.write(
+            'INSERT INTO `fsentries` (`uuid`, `name`, `path`, `user_id`, `is_dir`, `modified`) ' +
+                'VALUES (?, ?, ?, ?, ?, ?)',
+            [
+                uid,
+                name,
+                path,
+                ownerId,
+                fx.env.server.clients.db.booleanValue(false),
+                Math.floor(Date.now() / 1000),
+            ],
+        );
+        return path;
+    };
+
+    /** Share and announce, the way `ShareController` does on the response path. */
+    const shareAndNotify = async (
+        issuerId: number,
+        path: string,
+        recipient: Record<string, string>,
+    ) => {
+        const actor = await actorFor(issuerId);
+        const share = await fx.env.server.services.share.share(actor, {
+            path,
+            recipient,
+            mode: 'read',
+        } as never);
+        await fx.env.server.services.shareNotification.notifyShared(actor, [
+            share,
+        ]);
+        return share;
+    };
+
+    const notificationsFor = async (userId: number) => {
+        const rows = await fx.env.server.stores.notification.listByUserId(
+            userId,
+            { filter: 'unacknowledged' },
+        );
+        return rows as unknown as Array<{ value?: unknown }>;
+    };
+
+    const titlesFor = async (userId: number): Promise<string[]> =>
+        (await notificationsFor(userId)).map((row) => {
+            const value = (
+                typeof row.value === 'string'
+                    ? JSON.parse(row.value)
+                    : (row.value ?? {})
+            ) as { title?: string };
+            return value.title ?? '';
+        });
+
+    let sent: Array<{ to: string; subject: string }>;
+
+    beforeAll(async () => {
+        fx = await setupTwoTeams({
+            // A transport must exist for the service to try at all; `sendRaw`
+            // is spied, so nothing leaves the process.
+            email: {
+                from: '"Puter (test)" <no-reply@puter.localhost>',
+                host: '127.0.0.1',
+                port: 1,
+            },
+            // Digests flush almost at once rather than after a real minute.
+            share_notify_limits: { emailBatchSeconds: 0.05 },
+        } as never);
+    }, 180_000);
+
+    beforeEach(() => {
+        sent = [];
+        vi.spyOn(fx.env.server.clients.email, 'sendRaw').mockImplementation(
+            async (options: { to: string; subject: string }) => {
+                sent.push({ to: options.to, subject: options.subject });
+                return null;
+            },
+        );
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    afterAll(async () => {
+        await fx?.shutdown();
+    });
+
+    it('tells every member of the team', async () => {
+        const path = await makeFile(fx.a.owner.userId);
+        await shareAndNotify(fx.a.owner.userId, path, { team: fx.a.uid });
+
+        for (const seat of fx.a.seats) {
+            const titles = await titlesFor(seat.userId);
+            expect(titles.length).toBeGreaterThan(0);
+        }
+    });
+
+    it('does not tell the issuer about their own share', async () => {
+        const before = (await notificationsFor(fx.a.owner.userId)).length;
+        const path = await makeFile(fx.a.owner.userId);
+        await shareAndNotify(fx.a.owner.userId, path, { team: fx.a.uid });
+
+        expect((await notificationsFor(fx.a.owner.userId)).length).toBe(before);
+    });
+
+    it('does not tell members of a team it was not shared with', async () => {
+        const before = await Promise.all(
+            fx.b.seats.map(async (s) => (await notificationsFor(s.userId)).length),
+        );
+        const path = await makeFile(fx.a.owner.userId);
+        await shareAndNotify(fx.a.owner.userId, path, { team: fx.a.uid });
+
+        const after = await Promise.all(
+            fx.b.seats.map(async (s) => (await notificationsFor(s.userId)).length),
+        );
+        expect(after).toEqual(before);
+    });
+
+    it('does not retroactively tell a member who joins afterwards', async () => {
+        const path = await makeFile(fx.a.owner.userId);
+        await shareAndNotify(fx.a.owner.userId, path, { team: fx.a.uid });
+
+        // The outsider joins after the announcement; the scan will resolve the
+        // grant for them, but announcements describe a moment, not a state.
+        const team = await fx.env.server.stores.team.getByUid(fx.a.uid);
+        await fx.env.server.stores.team.addMember(
+            fx.a.uid,
+            fx.outsider.userId,
+            { orgOwned: false },
+        );
+        expect(team).toBeTruthy();
+
+        expect(await titlesFor(fx.outsider.userId)).toHaveLength(0);
+    });
+
+    it('emails every member too, not just the in-app notification', async () => {
+        const path = await makeFile(fx.a.owner.userId);
+        await shareAndNotify(fx.a.owner.userId, path, { team: fx.a.uid });
+
+        // The digest is held briefly, so wait for the flush rather than the
+        // queueing -- asserting too early passes for the wrong reason.
+        await vi.waitFor(
+            () => {
+                for (const seat of fx.a.seats) {
+                    expect(
+                        sent.some((mail) => mail.to === `${seat.username}@test.local`),
+                    ).toBe(true);
+                }
+            },
+            { timeout: 10_000, interval: 100 },
+        );
+
+        // And nobody outside the team was mailed about it. Checked against
+        // team B's owner, who never joins A -- the `outsider` is admitted
+        // to A by the test above, so by here they are a member.
+        expect(
+            sent.some((mail) => mail.to.includes(fx.b.owner.username)),
+        ).toBe(false);
+    });
+
+    it('does not announce to a member who blocked the sharer', async () => {
+        // A member nobody has notified yet, so a new row is detectable. Reusing
+        // a seat would not be: a second share *folds* into its open
+        // notification, leaving the row count unchanged either way.
+        const username = `blk_${Math.random().toString(36).slice(2, 9)}`;
+        const fresh = await fx.env.server.stores.user.create({
+            username,
+            uuid: crypto.randomUUID(),
+            password: null,
+            email: `${username}@test.local`,
+        });
+        await fx.env.server.stores.team.addMember(fx.a.uid, fresh.id, {
+            orgOwned: false,
+        });
+        const blocker = { userId: fresh.id, username };
+        const other = fx.a.seats[1];
+        await fx.env.server.stores.userBlock.create(
+            blocker.userId,
+            fx.a.owner.userId,
+        );
+
+        const before = (await notificationsFor(blocker.userId)).length;
+        expect(before).toBe(0);
+        const path = await makeFile(fx.a.owner.userId);
+        await shareAndNotify(fx.a.owner.userId, path, { team: fx.a.uid });
+
+        // The grant is one row against the group so it still reaches them; the
+        // contact the block refuses is the telling.
+        //
+        // Asserted on notifications rather than mail: by this point in the file
+        // the per-pair interruption budget is spent, so no digest opens and an
+        // email assertion would pass for the wrong reason. Notifications are
+        // still written when the budget is spent -- that is the documented
+        // split between what it says and whether it may interrupt.
+        expect((await notificationsFor(blocker.userId)).length).toBe(before);
+        expect(
+            (await notificationsFor(other.userId)).length,
+        ).toBeGreaterThan(0);
+
+        await fx.env.server.stores.userBlock.deleteByPair(
+            blocker.userId,
+            fx.a.owner.userId,
+        );
+    });
+
+    it('reads the member list once however many items are shared', async () => {
+        const spy = vi.spyOn(
+            fx.env.server.stores.team,
+            'listMemberIdsByGroupId',
+        );
+        const actor = await actorFor(fx.a.owner.userId);
+        const paths = [
+            await makeFile(fx.a.owner.userId),
+            await makeFile(fx.a.owner.userId),
+            await makeFile(fx.a.owner.userId),
+        ];
+        const created = [];
+        for (const path of paths) {
+            created.push(
+                await fx.env.server.services.share.share(actor, {
+                    path,
+                    recipient: { team: fx.a.uid },
+                    mode: 'read',
+                }),
+            );
+        }
+        spy.mockClear();
+
+        await fx.env.server.services.shareNotification.notifyShared(
+            actor,
+            created,
+        );
+
+        // One team, so one read -- not one per item.
+        expect(spy).toHaveBeenCalledTimes(1);
+    });
+    it('checks block state once per team, not once per item', async () => {
+        const spy = vi.spyOn(fx.env.server.stores.userBlock, 'isBlocked');
+        const actor = await actorFor(fx.a.owner.userId);
+        const created = [];
+        for (let i = 0; i < 3; i++) {
+            created.push(
+                await fx.env.server.services.share.share(actor, {
+                    path: await makeFile(fx.a.owner.userId),
+                    recipient: { team: fx.a.uid },
+                    mode: 'read',
+                }),
+            );
+        }
+        spy.mockClear();
+
+        await fx.env.server.services.shareNotification.notifyShared(
+            actor,
+            created,
+        );
+
+        // Block state is per (member, issuer) pair -- constant across the items
+        // in one call, so 3 items must not triple the queries.
+        const team = await fx.env.server.stores.team.getByUid(fx.a.uid);
+        const members = await fx.env.server.stores.team.listMemberIdsByGroupId(
+            team.id,
+        );
+        expect(spy.mock.calls.length).toBeLessThanOrEqual(members.length);
+    });
+});

--- a/src/backend/services/team/TeamEvents.test.ts
+++ b/src/backend/services/team/TeamEvents.test.ts
@@ -217,6 +217,69 @@ describe('team billing events', () => {
         expect(await server.stores.team.getOrgSeat(seat.userId)).toBeNull();
     });
 
+    // -- the authorization cache ------------------------------------------
+    // `isMember` and `getByUid` gate every team route, so a stale entry is
+    // access, not a stray notification. Each bust gets its own case.
+
+    it('stops answering member once the account is removed', async () => {
+        const team = await makeTeam();
+        const seat = await provision(team);
+        expect(await server.stores.team.isMember(team.uid, seat.userId)).toBe(true);
+
+        await server.stores.team.removeMember(team.uid, seat.userId);
+
+        expect(await server.stores.team.isMember(team.uid, seat.userId)).toBe(false);
+    });
+
+    it('stops answering member once the account is deleted out from under it', async () => {
+        const team = await makeTeam();
+        const seat = await provision(team);
+        expect(await server.stores.team.isMember(team.uid, seat.userId)).toBe(true);
+
+        // Cascades the membership row without passing through TeamStore.
+        await server.services.userAccount.cascadeDelete(seat.userId);
+
+        expect(await server.stores.team.isMember(team.uid, seat.userId)).toBe(false);
+    });
+
+    it('stops resolving the team, and its memberships, once it is deleted', async () => {
+        const team = await makeTeam();
+        const seat = await provision(team);
+        expect(await server.stores.team.getByUid(team.uid)).toBeTruthy();
+        expect(await server.stores.team.isMember(team.uid, seat.userId)).toBe(true);
+
+        await server.stores.team.softDelete(team.uid);
+
+        expect(await server.stores.team.getByUid(team.uid)).toBeNull();
+        expect(await server.stores.team.isMember(team.uid, seat.userId)).toBe(false);
+    });
+
+    it('serves the renamed team, not the name it was read at', async () => {
+        const team = await makeTeam();
+        expect((await server.stores.team.getByUid(team.uid))?.name).toBe('Billing Co');
+
+        await server.stores.team.update(team.uid, { name: 'Renamed Co' });
+
+        expect((await server.stores.team.getByUid(team.uid))?.name).toBe('Renamed Co');
+    });
+
+    it('does not serve a stale member list after the roster changes', async () => {
+        const team = await makeTeam();
+        const before = await server.stores.team.listMemberIdsByGroupId(team.id);
+
+        const seat = await provision(team);
+        const after = await server.stores.team.listMemberIdsByGroupId(team.id);
+        expect(after).toContain(seat.userId);
+        expect(after.length).toBe(before.length + 1);
+
+        // The membership row cascades away with the account, never through
+        // TeamStore -- the case a TTL alone would get wrong.
+        await server.services.userAccount.cascadeDelete(seat.userId);
+        expect(
+            await server.stores.team.listMemberIdsByGroupId(team.id),
+        ).not.toContain(seat.userId);
+    });
+
     it('says nothing about an account no team pays for', async () => {
         const outsider = await makeUser();
         seen.length = 0;

--- a/src/backend/services/team/TeamService.ts
+++ b/src/backend/services/team/TeamService.ts
@@ -113,6 +113,13 @@ export class TeamService extends PuterService {
         }
     }
 
+    /** The membership cascaded away, so the cached reads over it must go too. */
+    async forgetSeat(seat: TeamBillingEvent): Promise<void> {
+        const team = await this.stores.team.getByUid(seat.team_uid);
+        await this.stores.team.bustMembership(team?.id ?? -1, seat.user_id);
+        await this.stores.team.bustMember(seat.team_uid, seat.user_id);
+    }
+
     /** Paired with `captureSeatForBilling`, once the account is really gone. */
     emitSeatDeleted(seat: TeamBillingEvent | null): void {
         if (seat) this.#emitBilling('team.account.deleted', seat);

--- a/src/backend/services/user/UserAccountService.ts
+++ b/src/backend/services/user/UserAccountService.ts
@@ -100,6 +100,8 @@ export class UserAccountService extends PuterService {
         }
         // Tells prod to stop charging the owner for this seat.
         this.services.team.emitSeatDeleted(seat);
+        // The membership row cascaded away, so anything keyed on it is stale.
+        if (seat) await this.services.team.forgetSeat(seat);
     }
 
     /**

--- a/src/backend/stores/team/TeamStore.ts
+++ b/src/backend/stores/team/TeamStore.ts
@@ -40,6 +40,9 @@ export interface TeamRow {
 
 export const TEAM_KIND = 'team';
 
+/** Short: a stale read here costs a notification, not access. */
+const TEAM_CACHE_TTL_SECONDS = 60;
+
 /** A membership row, joined to the member's username. */
 /** A seat, joined to the team that pays for it. */
 export interface OrgSeatRow {
@@ -76,6 +79,13 @@ export const MEMBER_PAGE_SIZE = 50;
 export const MEMBER_PAGE_CAP = 200;
 export const AUDIT_PAGE_SIZE = 50;
 export const AUDIT_PAGE_CAP = 200;
+
+/**
+ * Ceiling on a share announcement's fan-out. Well above the default seat cap,
+ * so it bounds a pathological team rather than a real one; the caller logs
+ * when it bites, because a silently shortened fan-out reads as "everyone knows".
+ */
+export const NOTIFY_FANOUT_CAP = 500;
 
 /** Longest handle mysql can store — `varchar(64)` in mysql_mig_28. */
 export const HANDLE_MAX_LENGTH = 64;
@@ -173,6 +183,10 @@ export class TeamStore extends PuterStore {
 
     /** The team with this uid, or null. Soft-deleted ones are excluded. */
     async getByUid(uid: string): Promise<TeamRow | null> {
+        return this.#cached(`team:row:${uid}`, () => this.#readByUid(uid));
+    }
+
+    async #readByUid(uid: string): Promise<TeamRow | null> {
         const rows = await this.clients.db.read(
             `SELECT * FROM \`group\` WHERE \`uid\` = ? AND ${this.#live()}`,
             [uid, TEAM_KIND],
@@ -270,15 +284,27 @@ export class TeamStore extends PuterStore {
             `UPDATE \`group\` SET ${sets.join(', ')} WHERE \`uid\` = ? AND ${this.#live()}`,
             [...params, uid, TEAM_KIND],
         );
+        await this.#bustRow(uid);
         return this.getByUid(uid);
     }
     /** Releases the handle, since nothing addresses by it; keeps `name`. */
     async softDelete(uid: string): Promise<boolean> {
+        // Both resolved first: once `deleted_at` is set neither lookup finds it.
+        const team = await this.getByUid(uid);
+        const memberIds = team
+            ? await this.#readMemberIds(team.id, NOTIFY_FANOUT_CAP)
+            : [];
         const result = await this.clients.db.write(
             `UPDATE \`group\` SET \`deleted_at\` = CURRENT_TIMESTAMP, \`handle\` = NULL ` +
                 `WHERE \`uid\` = ? AND ${this.#live()}`,
             [uid, TEAM_KIND],
         );
+        if (result.anyRowsAffected && team) {
+            // Bounded by the fan-out cap, and this runs once per deletion.
+            await this.bustMembership(team.id);
+            await this.#bustRow(uid);
+            await Promise.all(memberIds.map((id) => this.bustMember(uid, id)));
+        }
         return result.anyRowsAffected;
     }
 
@@ -286,6 +312,15 @@ export class TeamStore extends PuterStore {
 
     /** The membership row for this user in this team, or null. */
     async getMembership(
+        teamUid: string,
+        userId: number,
+    ): Promise<TeamMemberRow | null> {
+        return this.#cached(`team:member:${teamUid}:${userId}`, () =>
+            this.#readMembership(teamUid, userId),
+        );
+    }
+
+    async #readMembership(
         teamUid: string,
         userId: number,
     ): Promise<TeamMemberRow | null> {
@@ -358,6 +393,87 @@ export class TeamStore extends PuterStore {
         return rows[0] ?? null;
     }
 
+    /** Members to announce a team share to; bounded, or the send is too. */
+    /**
+     * Short-lived, and deliberately only over reads that are not authorization.
+     * A stale entry here costs a notification, never access -- `isMember` and
+     * `getByUid` are left uncached for that reason.
+     *
+     * `jct_user_group.user_id` is ON DELETE CASCADE, so deleting an account
+     * changes membership without passing through this store. The TTL is the
+     * backstop for that; the explicit busts cover everything else.
+     */
+    async #cached<T>(key: string, read: () => Promise<T>): Promise<T> {
+        try {
+            const hit = await this.clients.redis.get(key);
+            if (hit !== null) return JSON.parse(hit) as T;
+        } catch {
+            return read();
+        }
+        const value = await read();
+        try {
+            await this.clients.redis.set(
+                key,
+                JSON.stringify(value),
+                'EX',
+                TEAM_CACHE_TTL_SECONDS,
+            );
+        } catch {
+            /* a cache that cannot be written is still correct */
+        }
+        return value;
+    }
+
+    async #bust(...keys: string[]): Promise<void> {
+        try {
+            await Promise.all(keys.map((k) => this.clients.redis.del(k)));
+        } catch {
+            /* the TTL clears it */
+        }
+    }
+
+    /** Busts everything keyed on this team's membership. */
+    async bustMembership(groupId: number, userId?: number): Promise<void> {
+        await this.#bust(
+            `team:members:${groupId}`,
+            ...(userId === undefined ? [] : [`team:seat:${userId}`]),
+        );
+    }
+
+    /**
+     * One membership pair. Authorization reads this, so every path that can
+     * change it busts here -- the TTL is not the mechanism.
+     */
+    async bustMember(teamUid: string, userId: number): Promise<void> {
+        await this.#bust(`team:member:${teamUid}:${userId}`);
+    }
+
+    async #bustRow(uid: string): Promise<void> {
+        await this.#bust(`team:row:${uid}`);
+    }
+
+    async listMemberIdsByGroupId(
+        groupId: number,
+        limit = NOTIFY_FANOUT_CAP,
+    ): Promise<number[]> {
+        if (limit !== NOTIFY_FANOUT_CAP)
+            return this.#readMemberIds(groupId, limit);
+        return this.#cached(`team:members:${groupId}`, () =>
+            this.#readMemberIds(groupId, limit),
+        );
+    }
+
+    async #readMemberIds(groupId: number, limit: number): Promise<number[]> {
+        const rows = (await this.clients.db.read(
+            'SELECT ug.`user_id` FROM `jct_user_group` ug ' +
+                'JOIN `group` g ON g.`id` = ug.`group_id` ' +
+                `WHERE ug.\`group_id\` = ? AND g.${this.#live()} ` +
+                'ORDER BY ug.`id` LIMIT ?',
+            [groupId, TEAM_KIND, limit + 1],
+        )) as { user_id: number }[];
+        return rows.map((r) => Number(r.user_id));
+    }
+
     /** Teams this user belongs to, oldest first. */
     async listTeamsForUser(userId: number): Promise<TeamRow[]> {
         const rows = await this.clients.db.read(
@@ -396,6 +512,7 @@ export class TeamStore extends PuterStore {
             // Not `booleanValue`: it yields a real boolean on postgres.
             [userId, opts.orgOwned ? 1 : 0, teamUid, TEAM_KIND],
         );
+        if (result.anyRowsAffected) await this.#bustForTeamUid(teamUid, userId);
         return result.anyRowsAffected;
     }
 
@@ -433,6 +550,12 @@ export class TeamStore extends PuterStore {
 
     /** Soft-deleted teams count: their seats still hold billable bytes. */
     async getOrgSeat(userId: number): Promise<OrgSeatRow | null> {
+        return this.#cached(`team:seat:${userId}`, () =>
+            this.#readOrgSeat(userId),
+        );
+    }
+
+    async #readOrgSeat(userId: number): Promise<OrgSeatRow | null> {
         const rows = (await this.clients.db.read(
             'SELECT ug.`id`, ug.`user_id`, u.`uuid`, u.`username`, ' +
                 'g.`uid` AS `team_uid`, g.`owner_user_id` ' +
@@ -529,7 +652,14 @@ export class TeamStore extends PuterStore {
                 `(SELECT \`id\` FROM \`group\` WHERE \`uid\` = ? AND ${this.#live()})`,
             [userId, teamUid, TEAM_KIND],
         );
+        if (result.anyRowsAffected) await this.#bustForTeamUid(teamUid, userId);
         return result.anyRowsAffected;
     }
 
+    /** The membership row is gone by now, so the team is resolved by uid. */
+    async #bustForTeamUid(teamUid: string, userId: number): Promise<void> {
+        const team = await this.getByUidIncludingDeleted(teamUid);
+        await this.bustMembership(team?.id ?? -1, userId);
+        await this.bustMember(teamUid, userId);
+    }
 }


### PR DESCRIPTION
Closes PUT-1761. Stacked on #3729.

## The bug

Sharing with a workspace notified **nobody**, and said it had succeeded.

`ShareNotificationService.notifyShared` keys every map off `ResolvedShare.holderId` — one user id, documented as "who to notify". A workspace share has no individual holder: the grant is a single row against the group, and `holder_user_id` on the index row is NULL. So `counts`, `named` and `targets` all skipped it and the call returned normally.

Nothing errored. The share was created correctly, resolved correctly for every member, and appeared in their listings. The failure mode was silence, which is why it needs a test that counts notifications — nothing else catches it.

## The fix

`#recipientsOf()` expands a workspace share to its live members at *announcement* time. The grant stays one row; only the telling fans out.

Because `#announce` and `#emailHolder` were already inside the same per-recipient loop, expanding the recipients fans out both channels — in-app notification **and** email digest — with no separate email path.

`TeamStore.listMemberIdsByGroupId()` is the lookup, scoped to live workspaces.

## The anti-spam decision

PUT-1761 listed three options and asked for a deliberate choice. **Option 1: expand per member**, and let the existing per-recipient budgets (10/hour, 50/day) plus the digest absorb it. Those budgets were designed for exactly this shape.

The fan-out is bounded at `NOTIFY_FANOUT_CAP = 500` — far above the default 50-seat cap, so it bounds a pathological workspace rather than a real one — and it **logs when it bites** instead of truncating silently. A shortened fan-out otherwise reads as "everyone knows".

## Wording deliberately unchanged

The ticket originally asked for the notification to name the workspace ("alice shared 3 items with Acme Design"). That was built and then reverted on review: it needed a `via` field threaded through `ShareSender`, `mergeShareSender`, `DigestEntry` and `digestSubject`, plus a rule for what to say when one person receives a direct share *and* a workspace share inside the same grouping window.

`shareNotifyTitle.ts` is therefore **unchanged in this PR** — the wording stays "shared N items with you" in both channels. The ticket has been updated to record that.

## Tests

`TeamShareNotify.test.ts`, five tests on the two-workspace fixture:

```
✓ tells every member of the workspace
✓ emails every member too, not just the in-app notification
✓ does not tell the issuer about their own share
✓ does not tell members of a workspace it was not shared with
✓ does not retroactively tell a member who joins afterwards
```

The email leg uses a `sendRaw` spy, so the digest renders for real and nothing leaves the process.

**Falsified, not just run.** Disabling the expansion reproduces the original silent skip:

```
 × tells every member of the workspace
 × emails every member too, not just the in-app notification
Tests  2 failed | 3 passed (5)     <- expansion disabled
Tests  5 passed (5)                <- restored
```

Worth noting the three negative tests pass either way — they are trivially true when nobody is told. That is the trap this ticket warns about, and it is why the two positive tests are the ones carrying the coverage.

Full suite: **7530 passed | 26 skipped**. Typecheck clean.

## Note for review

`listMemberIdsByGroupId` is a new unbounded-by-default read on a notification path. It takes an explicit limit with a documented cap rather than relying on the seat cap, because `max_seats_per_workspace` is configurable and a deployment that raises it should not silently turn one share into thousands of sends.
