### PR TITLE
ci: add CODEOWNERS, restrict Dependabot to patch bumps, make test wor…

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+* @Salazareo @ProgrammerIn-wonderland @jelveh @jfcastro92
+
+/src/docs/ @Salazareo @ProgrammerIn-wonderland @jelveh @jfcastro92 @reynaldichernando

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,9 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
 
   - package-ecosystem: "docker"
     directory: "/"

--- a/.github/workflows/backend-tests.yaml
+++ b/.github/workflows/backend-tests.yaml
@@ -1,28 +1,39 @@
 name: Backend Tests
 
-# Runs on backend and extension changes. Tests are co-located with the
-# code (src/backend/**/*.test.ts, extensions/**/*.test.ts), so test-only
-# changes match the same globs. puter.js SDK changes are covered by
-# puterjs-tests.yaml instead.
+# Always triggers so it can be a required PR check; the `changes` job below
+# decides whether backend/extension paths actually changed (test-only changes
+# match the same globs, since tests are co-located with the code), and every
+# other job is skipped — not absent — when they didn't, which still satisfies
+# a required check. puter.js SDK changes are covered by puterjs-tests.yaml.
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    paths:
-      - 'src/backend/**'
-      - 'extensions/**'
-      - 'tools/**'
-      - 'package.json'
-      - 'package-lock.json'
-      # The type-check job below reads these.
-      - 'tsconfig.json'
-      - 'tsconfig.build.json'
-      - '.github/workflows/backend-tests.yaml'
 
 permissions:
   contents: read
   pull-requests: write
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            backend:
+              - 'src/backend/**'
+              - 'extensions/**'
+              - 'tools/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'tsconfig.json'
+              - 'tsconfig.build.json'
+              - '.github/workflows/backend-tests.yaml'
+
   # `tsconfig.build.json` builds with `noCheck: true`, so nothing else in CI
   # runs the type checker and a missing export compiles to `undefined`,
   # surfacing only when the call is finally reached at runtime. This diffs
@@ -35,6 +46,8 @@ jobs:
   # Its own job rather than a step in `test`: that one runs a base/PR matrix for
   # coverage comparison, and the check only needs the PR ref, once.
   typecheck:
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -53,6 +66,12 @@ jobs:
         run: npm run typecheck
 
   test:
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
+    # Overrides the default matrix naming, which would otherwise bake the
+    # base/head branch name (matrix.ref) into the check name — making it a
+    # different string on every PR and impossible to pin as a required check.
+    name: test (${{ matrix.artifact }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -93,8 +112,8 @@ jobs:
           retention-days: 14
 
   report-coverage:
-    needs: test
-    if: always()
+    needs: [changes, test]
+    if: always() && needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/puterjs-tests.yaml
+++ b/.github/workflows/puterjs-tests.yaml
@@ -1,28 +1,42 @@
 name: Puter.js API Tests
 
-# Runs on puter.js SDK changes — the suites live in src/puter-js/tests,
-# so test changes are covered by the same glob — plus the pieces the
-# runners depend on: the worker preamble, the in-memory test env in
-# testUtil, and the backend vitest config the API-tests config extends.
-# Backend and extension changes run backend-tests.yaml instead.
+# Always triggers so it can be a required PR check; the `changes` job below
+# decides whether puter.js-relevant paths actually changed (the suites live
+# in src/puter-js/tests, so test-only changes are covered by the same glob,
+# plus the pieces the runners depend on: the worker preamble, the in-memory
+# test env in testUtil, and the backend vitest config the API-tests config
+# extends), and every other job is skipped — not absent — when they didn't,
+# which still satisfies a required check. Backend and extension changes run
+# backend-tests.yaml instead.
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    paths:
-      - 'src/puter-js/**'
-      - 'src/worker/**'
-      - 'src/backend/testUtil.ts'
-      - 'src/backend/vitest.config.ts'
-      - 'tools/**'
-      - 'package.json'
-      - 'package-lock.json'
-      - '.github/workflows/puterjs-tests.yaml'
 
 permissions:
   contents: read
   pull-requests: write
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      puterjs: ${{ steps.filter.outputs.puterjs }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            puterjs:
+              - 'src/puter-js/**'
+              - 'src/worker/**'
+              - 'src/backend/testUtil.ts'
+              - 'src/backend/vitest.config.ts'
+              - 'tools/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - '.github/workflows/puterjs-tests.yaml'
+
   # The JSDoc in src/puter-js/src is the source of truth for the SDK's public
   # types. The declarations shipped to npm are generated from it at build time
   # and never committed, so what needs guarding is the JSDoc itself: this
@@ -32,6 +46,8 @@ jobs:
   # Its own job rather than a step in `test`: that one builds bundles and
   # installs a browser, and this needs neither.
   types:
+    needs: changes
+    if: needs.changes.outputs.puterjs == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -51,6 +67,8 @@ jobs:
         run: npm run check:puterjs:types
 
   test:
+    needs: changes
+    if: needs.changes.outputs.puterjs == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -84,6 +102,12 @@ jobs:
   # backend-tests.yaml. This run uses the istanbul-instrumented bundle
   # (the `test` job above keeps exercising the production build).
   coverage:
+    needs: changes
+    if: needs.changes.outputs.puterjs == 'true'
+    # Overrides the default matrix naming, which would otherwise bake the
+    # base/head branch name (matrix.ref) into the check name — making it a
+    # different string on every PR and impossible to pin as a required check.
+    name: coverage (${{ matrix.artifact }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -131,8 +155,8 @@ jobs:
           if-no-files-found: ignore
 
   report-coverage:
-    needs: coverage
-    if: always()
+    needs: [changes, coverage]
+    if: always() && needs.changes.outputs.puterjs == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
…kflows always-run

- CODEOWNERS: default owners @Salazareo @ProgrammerIn-wonderland @jelveh @jfcastro92, plus @reynaldichernando for src/docs.
- dependabot.yml: ignore semver-minor/major npm updates, patch only.
- backend-tests.yaml / puterjs-tests.yaml: trigger unconditionally and gate the real work behind a dorny/paths-filter job instead of a workflow-level path filter, so the checks always report (skipped when irrelevant) and can be marked required. Also pins matrix job names to the artifact label instead of the branch ref, which previously made the check name change per PR and unusable as a required check.