### PR TITLE
fix(puter-js): preserve zero amount in kv incr/decr

### DIFF
--- a/src/puter-js/src/modules/kv/kv.test.js
+++ b/src/puter-js/src/modules/kv/kv.test.js
@@ -278,6 +278,11 @@ describe('kv.incr / kv.decr driver payloads', () => {
         expect(lastBody().args).toEqual({ key: 'n', pathAndAmountMap: { '': 5 } });
     });
 
+    it('incr(key, 0) preserves a zero amount instead of defaulting to 1', async () => {
+        await kv.incr('n', 0);
+        expect(lastBody().args).toEqual({ key: 'n', pathAndAmountMap: { '': 0 } });
+    });
+
     it('incr(key, pathAndAmountMap) passes the map through', async () => {
         await kv.incr('n', { 'user.score': 2 });
         expect(lastBody().args).toEqual({ key: 'n', pathAndAmountMap: { 'user.score': 2 } });
@@ -325,6 +330,11 @@ describe('kv.incr / kv.decr driver payloads', () => {
     it('decr(key, amount) maps the amount to the root path', async () => {
         await kv.decr('n', 4);
         expect(lastBody().args).toEqual({ key: 'n', pathAndAmountMap: { '': 4 } });
+    });
+
+    it('decr(key, 0) preserves a zero amount instead of defaulting to 1', async () => {
+        await kv.decr('n', 0);
+        expect(lastBody().args).toEqual({ key: 'n', pathAndAmountMap: { '': 0 } });
     });
 });
 

--- a/src/puter-js/src/modules/kv/lib/args.js
+++ b/src/puter-js/src/modules/kv/lib/args.js
@@ -63,7 +63,7 @@ export const parseCounterArgs = (keyOrOptions, amountOrMap, optConfig) => {
     }
     return {
         key: keyOrOptions,
-        pathAndAmountMap: !amountOrMap ? { '': 1 } : typeof amountOrMap === 'number' ? { '': amountOrMap } : amountOrMap,
+        pathAndAmountMap: amountOrMap === undefined || amountOrMap === null ? { '': 1 } : typeof amountOrMap === 'number' ? { '': amountOrMap } : amountOrMap,
         optConfig,
     };
 };


### PR DESCRIPTION
What: parseCounterArgs used a falsy check, so kv.incr(key, 0) and kv.decr(key, 0) sent amount 1.

Why: 0 is a valid no-op amount. Only undefined/null should default to 1, matching the temperature 0 / max_tokens 0 fixes.

How tested: added incr(key, 0) and decr(key, 0) wire-payload cases to kv.test.js. npx vitest run src/puter-js/src/modules/kv/kv.test.js — 98 passed.

No related open/closed issues or PRs found (searched parseCounterArgs).