### PR TITLE
fix(puter-js): return key_undefined for missing kv keys

### DIFF
--- a/src/puter-js/src/modules/kv/add.js
+++ b/src/puter-js/src/modules/kv/add.js
@@ -1,6 +1,6 @@
 import * as utils from '../../lib/utils.js';
 import { isObject, isOptConfigShorthand } from './lib/args.js';
-import { assertKeySize } from './lib/validate.js';
+import { assertKeyPresent, assertKeySize } from './lib/validate.js';
 
 /** @typedef {import('./types.js').KVAddPath} KVAddPath */
 /** @typedef {import('./types.js').KVOptConfig} KVOptConfig */
@@ -55,6 +55,7 @@ export async function add (keyOrOptions, valueOrMap, optConfig) {
         };
     }
 
+    assertKeyPresent(options.key);
     assertKeySize(options.key);
     return await utils.makeDriverMethod({ iface: 'puter-kvstore', method: 'add', argNames: ['key'], puter: this.puter })(options);
 }

--- a/src/puter-js/src/modules/kv/decr.js
+++ b/src/puter-js/src/modules/kv/decr.js
@@ -1,6 +1,6 @@
 import * as utils from '../../lib/utils.js';
 import { parseCounterArgs } from './lib/args.js';
-import { assertKeySize } from './lib/validate.js';
+import { assertKeyPresent, assertKeySize } from './lib/validate.js';
 
 /** @typedef {import('./types.js').KVIncrementPath} KVIncrementPath */
 /** @typedef {import('./types.js').KVOptConfig} KVOptConfig */
@@ -33,6 +33,7 @@ import { assertKeySize } from './lib/validate.js';
  */
 export async function decr (keyOrOptions, amountOrMap, optConfig) {
     const options = parseCounterArgs(keyOrOptions, amountOrMap, optConfig);
+    assertKeyPresent(options.key);
     assertKeySize(options.key);
     return await utils.makeDriverMethod({ iface: 'puter-kvstore', method: 'decr', argNames: ['key'], puter: this.puter })(options);
 }

--- a/src/puter-js/src/modules/kv/del.js
+++ b/src/puter-js/src/modules/kv/del.js
@@ -1,6 +1,6 @@
 import * as utils from '../../lib/utils.js';
 import { isObject, parseOptConfigThenCallbacks } from './lib/args.js';
-import { assertKeySize } from './lib/validate.js';
+import { assertKeyPresent, assertKeySize } from './lib/validate.js';
 
 /** @typedef {import('./types.js').KVOptConfig} KVOptConfig */
 
@@ -11,6 +11,7 @@ const delDriverCall = (puter, args) =>
         argNames: ['key'],
         puter,
         preprocess: (driverArgs) => {
+            assertKeyPresent(driverArgs.key);
             assertKeySize(driverArgs.key);
             return driverArgs;
         },

--- a/src/puter-js/src/modules/kv/expire.js
+++ b/src/puter-js/src/modules/kv/expire.js
@@ -1,5 +1,5 @@
 import * as utils from '../../lib/utils.js';
-import { assertKeySize } from './lib/validate.js';
+import { assertKeyPresent, assertKeySize } from './lib/validate.js';
 
 /** @typedef {import('./types.js').KVOptConfig} KVOptConfig */
 
@@ -22,6 +22,7 @@ import { assertKeySize } from './lib/validate.js';
  * @returns {Promise<boolean>}
  */
 export async function expire (key, ttl, optConfig) {
+    assertKeyPresent(key);
     assertKeySize(key);
     return await utils.makeDriverMethod({ iface: 'puter-kvstore', method: 'expire', argNames: ['key', 'ttl'], puter: this.puter })({ key, ttl, optConfig });
 }

--- a/src/puter-js/src/modules/kv/expireAt.js
+++ b/src/puter-js/src/modules/kv/expireAt.js
@@ -1,5 +1,5 @@
 import * as utils from '../../lib/utils.js';
-import { assertKeySize } from './lib/validate.js';
+import { assertKeyPresent, assertKeySize } from './lib/validate.js';
 
 /** @typedef {import('./types.js').KVOptConfig} KVOptConfig */
 
@@ -23,6 +23,7 @@ import { assertKeySize } from './lib/validate.js';
  * @returns {Promise<boolean>}
  */
 export async function expireAt (key, timestamp, optConfig) {
+    assertKeyPresent(key);
     assertKeySize(key);
     return await utils.makeDriverMethod({ iface: 'puter-kvstore', method: 'expireAt', argNames: ['key', 'timestamp'], puter: this.puter })({ key, timestamp, optConfig });
 }

--- a/src/puter-js/src/modules/kv/get.js
+++ b/src/puter-js/src/modules/kv/get.js
@@ -1,6 +1,6 @@
 import * as utils from '../../lib/utils.js';
 import { isObject, parseOptConfigThenCallbacks } from './lib/args.js';
-import { assertKeySize } from './lib/validate.js';
+import { assertKeyPresent, assertKeySize } from './lib/validate.js';
 
 /** @typedef {import('./types.js').KVOptConfig} KVOptConfig */
 
@@ -12,6 +12,7 @@ const getDriverCall = (puter, args) =>
         puter,
         readonly: true,
         preprocess: (driverArgs) => {
+            assertKeyPresent(driverArgs.key);
             assertKeySize(driverArgs.key);
             return driverArgs;
         },

--- a/src/puter-js/src/modules/kv/incr.js
+++ b/src/puter-js/src/modules/kv/incr.js
@@ -1,6 +1,6 @@
 import * as utils from '../../lib/utils.js';
 import { parseCounterArgs } from './lib/args.js';
-import { assertKeySize } from './lib/validate.js';
+import { assertKeyPresent, assertKeySize } from './lib/validate.js';
 
 /** @typedef {import('./types.js').KVIncrementPath} KVIncrementPath */
 /** @typedef {import('./types.js').KVOptConfig} KVOptConfig */
@@ -33,6 +33,7 @@ import { assertKeySize } from './lib/validate.js';
  */
 export async function incr (keyOrOptions, amountOrMap, optConfig) {
     const options = parseCounterArgs(keyOrOptions, amountOrMap, optConfig);
+    assertKeyPresent(options.key);
     assertKeySize(options.key);
     return await utils.makeDriverMethod({ iface: 'puter-kvstore', method: 'incr', argNames: ['key'], puter: this.puter })(options);
 }

--- a/src/puter-js/src/modules/kv/kv.test.js
+++ b/src/puter-js/src/modules/kv/kv.test.js
@@ -232,6 +232,11 @@ describe('kv.get driver payloads', () => {
         await expect(kv.get('k'.repeat(1025))).rejects.toMatchObject({ code: 'key_too_large' });
         expect(FakeXHR.requests).toHaveLength(0);
     });
+
+    it('rejects an undefined key without a request', async () => {
+        await expect(kv.get(undefined)).rejects.toMatchObject({ code: 'key_undefined' });
+        expect(FakeXHR.requests).toHaveLength(0);
+    });
 });
 
 describe('kv.get GUI boot cache', () => {
@@ -477,6 +482,12 @@ describe('kv.expire / kv.expireAt driver payloads', () => {
         await expect(kv.expireAt(bigKey, 1)).rejects.toMatchObject({ code: 'key_too_large' });
         expect(FakeXHR.requests).toHaveLength(0);
     });
+
+    it('both reject an undefined key without a request', async () => {
+        await expect(kv.expire(undefined, 60)).rejects.toMatchObject({ code: 'key_undefined' });
+        await expect(kv.expireAt(undefined, 1)).rejects.toMatchObject({ code: 'key_undefined' });
+        expect(FakeXHR.requests).toHaveLength(0);
+    });
 });
 
 describe('kv.del driver payloads', () => {
@@ -499,6 +510,11 @@ describe('kv.del driver payloads', () => {
 
     it('rejects an oversized key without a request', async () => {
         await expect(kv.del('k'.repeat(1025))).rejects.toMatchObject({ code: 'key_too_large' });
+        expect(FakeXHR.requests).toHaveLength(0);
+    });
+
+    it('rejects an undefined key without a request', async () => {
+        await expect(kv.del(undefined)).rejects.toMatchObject({ code: 'key_undefined' });
         expect(FakeXHR.requests).toHaveLength(0);
     });
 });


### PR DESCRIPTION
What: get/del/incr/decr/add/expire/expireAt only called assertKeySize, so kv.get(undefined) threw TypeError reading length.

Why: set/update/remove already call assertKeyPresent first and return { code: key_undefined }. This aligns the rest of the module to the same stable error contract.

How tested: added undefined-key rejection cases for get/del/expire/expireAt in kv.test.js. npx vitest run src/puter-js/src/modules/kv/kv.test.js — 99 passed.

No related open/closed issues or PRs found (searched assertKeyPresent).