### PR TITLE
fix(puter-js): require prompt in ai.txt2img

### DIFF
--- a/src/puter-js/src/modules/ai/ai.test.js
+++ b/src/puter-js/src/modules/ai/ai.test.js
@@ -607,6 +607,11 @@ describe('ai.txt2img driver payloads', () => {
         expect(img.src).toBe('data:image/png;base64,QUJD');
         expect(img.toString()).toBe('data:image/png;base64,QUJD');
     });
+
+    it('txt2img rejects without a prompt', async () => {
+        await expect(ai.txt2img({})).rejects.toMatchObject({ code: 'prompt_required' });
+        expect(FakeXHR.requests).toHaveLength(0);
+    });
 });
 
 describe('ai.txt2vid driver payloads', () => {

--- a/src/puter-js/src/modules/ai/image.js
+++ b/src/puter-js/src/modules/ai/image.js
@@ -58,6 +58,10 @@ export async function txt2img (promptOrOptions, optionsOrTestMode) {
         options = promptOrOptions;
     }
 
+    if ( ! options.prompt ) {
+        throw ({ message: 'Prompt parameter is required', code: 'prompt_required' });
+    }
+
     const driverHint = typeof options.driver === 'string' ? options.driver : undefined;
     const imageService = driverHint || 'ai-image';
 


### PR DESCRIPTION
What: ai.txt2vid rejects a missing prompt client-side with prompt_required, but ai.txt2img sent the request to the backend.

Why: consistent client-side validation saves a network round-trip and keeps error codes uniform across ai.* methods.

How tested: added txt2img rejects without a prompt case to ai.test.js (mirrors txt2vid). npx vitest run src/puter-js/src/modules/ai/ai.test.js — 61 passed.

No related open/closed issues or PRs found.