### PR TITLE
fix(puter-js): account for base64 padding in estimateDataUrlSize

### DIFF
--- a/src/puter-js/src/modules/FileSystem/operations/upload/dataUrl.js
+++ b/src/puter-js/src/modules/FileSystem/operations/upload/dataUrl.js
@@ -11,7 +11,8 @@ export const estimateDataUrlSize = (dataUrl) => {
     if ( ! dataUrl ) return 0;
     const commaIndex = dataUrl.indexOf(',');
     const base64 = commaIndex === -1 ? dataUrl : dataUrl.slice(commaIndex + 1);
-    return Math.ceil(base64.length * 3 / 4);
+    const padding = base64.endsWith('==') ? 2 : (base64.endsWith('=') ? 1 : 0);
+    return Math.floor(base64.length * 3 / 4) - padding;
 };
 
 /**

--- a/src/puter-js/src/modules/FileSystem/operations/upload/dataUrl.test.js
+++ b/src/puter-js/src/modules/FileSystem/operations/upload/dataUrl.test.js
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import { estimateDataUrlSize } from './dataUrl.js';
+
+// `estimateDataUrlSize` gates thumbnail uploads, so it must return decoded
+// bytes — not `ceil(base64.length * 3 / 4)`, which over-counts by 1-2 bytes
+// whenever the payload ends in `=` padding.
+describe('estimateDataUrlSize', () => {
+    it('returns 0 for empty input', () => {
+        expect(estimateDataUrlSize('')).toBe(0);
+    });
+
+    it('sizes an unpadded payload', () => {
+        // 'ABC' -> 'QUJD'
+        expect(estimateDataUrlSize('data:text/plain;base64,QUJD')).toBe(3);
+    });
+
+    it('subtracts single `=` padding', () => {
+        // 'AB' -> 'QUI='
+        expect(estimateDataUrlSize('data:text/plain;base64,QUI=')).toBe(2);
+    });
+
+    it('subtracts double `==` padding', () => {
+        // 'A' -> 'QQ=='
+        expect(estimateDataUrlSize('data:text/plain;base64,QQ==')).toBe(1);
+    });
+
+    it('sizes raw base64 without a data URL prefix', () => {
+        expect(estimateDataUrlSize('QUI=')).toBe(2);
+    });
+});


### PR DESCRIPTION
What: estimateDataUrlSize used Math.ceil(len * 3 / 4), over-counting by 1-2 bytes on payloads ending in =/==.

Why: it gates thumbnail uploads in thumbnails.js and signedBatchUpload.js, so items at the size limit were wrongly rejected. The ai dataUriByteLength helper already subtracts padding correctly.

How tested: new dataUrl.test.js with unpadded, single-padded, double-padded, raw-base64, and empty cases. npx vitest run src/puter-js/src/modules/FileSystem/operations/upload/dataUrl.test.js — 5 passed. Verified old formula fails the padded cases via node.

No related open/closed issues or PRs found.