### PR TITLE
fix: configure self-hosted S3 CORS for presigned uploads (#3379)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,13 @@
 HTTP_PORT=80
 # HTTPS_PORT=443     # uncomment after you enable TLS in caddy/Caddyfile
 
+# ── Public domain & protocol ------------------------------------------
+# Domain and protocol used by Puter and its subdomains (api, app, site,
+# dev, host). Also used by s3-init to configure S3/RustFS bucket CORS
+# for browser presigned uploads. Set PUTER_PROTOCOL=https when TLS is enabled.
+PUTER_DOMAIN=puter.localhost
+PUTER_PROTOCOL=http
+
 # ── MariaDB ------------------------------------------------------------
 MARIADB_ROOT_PASSWORD=replace-with-strong-password
 MARIADB_DATABASE=puter

--- a/doc/self-hosting.md
+++ b/doc/self-hosting.md
@@ -26,7 +26,7 @@ Generates secrets, writes `.env` + `puter/config/config.json`, downloads `docker
 | `puter-valkey`  | `valkey/valkey:8-alpine` | Redis-compatible cache + rate-limiter                      |
 | `puter-dynamo`  | `amazon/dynamodb-local`  | KV store — table auto-created on first boot                |
 | `puter-s3`      | `rustfs/rustfs`          | S3-compatible object storage (MinIO drop-in noted in file) |
-| `puter-s3-init` | `amazon/aws-cli`         | One-shot — creates the bucket on first boot, then exits    |
+| `puter-s3-init` | `amazon/aws-cli`         | One-shot — creates the bucket and configures CORS, then exits |
 
 Optional services (compose profile `ai`, opt-in):
 
@@ -53,6 +53,9 @@ URL_SIGNATURE_SECRET=$(openssl rand -hex 64)
 cat > .env <<EOF
 HTTP_PORT=80
 # HTTPS_PORT=443     # uncomment after enabling TLS in Step 3
+
+PUTER_DOMAIN=puter.localhost
+PUTER_PROTOCOL=http
 
 MARIADB_ROOT_PASSWORD=$MARIADB_ROOT_PASSWORD
 MARIADB_DATABASE=puter
@@ -135,6 +138,12 @@ Replace `puter.localhost`, `site.puter.localhost`, `host.puter.localhost`, `dev.
 
 Why these knobs:
 
+- `PUTER_DOMAIN` and `PUTER_PROTOCOL` (in `.env`) — the domain and scheme (`http` or `https`) Puter and its subdomains (`api`, `app`, `site`, `dev`, `host`) serve on. Passed to `s3-init` in `docker-compose.yml` to automatically configure bucket-level CORS on RustFS (`s3.<domain>`). Direct browser uploads to presigned S3 URLs require CORS preflight (`OPTIONS`) approval from RustFS; without bucket CORS configuration, the browser blocks the upload. `s3-init` automatically configures CORS origins for `${PUTER_PROTOCOL}://${PUTER_DOMAIN}` and its required subdomains. For HTTPS deployments, set:
+    ```bash
+    PUTER_DOMAIN=example.com
+    PUTER_PROTOCOL=https
+    ```
+    This ensures CORS rules allow `https://...` origins rather than `http://...`. The `s3-init` service is idempotent: if the bucket already exists (e.g. upgrades or restarts), it detects the bucket and applies/updates the CORS policy rather than exiting early.
 - `jwt_secret_v2` — the HMAC secret Puter signs and verifies auth tokens with (`kid: 'v2'` JWT header). The pre-v2 token format is retired: a token signed with the old `jwt_secret` no longer verifies, and holders are asked to sign in again. If you are upgrading from a release that had `jwt_secret`, drop it from your config — it is ignored.
 - `env: "prod"` — the bundled `config.default.json` ships with `env: "dev"` (matches the source-tree `npm run start:gui` workflow, which expects webpack-dev-server emitting a CSS manifest). Self-host runs against pre-built static bundles, so `env: "prod"` makes the homepage emit the `/dist/bundle.min.css` `<link>` tag instead of waiting on a manifest that doesn't exist.
 - `database.migrationPaths` — Puter applies the bundled MySQL/MariaDB schema on boot. The migration files are idempotent, so it is safe to leave this configured across restarts.
@@ -193,7 +202,7 @@ Drop the resulting `fullchain.pem` and `privkey.pem` into `./puter/tls/`.
 1. Open [caddy/Caddyfile](../caddy/Caddyfile) and uncomment the `# :443 { … }` block at the bottom.
 2. (Optional but recommended) Replace the plain `:80 { import puter_routes }` block with the `redir` version shown alongside it, to force HTTPS everywhere.
 3. In [docker-compose.yml](../docker-compose.yml), uncomment the `443:443` port mapping under the `caddy` service.
-4. In `.env`, uncomment `HTTPS_PORT=443`.
+4. In `.env`, uncomment `HTTPS_PORT=443` and set `PUTER_PROTOCOL=https` (so `s3-init` generates `https://...` CORS origins).
 5. In `config.json`, switch:
     ```json
     { "protocol": "https", "pub_port": 443 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -139,8 +139,8 @@ services:
       start_period: 5s
 
   s3-init:
-    # One-shot container that creates the `puter-local` bucket on first
-    # boot. Exits 0 once the bucket exists; stays exited 0 thereafter.
+    # One-shot container that creates the `puter-local` bucket and applies
+    # the browser CORS policy. Both operations are idempotent.
     image: amazon/aws-cli:latest
     container_name: puter-s3-init
     depends_on:
@@ -150,11 +150,13 @@ services:
       AWS_ACCESS_KEY_ID: ${S3_ACCESS_KEY:-puter}
       AWS_SECRET_ACCESS_KEY: ${S3_SECRET_KEY:-puter-secret-change-me}
       AWS_DEFAULT_REGION: us-east-1
+      PUTER_DOMAIN: ${PUTER_DOMAIN:-puter.localhost}
+      PUTER_PROTOCOL: ${PUTER_PROTOCOL:-http}
     entrypoint:
       - /bin/sh
       - -c
       - |
-        set -e
+        set -eu
         endpoint=http://s3:9000
         bucket=${S3_BUCKET:-puter-local}
         if aws --endpoint-url "$$endpoint" s3api head-bucket --bucket "$$bucket" 2>/dev/null; then
@@ -163,6 +165,30 @@ services:
           echo "creating bucket $$bucket"
           aws --endpoint-url "$$endpoint" s3 mb "s3://$$bucket"
         fi
+        cat > /tmp/cors.json <<EOF
+        {
+          "CORSRules": [
+            {
+              "AllowedOrigins": [
+                "$${PUTER_PROTOCOL}://$${PUTER_DOMAIN}",
+                "$${PUTER_PROTOCOL}://api.$${PUTER_DOMAIN}",
+                "$${PUTER_PROTOCOL}://app.$${PUTER_DOMAIN}",
+                "$${PUTER_PROTOCOL}://site.$${PUTER_DOMAIN}",
+                "$${PUTER_PROTOCOL}://dev.$${PUTER_DOMAIN}",
+                "$${PUTER_PROTOCOL}://host.$${PUTER_DOMAIN}"
+              ],
+              "AllowedMethods": ["GET", "HEAD", "PUT", "POST", "DELETE"],
+              "AllowedHeaders": ["*"],
+              "ExposeHeaders": ["ETag", "x-amz-request-id"],
+              "MaxAgeSeconds": 3600
+            }
+          ]
+        }
+        EOF
+        aws --endpoint-url "$$endpoint" s3api put-bucket-cors \
+          --bucket "$$bucket" \
+          --cors-configuration file:///tmp/cors.json
+        echo "bucket $$bucket CORS configured"
     restart: "no"
 
   # ── Optional: local LLM ───────────────────────────────────────────

--- a/install.ps1
+++ b/install.ps1
@@ -20,19 +20,21 @@
 # compose file + brings the stack up. Set PUTER_FORCE=1 to overwrite.
 #
 # Tunable env vars (or pass as -Parameters when running the file directly):
-#   PUTER_DIR     install directory                       (default: ./puter-selfhosted)
-#   PUTER_URL     base URL to fetch docker-compose.yml    (default: GitHub raw, main branch)
-#   PUTER_DOMAIN  domain Puter will serve on              (default: puter.localhost)
-#   PUTER_PORT    HTTP port for Caddy                     (default: 80)
-#   PUTER_FORCE   set to 1 to overwrite existing .env / config.json
+#   PUTER_DIR       install directory                       (default: ./puter-selfhosted)
+#   PUTER_URL       base URL to fetch docker-compose.yml    (default: GitHub raw, main branch)
+#   PUTER_DOMAIN    domain Puter will serve on              (default: puter.localhost)
+#   PUTER_PORT      HTTP port for Caddy                     (default: 80)
+#   PUTER_PROTOCOL  public scheme: http | https             (default: http)
+#   PUTER_FORCE     set to 1 to overwrite existing .env / config.json
 
 [CmdletBinding()]
 param(
-    [string]$PuterDir    = $(if ($env:PUTER_DIR)    { $env:PUTER_DIR }         else { 'puter-selfhosted' }),
-    [string]$PuterUrl    = $(if ($env:PUTER_URL)    { $env:PUTER_URL }         else { 'https://raw.githubusercontent.com/HeyPuter/puter/main' }),
-    [string]$PuterDomain = $(if ($env:PUTER_DOMAIN) { $env:PUTER_DOMAIN }      else { 'puter.localhost' }),
-    [int]   $PuterPort   = $(if ($env:PUTER_PORT)   { [int]$env:PUTER_PORT }   else { 80 }),
-    [switch]$Force       = $($env:PUTER_FORCE -eq '1')
+    [string]$PuterDir      = $(if ($env:PUTER_DIR)      { $env:PUTER_DIR }         else { 'puter-selfhosted' }),
+    [string]$PuterUrl      = $(if ($env:PUTER_URL)      { $env:PUTER_URL }         else { 'https://raw.githubusercontent.com/HeyPuter/puter/main' }),
+    [string]$PuterDomain   = $(if ($env:PUTER_DOMAIN)   { $env:PUTER_DOMAIN }      else { 'puter.localhost' }),
+    [int]   $PuterPort     = $(if ($env:PUTER_PORT)     { [int]$env:PUTER_PORT }   else { 80 }),
+    [string]$PuterProtocol = $(if ($env:PUTER_PROTOCOL) { $env:PUTER_PROTOCOL }   else { 'http' }),
+    [switch]$Force         = $($env:PUTER_FORCE -eq '1')
 )
 
 $ErrorActionPreference = 'Stop'
@@ -125,6 +127,8 @@ if ($writeConfig) {
 HTTP_PORT=$PuterPort
 # HTTPS_PORT=443     # uncomment after enabling TLS in caddy/Caddyfile
 #                    # (see "Step 3 — TLS" in doc/self-hosting.md)
+PUTER_DOMAIN=$PuterDomain
+PUTER_PROTOCOL=$PuterProtocol
 
 MARIADB_ROOT_PASSWORD=$mariadbRootPw
 MARIADB_DATABASE=puter
@@ -140,7 +144,7 @@ S3_BUCKET=puter-local
     Write-Log 'writing puter/config/config.json'
     $config = [ordered]@{
         domain                         = $PuterDomain
-        protocol                       = 'http'
+        protocol                       = $PuterProtocol
         pub_port                       = $PuterPort
         env                            = 'prod'
         static_hosting_domain          = "site.$PuterDomain"
@@ -178,7 +182,7 @@ S3_BUCKET=puter-local
         s3 = [ordered]@{
             s3Config = [ordered]@{
                 endpoint        = 'http://s3:9000'
-                publicEndpoint  = "http://s3.$PuterDomain"
+                publicEndpoint  = "${PuterProtocol}://s3.$PuterDomain"
                 accessKeyId     = 'puter'
                 secretAccessKey = $s3SecretKey
                 region          = 'us-east-1'
@@ -206,6 +210,6 @@ Write-Log 'stack starting. first boot takes ~30s while MariaDB initialises.'
 Write-Log 'follow puter logs:'
 Write-Log "    cd $PuterDir; docker compose logs -f puter"
 Write-Log ''
-Write-Log "open http://${PuterDomain}:${PuterPort} once the puter container is healthy."
+Write-Log "open ${PuterProtocol}://${PuterDomain}:${PuterPort} once the puter container is healthy."
 Write-Log 'first-boot admin password is logged once — grab it with:'
 Write-Log "    cd $PuterDir; docker compose logs puter | Select-String password"

--- a/install.sh
+++ b/install.sh
@@ -120,6 +120,8 @@ if [ "$write_config" = "1" ]; then
 HTTP_PORT=$PUTER_PORT
 # HTTPS_PORT=443     # uncomment after enabling TLS in caddy/Caddyfile
 #                    # (see "Step 3 — TLS" in doc/self-hosting.md)
+PUTER_DOMAIN=$PUTER_DOMAIN
+PUTER_PROTOCOL=$PUTER_PROTOCOL
 
 MARIADB_ROOT_PASSWORD=$MARIADB_ROOT_PASSWORD
 MARIADB_DATABASE=puter

--- a/tools/test-s3-cors.mjs
+++ b/tools/test-s3-cors.mjs
@@ -1,0 +1,271 @@
+#!/usr/bin/env node
+/**
+ * Automated test suite for self-hosted S3/RustFS CORS configuration (Issue #3379).
+ *
+ * Validates:
+ *  1. docker-compose.yml s3-init service configuration and CORS policy generation.
+ *  2. HTTP default domain origin generation (puter.localhost and subdomains).
+ *  3. HTTPS custom domain origin generation (example.com and subdomains).
+ *  4. Allowed methods (GET, HEAD, PUT, POST, DELETE).
+ *  5. Allowed headers (wildcard [*]).
+ *  6. Exposed headers (ETag, x-amz-request-id) and MaxAgeSeconds (3600).
+ *  7. Negative CORS authorization checks (no wildcard origin, rejection of evil origins).
+ *  8. Browser OPTIONS preflight simulation (positive and negative).
+ *  9. Idempotent initialization logic (new bucket vs existing bucket).
+ * 10. Installer configuration consistency (install.sh, install.ps1, .env.example, doc/self-hosting.md).
+ *
+ * Usage:
+ *   node tools/test-s3-cors.mjs
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const COMPOSE_PATH = path.join(ROOT_DIR, 'docker-compose.yml');
+const INSTALL_SH_PATH = path.join(ROOT_DIR, 'install.sh');
+const INSTALL_PS1_PATH = path.join(ROOT_DIR, 'install.ps1');
+const ENV_EXAMPLE_PATH = path.join(ROOT_DIR, '.env.example');
+const DOC_PATH = path.join(ROOT_DIR, 'doc', 'self-hosting.md');
+
+/**
+ * Parses the CORS JSON template embedded inside docker-compose.yml s3-init entrypoint
+ * and interpolates PUTER_PROTOCOL and PUTER_DOMAIN variables.
+ */
+function extractAndRenderCorsJson(protocol, domain) {
+    const composeContent = fs.readFileSync(COMPOSE_PATH, 'utf8');
+
+    // Extract the cat > /tmp/cors.json <<EOF ... EOF block
+    const match = composeContent.match(/cat\s*>\s*\/tmp\/cors\.json\s*<<\s*EOF\s*\n([\s\S]*?)\n\s*EOF/);
+    assert.ok(match, 'docker-compose.yml must contain cat > /tmp/cors.json <<EOF block');
+
+    const template = match[1];
+
+    // Substitute $${PUTER_PROTOCOL} and $${PUTER_DOMAIN} as evaluated by compose -> shell
+    const rendered = template
+        .replace(/\$\$\{PUTER_PROTOCOL\}|\$\{PUTER_PROTOCOL\}/g, protocol)
+        .replace(/\$\$\{PUTER_DOMAIN\}|\$\{PUTER_DOMAIN\}/g, domain);
+
+    const corsConfig = JSON.parse(rendered);
+    return corsConfig;
+}
+
+/**
+ * Simulates a browser CORS preflight check against S3 CORS rules.
+ */
+function evaluatePreflight(corsRule, { origin, method, headers = [] }) {
+    // 1. Origin match
+    const originAllowed = corsRule.AllowedOrigins.includes(origin) || corsRule.AllowedOrigins.includes('*');
+    if (!originAllowed) {
+        return { allowed: false, reason: 'Origin not allowed' };
+    }
+
+    // 2. Method match
+    const methodAllowed = corsRule.AllowedMethods.includes(method.toUpperCase());
+    if (!methodAllowed) {
+        return { allowed: false, reason: 'Method not allowed' };
+    }
+
+    // 3. Headers match
+    const headersAllowed = corsRule.AllowedHeaders.includes('*') ||
+        headers.every(h => corsRule.AllowedHeaders.map(x => x.toLowerCase()).includes(h.toLowerCase()));
+    if (!headersAllowed) {
+        return { allowed: false, reason: 'Headers not allowed' };
+    }
+
+    return {
+        allowed: true,
+        allowOrigin: origin,
+        allowMethods: corsRule.AllowedMethods,
+        allowHeaders: corsRule.AllowedHeaders,
+        exposeHeaders: corsRule.ExposeHeaders || [],
+        maxAge: corsRule.MaxAgeSeconds
+    };
+}
+
+describe('Self-Hosted S3/RustFS CORS Configuration (#3379)', () => {
+
+    describe('1. Default HTTP Domain Origin Generation', () => {
+        const corsConfig = extractAndRenderCorsJson('http', 'puter.localhost');
+        const rule = corsConfig.CORSRules[0];
+
+        it('generates the expected set of allowed origins', () => {
+            const expectedOrigins = [
+                'http://puter.localhost',
+                'http://api.puter.localhost',
+                'http://app.puter.localhost',
+                'http://site.puter.localhost',
+                'http://dev.puter.localhost',
+                'http://host.puter.localhost',
+            ];
+
+            assert.deepEqual(rule.AllowedOrigins, expectedOrigins);
+        });
+
+        it('does NOT contain wildcard origin (*)', () => {
+            assert.ok(!rule.AllowedOrigins.includes('*'), 'AllowedOrigins must not contain wildcard *');
+        });
+
+        it('does NOT allow unauthorized external origins', () => {
+            assert.ok(!rule.AllowedOrigins.includes('https://evil.example.com'));
+            assert.ok(!rule.AllowedOrigins.includes('http://attacker.localhost'));
+            assert.ok(!rule.AllowedOrigins.includes('http://localhost:3000'));
+        });
+    });
+
+    describe('2. Custom HTTPS Domain Origin Generation', () => {
+        const corsConfig = extractAndRenderCorsJson('https', 'example.com');
+        const rule = corsConfig.CORSRules[0];
+
+        it('generates HTTPS origins for custom domain and subdomains', () => {
+            const expectedOrigins = [
+                'https://example.com',
+                'https://api.example.com',
+                'https://app.example.com',
+                'https://site.example.com',
+                'https://dev.example.com',
+                'https://host.example.com',
+            ];
+
+            assert.deepEqual(rule.AllowedOrigins, expectedOrigins);
+        });
+
+        it('does NOT include plain http:// origins when protocol is https', () => {
+            const hasHttp = rule.AllowedOrigins.some(origin => origin.startsWith('http://'));
+            assert.equal(hasHttp, false, 'HTTPS configuration must not contain http:// origins');
+        });
+    });
+
+    describe('3. Allowed Methods, Headers, and ExposeHeaders', () => {
+        const corsConfig = extractAndRenderCorsJson('http', 'puter.localhost');
+        const rule = corsConfig.CORSRules[0];
+
+        it('includes all standard S3 methods including PUT for presigned uploads', () => {
+            assert.ok(rule.AllowedMethods.includes('PUT'), 'AllowedMethods must include PUT');
+            assert.ok(rule.AllowedMethods.includes('GET'), 'AllowedMethods must include GET');
+            assert.ok(rule.AllowedMethods.includes('HEAD'), 'AllowedMethods must include HEAD');
+            assert.ok(rule.AllowedMethods.includes('POST'), 'AllowedMethods must include POST');
+            assert.ok(rule.AllowedMethods.includes('DELETE'), 'AllowedMethods must include DELETE');
+        });
+
+        it('allows wildcard headers [*] required for presigned S3 uploads', () => {
+            assert.deepEqual(rule.AllowedHeaders, ['*']);
+        });
+
+        it('exposes critical response headers (ETag, x-amz-request-id)', () => {
+            assert.ok(rule.ExposeHeaders.includes('ETag'), 'ExposeHeaders must include ETag');
+            assert.ok(rule.ExposeHeaders.includes('x-amz-request-id'), 'ExposeHeaders must include x-amz-request-id');
+        });
+
+        it('sets MaxAgeSeconds to 3600 for optimal preflight caching', () => {
+            assert.equal(rule.MaxAgeSeconds, 3600);
+        });
+    });
+
+    describe('4. Simulated Browser OPTIONS Preflight', () => {
+        const corsConfig = extractAndRenderCorsJson('http', 'puter.localhost');
+        const rule = corsConfig.CORSRules[0];
+
+        it('succeeds for valid frontend origin requesting PUT with content-type', () => {
+            const preflight = evaluatePreflight(rule, {
+                origin: 'http://puter.localhost',
+                method: 'PUT',
+                headers: ['content-type']
+            });
+
+            assert.equal(preflight.allowed, true);
+            assert.equal(preflight.allowOrigin, 'http://puter.localhost');
+            assert.ok(preflight.allowMethods.includes('PUT'));
+            assert.ok(preflight.exposeHeaders.includes('ETag'));
+        });
+
+        it('succeeds for subdomain origin requesting PUT with custom headers', () => {
+            const preflight = evaluatePreflight(rule, {
+                origin: 'http://app.puter.localhost',
+                method: 'PUT',
+                headers: ['content-type', 'x-amz-meta-custom']
+            });
+
+            assert.equal(preflight.allowed, true);
+            assert.equal(preflight.allowOrigin, 'http://app.puter.localhost');
+        });
+
+        it('rejects unauthorized origin in preflight', () => {
+            const preflight = evaluatePreflight(rule, {
+                origin: 'https://evil.example.com',
+                method: 'PUT',
+                headers: ['content-type']
+            });
+
+            assert.equal(preflight.allowed, false);
+            assert.equal(preflight.reason, 'Origin not allowed');
+        });
+
+        it('rejects unauthorized HTTP method in preflight', () => {
+            const preflight = evaluatePreflight(rule, {
+                origin: 'http://puter.localhost',
+                method: 'PATCH',
+                headers: ['content-type']
+            });
+
+            assert.equal(preflight.allowed, false);
+            assert.equal(preflight.reason, 'Method not allowed');
+        });
+    });
+
+    describe('5. s3-init Script Idempotency', () => {
+        const composeContent = fs.readFileSync(COMPOSE_PATH, 'utf8');
+
+        it('passes PUTER_DOMAIN and PUTER_PROTOCOL environment variables to s3-init', () => {
+            assert.match(composeContent, /PUTER_DOMAIN:\s*\$\{PUTER_DOMAIN:-puter\.localhost\}/);
+            assert.match(composeContent, /PUTER_PROTOCOL:\s*\$\{PUTER_PROTOCOL:-http\}/);
+        });
+
+        it('does not exit early when bucket already exists', () => {
+            // Check that in the head-bucket branch, it does not exit 0 before put-bucket-cors
+            const headBucketMatch = composeContent.match(/if aws --endpoint-url "\$\$endpoint" s3api head-bucket[\s\S]*?fi/);
+            assert.ok(headBucketMatch, 'head-bucket check must be present');
+            assert.ok(!headBucketMatch[0].includes('exit 0'), 'Existing bucket branch must NOT exit early');
+        });
+
+        it('applies put-bucket-cors after bucket verification/creation', () => {
+            assert.match(composeContent, /aws --endpoint-url "\$\$endpoint" s3api put-bucket-cors/);
+            assert.match(composeContent, /--cors-configuration file:\/\/\/tmp\/cors\.json/);
+        });
+    });
+
+    describe('6. Installer Configuration Consistency', () => {
+        it('install.sh writes PUTER_DOMAIN and PUTER_PROTOCOL to .env', () => {
+            const installSh = fs.readFileSync(INSTALL_SH_PATH, 'utf8');
+            assert.match(installSh, /PUTER_DOMAIN=\$PUTER_DOMAIN/);
+            assert.match(installSh, /PUTER_PROTOCOL=\$PUTER_PROTOCOL/);
+        });
+
+        it('install.ps1 writes PUTER_DOMAIN and PUTER_PROTOCOL to .env', () => {
+            const installPs1 = fs.readFileSync(INSTALL_PS1_PATH, 'utf8');
+            assert.match(installPs1, /PUTER_DOMAIN=\$PuterDomain/);
+            assert.match(installPs1, /PUTER_PROTOCOL=\$PuterProtocol/);
+            assert.match(installPs1, /protocol\s*=\s*\$PuterProtocol/);
+            assert.match(installPs1, /publicEndpoint\s*=\s*"\$\{PuterProtocol\}:\/\/s3\.\$PuterDomain"/);
+        });
+
+        it('.env.example documents PUTER_DOMAIN and PUTER_PROTOCOL', () => {
+            const envExample = fs.readFileSync(ENV_EXAMPLE_PATH, 'utf8');
+            assert.match(envExample, /PUTER_DOMAIN=puter\.localhost/);
+            assert.match(envExample, /PUTER_PROTOCOL=http/);
+        });
+
+        it('doc/self-hosting.md explains PUTER_DOMAIN, PUTER_PROTOCOL, and S3 CORS', () => {
+            const doc = fs.readFileSync(DOC_PATH, 'utf8');
+            assert.match(doc, /PUTER_DOMAIN=puter\.localhost/);
+            assert.match(doc, /PUTER_PROTOCOL=http/);
+            assert.match(doc, /PUTER_DOMAIN=example\.com/);
+            assert.match(doc, /PUTER_PROTOCOL=https/);
+            assert.match(doc, /s3-init/);
+            assert.match(doc, /CORS/);
+        });
+    });
+});


### PR DESCRIPTION
### Problem
In self-hosted Puter deployments, browser file uploads fail with a CORS policy error when sending `PUT` requests to S3 presigned URLs on RustFS (`s3.<domain>`). The browser issues an HTTP `OPTIONS` preflight request prior to the upload, but because the bucket was created without a bucket-level CORS policy, RustFS does not return the required `Access-Control-Allow-*` headers.

Fixes #3379

### Solution
1. **Automated Bucket CORS Policy (`docker-compose.yml`)**:
   - Updated the `s3-init` service to pass `PUTER_DOMAIN` and `PUTER_PROTOCOL`.
   - `s3-init` writes and applies a bucket-level CORS configuration allowing origins for `${PUTER_PROTOCOL}://${PUTER_DOMAIN}` and its subdomains (`api`, `app`, `site`, `dev`, `host`).
   - Configured `AllowedMethods: ["GET", "HEAD", "PUT", "POST", "DELETE"]`, `AllowedHeaders: ["*"]`, `ExposeHeaders: ["ETag", "x-amz-request-id"]`, and `MaxAgeSeconds: 3600`.
   - Applied via `aws --endpoint-url "$endpoint" s3api put-bucket-cors`.

2. **Idempotent Initialization**:
   - If the bucket already exists (`head-bucket` succeeds), `s3-init` does not exit early; it proceeds to apply/update the CORS policy so existing installations receive the fix without data loss.

3. **Installer Support (`install.sh` & `install.ps1`)**:
   - Updated `install.sh` and `install.ps1` to write `PUTER_DOMAIN` and `PUTER_PROTOCOL` to `.env`.
   - Updated `install.ps1` to accept `-PuterProtocol` parameter and dynamically configure `protocol` and `publicEndpoint` in `config.json`.

4. **Documentation**:
   - Documented `PUTER_DOMAIN` and `PUTER_PROTOCOL` in `doc/self-hosting.md` and `.env.example`, including HTTPS setup instructions.

5. **Testing**:
   - Added automated test suite (`tools/test-s3-cors.mjs`) validating default HTTP domain origins, custom HTTPS domain origins, allowed methods/headers, absence of wildcard origins, simulated browser `OPTIONS` preflights, idempotency logic, and installer consistency.

### Tests Run
- `node tools/test-s3-cors.mjs`: 20/20 tests passed.
- `git diff --check`: Passed with 0 whitespace errors.
- `sh -n install.sh`: Passed with exit code 0.
- PowerShell AST parser validation of `install.ps1`: Passed with 0 errors.
- PyYAML validation of `docker-compose.yml`: Passed with exit code 0.
