### PR TITLE
fix(ai): canonicalize image parts once and translate them per provider

### DIFF
--- a/src/backend/drivers/ai-chat/ChatCompletionDriver.media.test.ts
+++ b/src/backend/drivers/ai-chat/ChatCompletionDriver.media.test.ts
@@ -1,0 +1,354 @@
+/*
+ * Copyright (C) 2024-present Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Driver-level media handling: canonicalising image/video parts once for every
+ * provider, refusing them up front for models whose catalog entry says they
+ * cannot read them, and resolving `puter_path` parts per attempt for providers
+ * without an upload mechanism of their own.
+ *
+ * Same harness as ChatCompletionDriver.test.ts — a live test server with only
+ * `fake-chat` registered — so the catalog is shaped per test by spying on
+ * `FakeChatProvider.prototype.models` before the driver builds its model map.
+ */
+
+import {
+    afterAll,
+    afterEach,
+    beforeAll,
+    describe,
+    expect,
+    it,
+    vi,
+} from 'vitest';
+
+import { PuterServer } from '../../server.js';
+import { setupTestServer } from '../../testUtil.js';
+import { withTestActor } from '../integrationTestUtil.js';
+import { ChatCompletionDriver } from './ChatCompletionDriver.js';
+import { FakeChatProvider } from './providers/FakeChatProvider.js';
+import type { IChatModel, ICompleteArguments } from './types.js';
+
+// The puter_path resolver reads the user's filesystem; stub it and assert on
+// when the driver invokes it.
+const { processPuterPathUploadsMock } = vi.hoisted(() => ({
+    processPuterPathUploadsMock: vi.fn(async (_messages: unknown) => {}),
+}));
+
+vi.mock('./providers/openai/fileUpload.js', () => ({
+    processPuterPathUploads: processPuterPathUploadsMock,
+    MAX_FILE_SIZE: 5 * 1_000_000,
+}));
+
+let server: PuterServer;
+
+beforeAll(async () => {
+    server = await setupTestServer();
+});
+
+afterAll(async () => {
+    await server?.shutdown();
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+    processPuterPathUploadsMock.mockClear();
+    delete (FakeChatProvider.prototype as { resolvesPuterPaths?: boolean })
+        .resolvesPuterPaths;
+});
+
+const makeDriver = async () => {
+    const d = new ChatCompletionDriver(
+        { providers: { ollama: { enabled: false } } } as never,
+        server.clients,
+        server.stores,
+        server.services,
+    );
+    d.onServerStart();
+    for (let i = 0; i < 200; i++) {
+        const m = await d.models();
+        if (m.length > 0) return d;
+        await new Promise((r) => setTimeout(r, 5));
+    }
+    throw new Error('ChatCompletionDriver model map never populated in test');
+};
+
+const fakeCatalog = (modalities?: IChatModel['modalities']): IChatModel[] => [
+    {
+        id: 'fake',
+        aliases: [],
+        costs_currency: 'usd-cents',
+        costs: { 'input-tokens': 0, 'output-tokens': 0 },
+        max_tokens: 8192,
+        ...(modalities ? { modalities } : {}),
+    },
+];
+
+const okResult = {
+    message: { role: 'assistant', content: [{ type: 'text', text: 'ok' }] },
+    usage: {},
+    finish_reason: 'stop',
+};
+
+const IMAGE_URL = 'https://cdn.test/doge.jpeg';
+
+describe('ChatCompletionDriver media canonicalisation', () => {
+    it('hands the provider canonical image parts whatever shape the caller sent', async () => {
+        const driver = await makeDriver();
+        const completeSpy = vi
+            .spyOn(FakeChatProvider.prototype, 'complete')
+            .mockResolvedValueOnce(okResult as never);
+
+        await withTestActor(() =>
+            driver.complete({
+                model: 'fake',
+                messages: [
+                    {
+                        role: 'user',
+                        content: [
+                            'What do you see?',
+                            // puter.js shorthand: no type.
+                            { image_url: { url: IMAGE_URL } },
+                            // Bare string URL.
+                            { image_url: `${IMAGE_URL}?v=2` },
+                            // OpenAI Responses shape.
+                            {
+                                type: 'input_image',
+                                image_url: `${IMAGE_URL}?v=3`,
+                                detail: 'low',
+                            },
+                            // Anthropic shape.
+                            {
+                                type: 'image',
+                                source: {
+                                    type: 'url',
+                                    url: `${IMAGE_URL}?v=4`,
+                                },
+                            },
+                        ],
+                    },
+                ],
+            }),
+        );
+
+        const passed = completeSpy.mock.calls[0]![0] as ICompleteArguments;
+        expect(passed.messages[0].content).toEqual([
+            { type: 'text', text: 'What do you see?' },
+            { type: 'image_url', image_url: { url: IMAGE_URL } },
+            { type: 'image_url', image_url: { url: `${IMAGE_URL}?v=2` } },
+            {
+                type: 'image_url',
+                image_url: { url: `${IMAGE_URL}?v=3`, detail: 'low' },
+            },
+            { type: 'image_url', image_url: { url: `${IMAGE_URL}?v=4` } },
+        ]);
+    });
+});
+
+describe('ChatCompletionDriver input modality gate', () => {
+    it('returns 400 for an image part when the catalog entry declares text-only input', async () => {
+        vi.spyOn(FakeChatProvider.prototype, 'models').mockResolvedValueOnce(
+            fakeCatalog({ input: ['text'], output: ['text'] }),
+        );
+        const driver = await makeDriver();
+        const completeSpy = vi.spyOn(FakeChatProvider.prototype, 'complete');
+
+        let caught: unknown;
+        try {
+            await withTestActor(() =>
+                driver.complete({
+                    model: 'fake',
+                    messages: [
+                        {
+                            role: 'user',
+                            content: [
+                                { type: 'text', text: 'describe' },
+                                { image_url: { url: IMAGE_URL } },
+                            ],
+                        },
+                    ],
+                }),
+            );
+        } catch (e) {
+            caught = e;
+        }
+
+        expect(caught).toMatchObject({
+            statusCode: 400,
+            message: 'Model fake does not support image input',
+        });
+        // Refused before any provider round trip.
+        expect(completeSpy).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 for a video part when the entry reads images but not video', async () => {
+        vi.spyOn(FakeChatProvider.prototype, 'models').mockResolvedValueOnce(
+            fakeCatalog({ input: ['text', 'image'], output: ['text'] }),
+        );
+        const driver = await makeDriver();
+
+        await expect(
+            withTestActor(() =>
+                driver.complete({
+                    model: 'fake',
+                    messages: [
+                        {
+                            role: 'user',
+                            content: [
+                                {
+                                    video_url: {
+                                        url: 'https://cdn.test/a.mp4',
+                                    },
+                                },
+                            ],
+                        },
+                    ],
+                }),
+            ),
+        ).rejects.toMatchObject({
+            statusCode: 400,
+            message: 'Model fake does not support video input',
+        });
+    });
+
+    it('lets images through when the entry declares image input', async () => {
+        vi.spyOn(FakeChatProvider.prototype, 'models').mockResolvedValueOnce(
+            fakeCatalog({ input: ['text', 'image'], output: ['text'] }),
+        );
+        const driver = await makeDriver();
+        vi.spyOn(FakeChatProvider.prototype, 'complete').mockResolvedValueOnce(
+            okResult as never,
+        );
+
+        await expect(
+            withTestActor(() =>
+                driver.complete({
+                    model: 'fake',
+                    messages: [
+                        {
+                            role: 'user',
+                            content: [{ image_url: { url: IMAGE_URL } }],
+                        },
+                    ],
+                }),
+            ),
+        ).resolves.toBeDefined();
+    });
+
+    it('does not judge entries that declare no modalities (reseller catalogs)', async () => {
+        // The stock fake catalog has no `modalities`.
+        const driver = await makeDriver();
+        vi.spyOn(FakeChatProvider.prototype, 'complete').mockResolvedValueOnce(
+            okResult as never,
+        );
+
+        await expect(
+            withTestActor(() =>
+                driver.complete({
+                    model: 'fake',
+                    messages: [
+                        {
+                            role: 'user',
+                            content: [
+                                { image_url: { url: IMAGE_URL } },
+                                {
+                                    video_url: {
+                                        url: 'https://cdn.test/a.mp4',
+                                    },
+                                },
+                            ],
+                        },
+                    ],
+                }),
+            ),
+        ).resolves.toBeDefined();
+    });
+});
+
+describe('ChatCompletionDriver puter_path resolution', () => {
+    it('resolves puter_path parts before calling a provider without its own upload path', async () => {
+        const driver = await makeDriver();
+        const completeSpy = vi
+            .spyOn(FakeChatProvider.prototype, 'complete')
+            .mockResolvedValueOnce(okResult as never);
+
+        await withTestActor(() =>
+            driver.complete({
+                model: 'fake',
+                messages: [
+                    {
+                        role: 'user',
+                        content: [
+                            { type: 'text', text: 'describe' },
+                            { puter_path: '/someone/Documents/pic.png' },
+                        ],
+                    },
+                ],
+            }),
+        );
+
+        expect(processPuterPathUploadsMock).toHaveBeenCalledTimes(1);
+        // The very array the provider then receives, so a resolved part is
+        // what goes upstream.
+        const passed = completeSpy.mock.calls[0]![0] as ICompleteArguments;
+        expect(processPuterPathUploadsMock.mock.calls[0]![0]).toBe(
+            passed.messages,
+        );
+    });
+
+    it('skips resolution when the provider resolves puter_path itself', async () => {
+        (
+            FakeChatProvider.prototype as { resolvesPuterPaths?: boolean }
+        ).resolvesPuterPaths = true;
+        const driver = await makeDriver();
+        vi.spyOn(FakeChatProvider.prototype, 'complete').mockResolvedValueOnce(
+            okResult as never,
+        );
+
+        await withTestActor(() =>
+            driver.complete({
+                model: 'fake',
+                messages: [
+                    {
+                        role: 'user',
+                        content: [{ puter_path: '/someone/Documents/pic.png' }],
+                    },
+                ],
+            }),
+        );
+
+        expect(processPuterPathUploadsMock).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when no part carries a puter_path', async () => {
+        const driver = await makeDriver();
+        vi.spyOn(FakeChatProvider.prototype, 'complete').mockResolvedValueOnce(
+            okResult as never,
+        );
+
+        await withTestActor(() =>
+            driver.complete({
+                model: 'fake',
+                messages: [{ role: 'user', content: 'hi' }],
+            }),
+        );
+
+        expect(processPuterPathUploadsMock).not.toHaveBeenCalled();
+    });
+});

--- a/src/backend/drivers/ai-chat/ChatCompletionDriver.ts
+++ b/src/backend/drivers/ai-chat/ChatCompletionDriver.ts
@@ -50,6 +50,7 @@ import { MistralAIProvider } from './providers/mistral/MistralAiProvider.js';
 import { MoonshotProvider } from './providers/moonshot/MoonshotProvider.js';
 import { NeuralwattProvider } from './providers/neuralwatt/NeuralwattProvider.js';
 import { OllamaChatProvider } from './providers/ollama/OllamaProvider.js';
+import { processPuterPathUploads } from './providers/openai/fileUpload.js';
 import { OpenAiChatProvider } from './providers/openai/OpenAiChatCompletionsProvider.js';
 import { OpenAiResponsesChatProvider } from './providers/openai/OpenAiChatResponsesProvider.js';
 import { OpenRouterProvider } from './providers/openrouter/OpenRouterProvider.js';
@@ -64,6 +65,12 @@ import type {
     ICompleteArguments,
 } from './types.js';
 import { normalize_tools_object } from './utils/FunctionCalling.js';
+import {
+    messagesHavePuterPaths,
+    modelSupportsModality,
+    normalizeMediaParts,
+    requiredInputModalities,
+} from './utils/mediaParts.js';
 import {
     normalize_messages,
     normalize_single_message,
@@ -381,10 +388,28 @@ export class ChatCompletionDriver extends PuterDriver {
         }
 
         if (args.messages) {
-            args.messages = normalize_messages(args.messages);
+            args.messages = normalizeMediaParts(
+                normalize_messages(args.messages),
+            );
         }
         if (args.tools) {
             normalize_tools_object(args.tools);
+        }
+
+        // A clear 400 for image/video parts the catalog says the model cannot
+        // read, before the credit hold and the round trip. Entries that declare
+        // no modalities (reseller catalogs) are not judged.
+        for (const modality of requiredInputModalities(args.messages)) {
+            if (
+                Array.isArray(model.modalities?.input) &&
+                !modelSupportsModality(model, modality)
+            ) {
+                throw new HttpError(
+                    400,
+                    `Model ${model.id} does not support ${modality} input`,
+                    { legacyCode: 'bad_request' },
+                );
+            }
         }
 
         // Both estimated once, before any attempt: providers rewrite
@@ -488,6 +513,7 @@ export class ChatCompletionDriver extends PuterDriver {
         };
 
         try {
+            if (!blocked) await this.#resolvePuterPaths(provider, args, actor);
             res = await provider.complete({
                 ...args,
                 model: model.id,
@@ -536,6 +562,9 @@ export class ChatCompletionDriver extends PuterDriver {
                 tried.add(routeId(fallback.provider!, fallback.id));
 
                 try {
+                    if (!blocked) {
+                        await this.#resolvePuterPaths(fbProvider, args, actor);
+                    }
                     res = await fbProvider.complete({
                         ...args,
                         model: fallback.id,
@@ -1441,6 +1470,27 @@ export class ChatCompletionDriver extends PuterDriver {
             if (pinned) return pinned;
         }
         return this.#preferHealthy(models) ?? models[0];
+    }
+
+    /**
+     * Inline `puter_path` parts as data URLs for a provider without its own
+     * upload path. Per attempt, not once up front: Claude uploads the same
+     * parts to its Files API and restores them if its attempt fails.
+     * Idempotent.
+     */
+    async #resolvePuterPaths(
+        provider: IChatProvider,
+        args: ICompleteArguments,
+        actor: Actor | undefined,
+    ): Promise<void> {
+        if (provider.resolvesPuterPaths) return;
+        if (!messagesHavePuterPaths(args.messages)) return;
+        await processPuterPathUploads(
+            args.messages,
+            { fsEntry: this.stores.fsEntry, s3Object: this.stores.s3Object },
+            this.services.fs,
+            actor,
+        );
     }
 
     #findFallback(modelId: string, tried: Set<string>): IChatModel | null {

--- a/src/backend/drivers/ai-chat/providers/azure/AzureChatProvider.test.ts
+++ b/src/backend/drivers/ai-chat/providers/azure/AzureChatProvider.test.ts
@@ -75,6 +75,15 @@ vi.mock('openai', () => {
     return { OpenAI: OpenAICtor, default: { OpenAI: OpenAICtor } };
 });
 
+// The http→data-URL inliner does real fetches; stub it and assert on calls.
+const { inlineHttpImageUrlsMock } = vi.hoisted(() => ({
+    inlineHttpImageUrlsMock: vi.fn(async (_messages: unknown) => {}),
+}));
+
+vi.mock('../../utils/inlineImages.js', () => ({
+    inlineHttpImageUrls: inlineHttpImageUrlsMock,
+}));
+
 // -- Test harness ----------------------------------------------------
 
 let server: PuterServer;
@@ -187,6 +196,61 @@ describe('AzureChatProvider model catalog', () => {
         expect(ids).toContain('x-ai/grok-4-20-non-reasoning');
         // Codex is Responses-only and must not be advertised here.
         expect(ids).not.toContain('gpt-5.3-codex');
+    });
+});
+
+// -- Image inlining for Grok deployments -----------------------------
+
+describe('AzureChatProvider.complete image inlining', () => {
+    it('inlines http image URLs for Grok deployments, which cannot fetch every host', async () => {
+        inlineHttpImageUrlsMock.mockClear();
+        createMock.mockResolvedValueOnce(okCompletion);
+        const messages = [
+            {
+                role: 'user',
+                content: [
+                    { type: 'text', text: 'what is this' },
+                    {
+                        type: 'image_url',
+                        image_url: { url: 'https://cdn.test/a.png' },
+                    },
+                ],
+            },
+        ];
+
+        await withTestActor(() =>
+            makeProvider().complete({
+                model: 'grok-4-1-fast-non-reasoning',
+                messages,
+            }),
+        );
+
+        expect(inlineHttpImageUrlsMock).toHaveBeenCalledTimes(1);
+        expect(inlineHttpImageUrlsMock.mock.calls[0]![0]).toBe(messages);
+    });
+
+    it('leaves image URLs alone for the OpenAI deployments, which fetch fine', async () => {
+        inlineHttpImageUrlsMock.mockClear();
+        createMock.mockResolvedValueOnce(okCompletion);
+
+        await withTestActor(() =>
+            makeProvider().complete({
+                model: 'gpt-4o',
+                messages: [
+                    {
+                        role: 'user',
+                        content: [
+                            {
+                                type: 'image_url',
+                                image_url: { url: 'https://cdn.test/a.png' },
+                            },
+                        ],
+                    },
+                ],
+            }),
+        );
+
+        expect(inlineHttpImageUrlsMock).not.toHaveBeenCalled();
     });
 });
 

--- a/src/backend/drivers/ai-chat/providers/azure/AzureChatProvider.ts
+++ b/src/backend/drivers/ai-chat/providers/azure/AzureChatProvider.ts
@@ -32,6 +32,7 @@ import {
 } from '../../utils/compaction.js';
 import * as OpenAiUtil from '../../utils/OpenAIUtil.js';
 import { buildCostsOverride } from '../../utils/pricing.js';
+import { inlineHttpImageUrls } from '../../utils/inlineImages.js';
 import { processPuterPathUploads } from '../openai/fileUpload.js';
 import { AZURE_MODELS } from './models.js';
 import { modelLookupNames } from '../../utils/modelRouting.js';
@@ -185,6 +186,13 @@ export class AzureChatProvider implements IChatProvider {
             actor,
         );
 
+        // The Grok deployments behind Azure cannot fetch every public image
+        // host (`image_fetch_failed`); hand them the bytes as data URLs.
+        const isGrok = modelUsed.id.startsWith('grok');
+        if (isGrok) {
+            await inlineHttpImageUrls(messages);
+        }
+
         // Here's something fun; the documentation shows `type: 'image_url'` in
         // objects that contain an image url, but everything still works if
         // that's missing. We normalise it here so the token count code works.
@@ -198,7 +206,6 @@ export class AzureChatProvider implements IChatProvider {
         // `safety_identifier` is an OpenAI-specific param. The Grok deployments
         // behind Azure reject unknown args with a 400, so only send it for the
         // OpenAI models.
-        const isGrok = modelUsed.id.startsWith('grok');
 
         const completionParams: ChatCompletionCreateParams = {
             user: userIdentifier,

--- a/src/backend/drivers/ai-chat/providers/claude/ClaudeProvider.test.ts
+++ b/src/backend/drivers/ai-chat/providers/claude/ClaudeProvider.test.ts
@@ -275,6 +275,117 @@ describe('ClaudeProvider.complete request shape', () => {
         usage: { input_tokens: 1, output_tokens: 1 },
     };
 
+    it('translates canonical image_url parts into url-source image blocks without touching the caller\'s parts', async () => {
+        const { provider } = makeProvider();
+        messagesCreateMock.mockResolvedValueOnce(baseResponse);
+
+        const imagePart = {
+            type: 'image_url',
+            image_url: { url: 'https://cdn.test/doge.jpeg', detail: 'low' },
+            cache_control: { type: 'ephemeral' },
+        };
+        const message = {
+            role: 'user',
+            content: [{ type: 'text', text: 'What do you see?' }, imagePart],
+        };
+        await withTestActor(() =>
+            provider.complete({
+                model: 'claude-haiku-4-5-20251001',
+                messages: [message],
+            }),
+        );
+
+        const [args] = messagesCreateMock.mock.calls[0]!;
+        expect(args.messages[0].content).toEqual([
+            { type: 'text', text: 'What do you see?' },
+            {
+                type: 'image',
+                source: { type: 'url', url: 'https://cdn.test/doge.jpeg' },
+                cache_control: { type: 'ephemeral' },
+            },
+        ]);
+        // The driver hands these same objects to the next route on fallback;
+        // an OpenAI-format reseller cannot read an Anthropic image block.
+        expect(imagePart).toEqual({
+            type: 'image_url',
+            image_url: { url: 'https://cdn.test/doge.jpeg', detail: 'low' },
+            cache_control: { type: 'ephemeral' },
+        });
+        expect(message.content[1]).toBe(imagePart);
+    });
+
+    it('translates data-URL images into base64 sources carrying the media type', async () => {
+        const { provider } = makeProvider();
+        messagesCreateMock.mockResolvedValueOnce(baseResponse);
+
+        await withTestActor(() =>
+            provider.complete({
+                model: 'claude-haiku-4-5-20251001',
+                messages: [
+                    {
+                        role: 'user',
+                        content: [
+                            // The untyped puter.js shorthand, as sent by
+                            // `puter.ai.chat(prompt, file)`.
+                            { image_url: { url: 'data:image/png;base64,iVBORw0KGgo=' } },
+                        ],
+                    },
+                ],
+            }),
+        );
+
+        const [args] = messagesCreateMock.mock.calls[0]!;
+        expect(args.messages[0].content).toEqual([
+            {
+                type: 'image',
+                source: {
+                    type: 'base64',
+                    media_type: 'image/png',
+                    data: 'iVBORw0KGgo=',
+                },
+            },
+        ]);
+    });
+
+    it('replaces video parts with an inline note and leaves text-only messages by identity', async () => {
+        const { provider } = makeProvider();
+        messagesCreateMock.mockResolvedValueOnce(baseResponse);
+
+        const textOnly = {
+            role: 'user',
+            content: [{ type: 'text', text: 'first' }],
+        };
+        await withTestActor(() =>
+            provider.complete({
+                model: 'claude-haiku-4-5-20251001',
+                messages: [
+                    textOnly,
+                    {
+                        role: 'user',
+                        content: [
+                            {
+                                type: 'video_url',
+                                video_url: { url: 'https://cdn.test/a.mp4' },
+                            },
+                        ],
+                    },
+                ],
+            }),
+        );
+
+        const [args] = messagesCreateMock.mock.calls[0]!;
+        expect(args.messages[0]).toBe(textOnly);
+        expect(args.messages[1].content[0].type).toBe('text');
+        expect(args.messages[1].content[0].text).toMatch(
+            /video input is not supported/,
+        );
+    });
+
+    it('tells the driver it resolves puter_path parts itself', () => {
+        const { provider } = makeProvider();
+        expect(provider.resolvesPuterPaths).toBe(true);
+    });
+
     it('forwards model + messages and threads max_tokens through', async () => {
         const { provider } = makeProvider();
         messagesCreateMock.mockResolvedValueOnce(baseResponse);

--- a/src/backend/drivers/ai-chat/providers/claude/ClaudeProvider.ts
+++ b/src/backend/drivers/ai-chat/providers/claude/ClaudeProvider.ts
@@ -39,6 +39,11 @@ import {
     toAnthropicContextManagement,
 } from '../../utils/compaction.js';
 import { make_claude_tools } from '../../utils/FunctionCalling.js';
+import {
+    mediaUrlOf,
+    parseDataUri,
+    unsupportedMediaTextPart,
+} from '../../utils/mediaParts.js';
 import { extract_and_remove_system_messages } from '../../utils/Messages.js';
 import type {
     AIChatStream,
@@ -54,6 +59,42 @@ import { modelLookupNames } from '../../utils/modelRouting.js';
 // params and streamed/returned blocks are handled with `as any` casts.
 const COMPACTION_BETA = 'compact-2026-01-12';
 
+/**
+ * Canonical media part → Anthropic block: `url` source for links, `base64`
+ * source for data URLs, `detail` dropped, video replaced by an inline note.
+ * Non-media parts come back by identity.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const toAnthropicMediaPart = (part: any): any => {
+    if (!part || typeof part !== 'object') return part;
+    if (part.type === 'image_url' || part.image_url !== undefined) {
+        const url = mediaUrlOf(part.image_url);
+        if (url === undefined) return part;
+        const {
+            type: _type,
+            image_url: _imageUrl,
+            detail: _detail,
+            ...rest
+        } = part;
+        const dataUri = parseDataUri(url);
+        const source =
+            dataUri && dataUri.base64
+                ? {
+                      type: 'base64',
+                      media_type: dataUri.mimeType,
+                      data: dataUri.data,
+                  }
+                : { type: 'url', url };
+        return { ...rest, type: 'image', source };
+    }
+    if (part.type === 'video_url' || part.video_url !== undefined) {
+        return unsupportedMediaTextPart(
+            'video input is not supported by Claude models',
+        );
+    }
+    return part;
+};
+
 export class ClaudeProvider implements IChatProvider {
     anthropic: Anthropic;
 
@@ -62,6 +103,10 @@ export class ClaudeProvider implements IChatProvider {
     #stores: { fsEntry: FSEntryStore; s3Object: S3ObjectStore };
 
     #fsService: FSService;
+
+    // `puter_path` parts go through Anthropic's Files API here (larger inputs,
+    // native PDF reading) instead of the driver's inline data URLs.
+    readonly resolvesPuterPaths = true;
 
     constructor(
         meteringService: MeteringService,
@@ -285,6 +330,21 @@ export class ClaudeProvider implements IChatProvider {
                 };
             });
             return message;
+        });
+
+        // Canonical media parts → Anthropic blocks, copy-on-write: the driver
+        // reuses these message objects on fallback to OpenAI-format routes.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        messages = messages.map((message: any) => {
+            if (!Array.isArray(message.content)) return message;
+            let changed = false;
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const content = message.content.map((part: any) => {
+                const converted = toAnthropicMediaPart(part);
+                if (converted !== part) changed = true;
+                return converted;
+            });
+            return changed ? { ...message, content } : message;
         });
 
         const modelUsed =

--- a/src/backend/drivers/ai-chat/providers/gemini/GeminiChatProvider.test.ts
+++ b/src/backend/drivers/ai-chat/providers/gemini/GeminiChatProvider.test.ts
@@ -74,6 +74,15 @@ vi.mock('openai', () => {
     return { OpenAI: OpenAICtor, default: { OpenAI: OpenAICtor } };
 });
 
+// The http→data-URL inliner does real fetches; stub it and assert on calls.
+const { inlineHttpImageUrlsMock } = vi.hoisted(() => ({
+    inlineHttpImageUrlsMock: vi.fn(async (_messages: unknown) => {}),
+}));
+
+vi.mock('../../utils/inlineImages.js', () => ({
+    inlineHttpImageUrls: inlineHttpImageUrlsMock,
+}));
+
 // ── Test harness ────────────────────────────────────────────────────
 
 let server: PuterServer;
@@ -298,6 +307,53 @@ describe('GeminiChatProvider.complete request shape', () => {
         expect(createMock.mock.calls[1]![0].stream_options).toEqual({
             include_usage: true,
         });
+    });
+});
+
+// -- Image inlining --------------------------------------------------
+
+describe('GeminiChatProvider.complete image inlining', () => {
+    const baseCompletion = {
+        choices: [
+            {
+                message: { content: 'Dog', role: 'assistant' },
+                finish_reason: 'stop',
+            },
+        ],
+        usage: { prompt_tokens: 1, completion_tokens: 1 },
+    };
+
+    it('runs http image URLs through the inliner before the request is shaped', async () => {
+        inlineHttpImageUrlsMock.mockClear();
+        const { provider } = makeProvider();
+        createMock.mockResolvedValueOnce(baseCompletion);
+        const messages = [
+            {
+                role: 'user',
+                content: [
+                    { type: 'text', text: 'What animal is this?' },
+                    {
+                        type: 'image_url',
+                        image_url: { url: 'https://cdn.test/doge.jpeg' },
+                    },
+                ],
+            },
+        ];
+
+        await withTestActor(() =>
+            provider.complete({ model: 'gemini-3.5-flash', messages }),
+        );
+
+        // Gemini 3.1+ returns a bodiless 400 for http URLs on Google's
+        // OpenAI-compatible endpoint; the inliner turns them into data URLs,
+        // which every Gemini model accepts.
+        expect(inlineHttpImageUrlsMock).toHaveBeenCalledTimes(1);
+        expect(inlineHttpImageUrlsMock.mock.calls[0]![0]).toBe(messages);
+        // And it runs before the OpenAI-shape pass, so what it rewrites is
+        // what gets typed and sent.
+        expect(inlineHttpImageUrlsMock.mock.invocationCallOrder[0]).toBeLessThan(
+            createMock.mock.invocationCallOrder[0]!,
+        );
     });
 });
 

--- a/src/backend/drivers/ai-chat/providers/gemini/GeminiChatProvider.ts
+++ b/src/backend/drivers/ai-chat/providers/gemini/GeminiChatProvider.ts
@@ -28,6 +28,7 @@ import {
     handle_completion_output,
     process_input_messages,
 } from '../../utils/OpenAIUtil.js';
+import { inlineHttpImageUrls } from '../../utils/inlineImages.js';
 import { buildCostsOverride } from '../../utils/pricing.js';
 import { GEMINI_MODELS } from './models.js';
 import { modelLookupNames } from '../../utils/modelRouting.js';
@@ -66,6 +67,12 @@ export class GeminiChatProvider implements IChatProvider {
         temperature,
     }: ICompleteArguments): ReturnType<IChatProvider['complete']> {
         const actor = Context.get('actor');
+
+        // Gemini 3.1+ rejects http(s) image URLs on Google's OpenAI-compatible
+        // endpoint (bodiless 400) but accepts data URLs; inline for every
+        // model rather than maintain a version list.
+        await inlineHttpImageUrls(messages);
+
         messages = await process_input_messages(messages);
 
         // delete cache_control

--- a/src/backend/drivers/ai-chat/providers/mistral/MistralAiProvider.test.ts
+++ b/src/backend/drivers/ai-chat/providers/mistral/MistralAiProvider.test.ts
@@ -915,10 +915,14 @@ describe('MistralAIProvider image_url coercion', () => {
         usage: { promptTokens: 1, completionTokens: 1 },
     };
 
-    it('flattens image_url objects to plain strings before sending to Mistral', async () => {
+    it('rewrites canonical image_url parts to the SDK\'s camelCase imageUrl', async () => {
         const { provider } = makeProvider();
         completeMock.mockResolvedValueOnce(baseCompletion);
 
+        const imagePartIn = {
+            type: 'image_url',
+            image_url: { url: 'https://example.com/img.png' },
+        };
         await withTestActor(() =>
             provider.complete({
                 model: 'mistral-small-2603',
@@ -927,10 +931,7 @@ describe('MistralAIProvider image_url coercion', () => {
                         role: 'user',
                         content: [
                             { type: 'text', text: 'describe this image' },
-                            {
-                                type: 'image_url',
-                                image_url: { url: 'https://example.com/img.png' },
-                            },
+                            imagePartIn,
                         ],
                     },
                 ],
@@ -940,12 +941,21 @@ describe('MistralAIProvider image_url coercion', () => {
         const [args] = completeMock.mock.calls[0]!;
         const imagePart = (args.messages[0].content as unknown[]).find(
             (p: unknown) => (p as { type: string }).type === 'image_url',
-        ) as { type: string; image_url: unknown };
-        // Mistral expects a plain string, not { url: string }.
-        expect(imagePart.image_url).toBe('https://example.com/img.png');
+        ) as Record<string, unknown>;
+        // The SDK's zod schema wants `imageUrl`; a snake_case `image_url` fails
+        // validation before the request leaves the box.
+        expect(imagePart).toEqual({
+            type: 'image_url',
+            imageUrl: 'https://example.com/img.png',
+        });
+        // Copy-on-write: the driver reuses the caller's parts on fallback.
+        expect(imagePartIn).toEqual({
+            type: 'image_url',
+            image_url: { url: 'https://example.com/img.png' },
+        });
     });
 
-    it('leaves image_url parts that are already plain strings unchanged', async () => {
+    it('carries `detail` into an imageUrl object and accepts a bare string URL', async () => {
         const { provider } = makeProvider();
         completeMock.mockResolvedValueOnce(baseCompletion);
 
@@ -956,6 +966,13 @@ describe('MistralAIProvider image_url coercion', () => {
                     {
                         role: 'user',
                         content: [
+                            {
+                                type: 'image_url',
+                                image_url: {
+                                    url: 'https://example.com/hi.png',
+                                    detail: 'high',
+                                },
+                            },
                             {
                                 type: 'image_url',
                                 image_url: 'https://example.com/already-flat.png',
@@ -967,10 +984,42 @@ describe('MistralAIProvider image_url coercion', () => {
         );
 
         const [args] = completeMock.mock.calls[0]!;
-        const imagePart = (args.messages[0].content as unknown[]).find(
-            (p: unknown) => (p as { type: string }).type === 'image_url',
-        ) as { type: string; image_url: unknown };
-        expect(imagePart.image_url).toBe('https://example.com/already-flat.png');
+        const parts = args.messages[0].content as Record<string, unknown>[];
+        expect(parts[0]).toEqual({
+            type: 'image_url',
+            imageUrl: { url: 'https://example.com/hi.png', detail: 'high' },
+        });
+        expect(parts[1]).toEqual({
+            type: 'image_url',
+            imageUrl: 'https://example.com/already-flat.png',
+        });
+    });
+
+    it('replaces video parts with an inline note since Mistral has no video input', async () => {
+        const { provider } = makeProvider();
+        completeMock.mockResolvedValueOnce(baseCompletion);
+
+        await withTestActor(() =>
+            provider.complete({
+                model: 'mistral-small-2603',
+                messages: [
+                    {
+                        role: 'user',
+                        content: [
+                            {
+                                type: 'video_url',
+                                video_url: { url: 'https://example.com/a.mp4' },
+                            },
+                        ],
+                    },
+                ],
+            }),
+        );
+
+        const [args] = completeMock.mock.calls[0]!;
+        const parts = args.messages[0].content as Record<string, unknown>[];
+        expect(parts[0]!.type).toBe('text');
+        expect(parts[0]!.text).toMatch(/video input is not supported/);
     });
 
     it('leaves messages with plain string content untouched', async () => {
@@ -1011,11 +1060,11 @@ describe('MistralAIProvider image_url coercion', () => {
         );
 
         const [args] = completeMock.mock.calls[0]!;
-        const parts = args.messages[0].content as { type: string; text?: string; image_url?: unknown }[];
+        const parts = args.messages[0].content as { type: string; text?: string; imageUrl?: unknown }[];
         const textPart = parts.find((p) => p.type === 'text');
         const imgPart = parts.find((p) => p.type === 'image_url');
         expect(textPart?.text).toBe('what is in this image?');
-        expect(imgPart?.image_url).toBe('https://example.com/photo.jpg');
+        expect(imgPart?.imageUrl).toBe('https://example.com/photo.jpg');
     });
 });
 

--- a/src/backend/drivers/ai-chat/providers/mistral/MistralAiProvider.ts
+++ b/src/backend/drivers/ai-chat/providers/mistral/MistralAiProvider.ts
@@ -26,6 +26,10 @@ import type {
     IChatProvider,
     ICompleteArguments,
 } from '../../types.js';
+import {
+    mediaUrlOf,
+    unsupportedMediaTextPart,
+} from '../../utils/mediaParts.js';
 import * as OpenAIUtil from '../../utils/OpenAIUtil.js';
 import { MISTRAL_MODELS } from './models.js';
 import { modelLookupNames } from '../../utils/modelRouting.js';
@@ -112,11 +116,10 @@ export class MistralAIProvider implements IChatProvider {
     }
 
     /**
-     * Mistral's API expects `image_url` content parts to carry a plain string
-     * URL, not the OpenAI-style `{ url: string }` object. This method
-     * normalises any `{ type: 'image_url', image_url: { url } }` parts to `{
-     * type: 'image_url', image_url: url }` before the request is sent. Messages
-     * whose `content` is a plain string are left untouched.
+     * The Mistral SDK validates camelCase fields, so canonical `image_url`
+     * parts become `imageUrl` (a snake_case key fails its schema client-side).
+     * Video has no Mistral equivalent and becomes an inline note.
+     * Copy-on-write: the driver reuses the caller's objects on fallback.
      */
     #coerceImageUrls(
         messages: { role: string; content: unknown }[],
@@ -124,17 +127,33 @@ export class MistralAIProvider implements IChatProvider {
         return messages.map((message) => {
             if (!Array.isArray(message.content)) return message;
             const content = message.content.map(
-                (part: { type?: string; image_url?: unknown }) => {
-                    if (
-                        part.type === 'image_url' &&
-                        part.image_url !== null &&
-                        typeof part.image_url === 'object' &&
-                        'url' in (part.image_url as object)
-                    ) {
+                (part: {
+                    type?: string;
+                    image_url?: unknown;
+                    video_url?: unknown;
+                }) => {
+                    if (part?.type === 'image_url' || part?.image_url) {
+                        const url = mediaUrlOf(part.image_url);
+                        if (url === undefined) return part;
+                        const detail =
+                            part.image_url && typeof part.image_url === 'object'
+                                ? (part.image_url as { detail?: unknown })
+                                      .detail
+                                : undefined;
+                        const { image_url: _imageUrl, ...rest } = part;
                         return {
-                            ...part,
-                            image_url: (part.image_url as { url: string }).url,
+                            ...rest,
+                            type: 'image_url',
+                            imageUrl:
+                                detail !== undefined && detail !== null
+                                    ? { url, detail }
+                                    : url,
                         };
+                    }
+                    if (part?.type === 'video_url' || part?.video_url) {
+                        return unsupportedMediaTextPart(
+                            'video input is not supported by Mistral models',
+                        );
                     }
                     return part;
                 },

--- a/src/backend/drivers/ai-chat/providers/moonshot/MoonshotProvider.test.ts
+++ b/src/backend/drivers/ai-chat/providers/moonshot/MoonshotProvider.test.ts
@@ -25,7 +25,7 @@
  * wired `MeteringService` so the recording side is exercised end-to-
  * end. Moonshot is OpenAI-compatible so the OpenAI SDK is mocked at
  * the module boundary; that's the real network egress point. Image-
- * inlining behaviour is covered by `imageHandling.test.ts`; here we
+ * inlining behaviour is covered by `utils/inlineImages.test.ts`; here we
  * stub `inlineHttpImageUrls` so http URLs in vision messages don't
  * trigger network fetches and only verify the provider invokes it
  * for vision-capable models. The companion integration test
@@ -78,14 +78,14 @@ vi.mock('openai', () => {
     return { OpenAI: OpenAICtor, default: { OpenAI: OpenAICtor } };
 });
 
-// ── imageHandling stub ──────────────────────────────────────────────
+// ── inlineImages stub ──────────────────────────────────────────────
 
 const { inlineHttpImageUrlsMock } = vi.hoisted(() => ({
     // Declared with the real function's arity so `mock.calls[0][0]` is typed.
     inlineHttpImageUrlsMock: vi.fn(async (_messages: unknown) => {}),
 }));
 
-vi.mock('./imageHandling.js', () => ({
+vi.mock('../../utils/inlineImages.js', () => ({
     inlineHttpImageUrls: inlineHttpImageUrlsMock,
 }));
 

--- a/src/backend/drivers/ai-chat/providers/moonshot/MoonshotProvider.ts
+++ b/src/backend/drivers/ai-chat/providers/moonshot/MoonshotProvider.ts
@@ -27,7 +27,7 @@ import type {
     ICompleteArguments,
 } from '../../types.js';
 import * as OpenAIUtil from '../../utils/OpenAIUtil.js';
-import { inlineHttpImageUrls } from './imageHandling.js';
+import { inlineHttpImageUrls } from '../../utils/inlineImages.js';
 import { MOONSHOT_MODELS } from './models.js';
 import { modelLookupNames } from '../../utils/modelRouting.js';
 

--- a/src/backend/drivers/ai-chat/providers/neuralwatt/NeuralwattProvider.ts
+++ b/src/backend/drivers/ai-chat/providers/neuralwatt/NeuralwattProvider.ts
@@ -31,12 +31,14 @@ import type {
     IChatCompleteResult,
     ICompleteArguments,
 } from '../../types.js';
-import { inlineHttpImageUrls } from '../moonshot/imageHandling.js';
+import { inlineHttpImageUrls } from '../../utils/inlineImages.js';
+import {
+    messagesHaveImageContent,
+    modelSupportsVision,
+} from '../../utils/mediaParts.js';
 import { modelLookupNames } from '../../utils/modelRouting.js';
 import {
     mapNeuralwattApiModel,
-    messagesHaveImageContent,
-    modelSupportsVision,
     NEURALWATT_DEFAULT_MODEL,
     NEURALWATT_ID_PREFIX,
     stripNeuralwattPrefix,

--- a/src/backend/drivers/ai-chat/providers/neuralwatt/models.ts
+++ b/src/backend/drivers/ai-chat/providers/neuralwatt/models.ts
@@ -159,28 +159,3 @@ export const mapNeuralwattApiModel = (
             : {}),
     };
 };
-
-/** True when the Puter model catalog entry advertises image input. */
-export const modelSupportsVision = (model: IChatModel): boolean =>
-    Array.isArray(model.modalities?.input) &&
-    model.modalities.input.includes('image');
-
-/**
- * Detect image / puter_path parts so we can prefer a vision-capable model from
- * the Neuralwatt catalog (or reject a text-only pick).
- */
-export const messagesHaveImageContent = (
-    messages: Array<{ content?: unknown }>,
-): boolean => {
-    for (const message of messages) {
-        if (!Array.isArray(message.content)) continue;
-        for (const part of message.content as Array<Record<string, unknown>>) {
-            if (!part || typeof part !== 'object') continue;
-            if (part.type === 'image_url' || part.image_url) return true;
-            if (typeof part.puter_path === 'string' && part.puter_path) {
-                return true;
-            }
-        }
-    }
-    return false;
-};

--- a/src/backend/drivers/ai-chat/types.ts
+++ b/src/backend/drivers/ai-chat/types.ts
@@ -155,4 +155,10 @@ export interface IChatProvider {
     checkModeration(
         text: string,
     ): Promise<{ flagged: boolean; categories?: string[] }> | void;
+    /**
+     * Set when the provider uploads `puter_path` parts itself (Anthropic's
+     * Files API); otherwise the driver inlines them as data URLs before each
+     * attempt.
+     */
+    readonly resolvesPuterPaths?: boolean;
 }

--- a/src/backend/drivers/ai-chat/utils/OpenAIUtil.js
+++ b/src/backend/drivers/ai-chat/utils/OpenAIUtil.js
@@ -1,4 +1,5 @@
 import { HttpError } from '@heyputer/backend/src/core/http';
+import { mediaUrlOf, unsupportedMediaTextPart } from './mediaParts.js';
 
 /**
  * Copyright (C) 2024-present Puter Technologies Inc.
@@ -159,7 +160,21 @@ export const process_input_messages_responses_api = async (messages) => {
         }
         expanded.push(msg);
     }
-    messages = expanded;
+    // Copy-on-write from here on: the rewrites below are Responses-specific and
+    // the driver reuses these message objects on fallback to Chat Completions
+    // routes.
+    messages = expanded.map((msg) => {
+        if (!msg || typeof msg !== 'object') return msg;
+        if (!Array.isArray(msg.content)) return { ...msg };
+        return {
+            ...msg,
+            content: msg.content.map((part) =>
+                part && typeof part === 'object' && !Array.isArray(part)
+                    ? { ...part }
+                    : part,
+            ),
+        };
+    });
 
     for (const msg of messages) {
         const content_as_string = (content) => {
@@ -201,12 +216,36 @@ export const process_input_messages_responses_api = async (messages) => {
 
         const content = msg.content;
 
-        for (const o of content) {
-            if (o['image_url'] && !o.type) {
-                o.type = 'image_url';
+        for (let i = 0; i < content.length; i++) {
+            const o = content[i];
+            if (!o || typeof o !== 'object') continue;
+            // Responses wants `input_image` with a bare string URL and `detail`
+            // beside it; it rejects the Chat Completions `image_url` part.
+            if (o.type === 'image_url' || (o.image_url && !o.type)) {
+                const url = mediaUrlOf(o.image_url);
+                const detail =
+                    (o.image_url && typeof o.image_url === 'object'
+                        ? o.image_url.detail
+                        : undefined) ?? o.detail;
+                const {
+                    type: _type,
+                    image_url: _imageUrl,
+                    detail: _detail,
+                    ...rest
+                } = o;
+                content[i] = {
+                    ...rest,
+                    type: 'input_image',
+                    detail: detail ?? 'auto',
+                    ...(url !== undefined ? { image_url: url } : {}),
+                };
+                continue;
             }
-            if (o['video_url'] && !o.type) {
-                o.type = 'video_url';
+            // The Responses API has no video input item.
+            if (o.type === 'video_url' || (o.video_url && !o.type)) {
+                content[i] = unsupportedMediaTextPart(
+                    'video input is not supported by this model',
+                );
             }
         }
 

--- a/src/backend/drivers/ai-chat/utils/OpenAIUtil.test.ts
+++ b/src/backend/drivers/ai-chat/utils/OpenAIUtil.test.ts
@@ -402,6 +402,86 @@ describe('process_input_messages_responses_api', () => {
         expect(blocks[0]?.type).toBe('output_text');
     });
 
+    it('rewrites canonical image parts into `input_image` items', async () => {
+        const imagePart = {
+            type: 'image_url',
+            image_url: { url: 'https://cdn.test/a.png', detail: 'high' },
+        };
+        const messages: Array<Record<string, unknown>> = [
+            {
+                role: 'user',
+                content: [{ type: 'text', text: 'what is this' }, imagePart],
+            },
+        ];
+
+        const out = (await process_input_messages_responses_api(
+            messages,
+        )) as Array<Record<string, unknown>>;
+        const blocks = out[0]!.content as Array<Record<string, unknown>>;
+        expect(blocks[0]).toEqual({ type: 'input_text', text: 'what is this' });
+        // Responses wants a bare string URL with `detail` beside it — the
+        // Chat Completions object form is rejected with "Invalid value:
+        // 'image_url'".
+        expect(blocks[1]).toEqual({
+            type: 'input_image',
+            image_url: 'https://cdn.test/a.png',
+            detail: 'high',
+        });
+        // The caller's part is untouched: the driver reuses it on fallback.
+        expect(imagePart).toEqual({
+            type: 'image_url',
+            image_url: { url: 'https://cdn.test/a.png', detail: 'high' },
+        });
+        expect(messages[0]!.content).toBe(blocks === messages[0]!.content ? blocks : messages[0]!.content);
+        expect((messages[0]!.content as unknown[])[0]).toEqual({
+            type: 'text',
+            text: 'what is this',
+        });
+    });
+
+    it('types an untyped shorthand image part, defaults detail to auto, keeps file_id', async () => {
+        const messages: Array<Record<string, unknown>> = [
+            {
+                role: 'user',
+                content: [
+                    { image_url: { url: 'data:image/png;base64,AAAA' } },
+                    { type: 'image_url', file_id: 'file_123' },
+                ],
+            },
+        ];
+
+        const out = (await process_input_messages_responses_api(
+            messages,
+        )) as Array<Record<string, unknown>>;
+        const blocks = out[0]!.content as Array<Record<string, unknown>>;
+        expect(blocks[0]).toEqual({
+            type: 'input_image',
+            image_url: 'data:image/png;base64,AAAA',
+            detail: 'auto',
+        });
+        expect(blocks[1]).toEqual({
+            type: 'input_image',
+            file_id: 'file_123',
+            detail: 'auto',
+        });
+    });
+
+    it('replaces video parts with an inline note — Responses has no video item', async () => {
+        const messages: Array<Record<string, unknown>> = [
+            {
+                role: 'user',
+                content: [{ video_url: { url: 'https://cdn.test/a.mp4' } }],
+            },
+        ];
+
+        const out = (await process_input_messages_responses_api(
+            messages,
+        )) as Array<Record<string, unknown>>;
+        const blocks = out[0]!.content as Array<Record<string, unknown>>;
+        expect(blocks[0]!.type).toBe('input_text');
+        expect(blocks[0]!.text).toMatch(/video input is not supported/);
+    });
+
     it('hoists a single assistant tool_use into a top-level function_call', async () => {
         const messages: Array<Record<string, unknown>> = [
             {

--- a/src/backend/drivers/ai-chat/utils/inlineImages.test.ts
+++ b/src/backend/drivers/ai-chat/utils/inlineImages.test.ts
@@ -19,12 +19,12 @@
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('../../../../util/secureHttp.js', () => ({
+vi.mock('../../../util/secureHttp.js', () => ({
     secureFetch: vi.fn(),
 }));
 
-import { secureFetch } from '../../../../util/secureHttp.js';
-import { inlineHttpImageUrls, MAX_IMAGE_BYTES } from './imageHandling.js';
+import { secureFetch } from '../../../util/secureHttp.js';
+import { inlineHttpImageUrls, MAX_IMAGE_BYTES } from './inlineImages.js';
 
 const mockedSecureFetch = vi.mocked(secureFetch);
 

--- a/src/backend/drivers/ai-chat/utils/inlineImages.ts
+++ b/src/backend/drivers/ai-chat/utils/inlineImages.ts
@@ -17,7 +17,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { secureFetch } from '../../../../util/secureHttp.js';
+import { secureFetch } from '../../../util/secureHttp.js';
 
 // Matches the OpenAI Chat-Completions inline-upload cap.
 export const MAX_IMAGE_BYTES = 5 * 1_000_000;

--- a/src/backend/drivers/ai-chat/utils/mediaParts.test.ts
+++ b/src/backend/drivers/ai-chat/utils/mediaParts.test.ts
@@ -1,0 +1,320 @@
+/*
+ * Copyright (C) 2024-present Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+    messagesHaveImageContent,
+    messagesHavePuterPaths,
+    modelSupportsModality,
+    modelSupportsVision,
+    normalizeMediaPart,
+    normalizeMediaParts,
+    parseDataUri,
+    requiredInputModalities,
+    unsupportedMediaTextPart,
+} from './mediaParts.js';
+
+const PNG_URL = 'https://cdn.test/a.png';
+const DATA_URL = 'data:image/png;base64,iVBORw0KGgo=';
+
+describe('parseDataUri', () => {
+    it('splits mime type, base64 flag and payload', () => {
+        expect(parseDataUri(DATA_URL)).toEqual({
+            mimeType: 'image/png',
+            base64: true,
+            data: 'iVBORw0KGgo=',
+        });
+    });
+
+    it('treats a missing mime type as text/plain and no base64 flag as false', () => {
+        expect(parseDataUri('data:,hello')).toEqual({
+            mimeType: 'text/plain',
+            base64: false,
+            data: 'hello',
+        });
+    });
+
+    it('returns null for anything that is not a data URI', () => {
+        expect(parseDataUri(PNG_URL)).toBeNull();
+        expect(parseDataUri('')).toBeNull();
+    });
+});
+
+describe('normalizeMediaPart', () => {
+    it('types the puter.js shorthand `{ image_url: { url } }`', () => {
+        expect(normalizeMediaPart({ image_url: { url: PNG_URL } })).toEqual({
+            type: 'image_url',
+            image_url: { url: PNG_URL },
+        });
+    });
+
+    it('wraps a bare string image_url in { url }', () => {
+        expect(normalizeMediaPart({ image_url: PNG_URL })).toEqual({
+            type: 'image_url',
+            image_url: { url: PNG_URL },
+        });
+        expect(
+            normalizeMediaPart({ type: 'image_url', image_url: PNG_URL }),
+        ).toEqual({ type: 'image_url', image_url: { url: PNG_URL } });
+    });
+
+    it('moves a sibling `detail` inside image_url', () => {
+        expect(
+            normalizeMediaPart({
+                type: 'image_url',
+                detail: 'low',
+                image_url: { url: PNG_URL },
+            }),
+        ).toEqual({
+            type: 'image_url',
+            image_url: { url: PNG_URL, detail: 'low' },
+        });
+    });
+
+    it('returns an already-canonical image part by identity', () => {
+        const part = {
+            type: 'image_url',
+            image_url: { url: PNG_URL, detail: 'high' },
+        };
+        expect(normalizeMediaPart(part)).toBe(part);
+    });
+
+    it('maps a Responses `input_image` item', () => {
+        expect(
+            normalizeMediaPart({
+                type: 'input_image',
+                image_url: PNG_URL,
+                detail: 'high',
+            }),
+        ).toEqual({
+            type: 'image_url',
+            image_url: { url: PNG_URL, detail: 'high' },
+        });
+    });
+
+    it('leaves a file_id-only `input_image` alone', () => {
+        const part = { type: 'input_image', file_id: 'file_123' };
+        expect(normalizeMediaPart(part)).toBe(part);
+    });
+
+    it('maps an Anthropic url-source image block', () => {
+        expect(
+            normalizeMediaPart({
+                type: 'image',
+                source: { type: 'url', url: PNG_URL },
+                cache_control: { type: 'ephemeral' },
+            }),
+        ).toEqual({
+            type: 'image_url',
+            image_url: { url: PNG_URL },
+            cache_control: { type: 'ephemeral' },
+        });
+    });
+
+    it('maps an Anthropic base64-source image block to a data URL', () => {
+        expect(
+            normalizeMediaPart({
+                type: 'image',
+                source: {
+                    type: 'base64',
+                    media_type: 'image/png',
+                    data: 'iVBORw0KGgo=',
+                },
+            }),
+        ).toEqual({ type: 'image_url', image_url: { url: DATA_URL } });
+    });
+
+    it('leaves an Anthropic Files API image block alone', () => {
+        const part = {
+            type: 'image',
+            source: { type: 'file', file_id: 'file_abc' },
+        };
+        expect(normalizeMediaPart(part)).toBe(part);
+    });
+
+    it('maps Gemini inline_data (snake and camel case) by mime type', () => {
+        expect(
+            normalizeMediaPart({
+                inline_data: { mime_type: 'image/png', data: 'iVBORw0KGgo=' },
+            }),
+        ).toEqual({ type: 'image_url', image_url: { url: DATA_URL } });
+        expect(
+            normalizeMediaPart({
+                inlineData: { mimeType: 'video/mp4', data: 'AAAA' },
+            }),
+        ).toEqual({
+            type: 'video_url',
+            video_url: { url: 'data:video/mp4;base64,AAAA' },
+        });
+        // Audio has no canonical part yet; passthrough by identity.
+        const audio = {
+            inline_data: { mime_type: 'audio/mpeg', data: 'AAAA' },
+        };
+        expect(normalizeMediaPart(audio)).toBe(audio);
+    });
+
+    it('types and wraps video_url parts', () => {
+        expect(
+            normalizeMediaPart({ video_url: 'https://cdn.test/a.mp4' }),
+        ).toEqual({
+            type: 'video_url',
+            video_url: { url: 'https://cdn.test/a.mp4' },
+        });
+        const canonical = {
+            type: 'video_url',
+            video_url: { url: 'https://cdn.test/a.mp4' },
+        };
+        expect(normalizeMediaPart(canonical)).toBe(canonical);
+    });
+
+    it('returns text, tool and puter_path parts and non-objects by identity', () => {
+        for (const part of [
+            { type: 'text', text: 'hi' },
+            { type: 'tool_use', id: 't1', name: 'f', input: {} },
+            { puter_path: '/u/Documents/a.png' },
+            'plain string',
+            null,
+            42,
+        ]) {
+            expect(normalizeMediaPart(part)).toBe(part);
+        }
+    });
+
+    it('does not mutate the part it was given', () => {
+        const part = Object.freeze({
+            image_url: Object.freeze({ url: PNG_URL }),
+        });
+        const out = normalizeMediaPart(part) as Record<string, unknown>;
+        expect(out).not.toBe(part);
+        expect(out.type).toBe('image_url');
+        expect(part).toEqual({ image_url: { url: PNG_URL } });
+    });
+});
+
+describe('normalizeMediaParts', () => {
+    it('rewrites media parts inside every message and returns the same array', () => {
+        const messages = [
+            { role: 'user', content: 'plain string content' },
+            {
+                role: 'user',
+                content: [
+                    { type: 'text', text: 'look' },
+                    { image_url: { url: PNG_URL } },
+                    { type: 'input_image', image_url: DATA_URL },
+                ],
+            },
+        ];
+        const out = normalizeMediaParts(messages);
+        expect(out).toBe(messages);
+        expect(messages[0]).toEqual({
+            role: 'user',
+            content: 'plain string content',
+        });
+        expect(messages[1]!.content).toEqual([
+            { type: 'text', text: 'look' },
+            { type: 'image_url', image_url: { url: PNG_URL } },
+            { type: 'image_url', image_url: { url: DATA_URL } },
+        ]);
+    });
+});
+
+describe('requiredInputModalities', () => {
+    it('reports image and video parts, counting each modality once', () => {
+        expect(
+            requiredInputModalities([
+                {
+                    content: [
+                        { type: 'text', text: 'a' },
+                        { type: 'image_url', image_url: { url: PNG_URL } },
+                        { image_url: { url: PNG_URL } },
+                    ],
+                },
+                { content: [{ video_url: { url: 'https://cdn.test/a.mp4' } }] },
+            ]),
+        ).toEqual(['image', 'video']);
+    });
+
+    it('ignores puter_path parts, string content and missing messages', () => {
+        expect(
+            requiredInputModalities([
+                { content: 'hi' },
+                { content: [{ puter_path: '/u/Documents/a.png' }] },
+            ]),
+        ).toEqual([]);
+        expect(requiredInputModalities(undefined)).toEqual([]);
+    });
+});
+
+describe('model modality helpers', () => {
+    it('reads modalities.input', () => {
+        const vision = {
+            modalities: { input: ['text', 'image'], output: ['text'] },
+        };
+        const textOnly = { modalities: { input: ['text'], output: ['text'] } };
+        expect(modelSupportsVision(vision)).toBe(true);
+        expect(modelSupportsVision(textOnly)).toBe(false);
+        expect(modelSupportsModality(vision, 'video')).toBe(false);
+        // Undeclared modalities are simply "not advertised".
+        expect(modelSupportsVision({})).toBe(false);
+    });
+});
+
+describe('message scanners', () => {
+    it('messagesHaveImageContent counts image parts and puter_path parts', () => {
+        expect(messagesHaveImageContent([{ content: 'hi' }])).toBe(false);
+        expect(
+            messagesHaveImageContent([
+                { content: [{ image_url: { url: PNG_URL } }] },
+            ]),
+        ).toBe(true);
+        expect(
+            messagesHaveImageContent([
+                { content: [{ puter_path: '/u/a.png' }] },
+            ]),
+        ).toBe(true);
+    });
+
+    it('messagesHavePuterPaths only counts unresolved puter_path parts', () => {
+        expect(
+            messagesHavePuterPaths([{ content: [{ puter_path: '/u/a.png' }] }]),
+        ).toBe(true);
+        expect(
+            messagesHavePuterPaths([
+                {
+                    content: [
+                        { type: 'image_url', image_url: { url: PNG_URL } },
+                    ],
+                },
+            ]),
+        ).toBe(false);
+        expect(messagesHavePuterPaths(undefined)).toBe(false);
+    });
+});
+
+describe('unsupportedMediaTextPart', () => {
+    it('produces the shared inline system-note shape', () => {
+        expect(
+            unsupportedMediaTextPart('video input is not supported'),
+        ).toEqual({
+            type: 'text',
+            text: '{error: video input is not supported; the user did not write this message}',
+        });
+    });
+});

--- a/src/backend/drivers/ai-chat/utils/mediaParts.ts
+++ b/src/backend/drivers/ai-chat/utils/mediaParts.ts
@@ -1,0 +1,292 @@
+/*
+ * Copyright (C) 2024-present Puter Technologies Inc.
+ *
+ * This file is part of Puter.
+ *
+ * Puter is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import type { IChatModel } from '../types.js';
+
+/**
+ * Media content parts, canonicalised once in the driver so providers only ever
+ * translate from one shape (the OpenAI Chat Completions form, which most
+ * upstreams speak natively):
+ *
+ * - Image: `{ type: 'image_url', image_url: { url, detail? } }`
+ * - Video: `{ type: 'video_url', video_url: { url } }`
+ *
+ * Accepted inbound shapes: OpenAI Chat (typed or untyped, object or bare string
+ * URL, `detail` inside or beside it), OpenAI Responses `input_image`, Anthropic
+ * `image` blocks with `url`/`base64` sources, and Gemini `inline_data`.
+ * `puter_path` parts are left alone; the driver resolves them per attempt.
+ */
+
+export type MediaModality = 'image' | 'video';
+
+type Part = Record<string, unknown>;
+
+const isObject = (value: unknown): value is Part =>
+    !!value && typeof value === 'object' && !Array.isArray(value);
+
+const DATA_URI_PATTERN = /^data:([^;,]*)((?:;[^;,]*)*),(.*)$/s;
+
+/**
+ * Split a `data:` URI into its MIME type, base64 flag and payload. Returns null
+ * for anything that isn't a data URI.
+ */
+export const parseDataUri = (
+    url: string,
+): { mimeType: string; base64: boolean; data: string } | null => {
+    const match = DATA_URI_PATTERN.exec(url);
+    if (!match) return null;
+    const params = (match[2] ?? '')
+        .split(';')
+        .filter(Boolean)
+        .map((p) => p.toLowerCase());
+    return {
+        mimeType: (match[1] || 'text/plain').toLowerCase(),
+        base64: params.includes('base64'),
+        data: match[3] ?? '',
+    };
+};
+
+/** The URL out of a bare string or an OpenAI-style `{ url }` object. */
+export const mediaUrlOf = (value: unknown): string | undefined => {
+    if (typeof value === 'string') return value;
+    if (isObject(value) && typeof value.url === 'string') return value.url;
+    return undefined;
+};
+
+const canonicalImagePart = (
+    rest: Part,
+    url: string,
+    detail: unknown,
+): Part => ({
+    ...rest,
+    type: 'image_url',
+    image_url: {
+        url,
+        ...(detail !== undefined && detail !== null ? { detail } : {}),
+    },
+});
+
+const canonicalVideoPart = (rest: Part, url: string): Part => ({
+    ...rest,
+    type: 'video_url',
+    video_url: { url },
+});
+
+/**
+ * Canonicalise one content part. Returns the same object when nothing had to
+ * change, so callers can tell a rewrite from a passthrough by identity.
+ */
+export const normalizeMediaPart = (part: unknown): unknown => {
+    if (!isObject(part)) return part;
+
+    // OpenAI Responses API: `image_url` is a bare string, `detail` a sibling.
+    if (part.type === 'input_image') {
+        const { type: _type, image_url, detail, ...rest } = part;
+        const url = mediaUrlOf(image_url);
+        // A `file_id`-only part has nothing we can canonicalise around.
+        if (url === undefined) return part;
+        return canonicalImagePart(rest, url, detail);
+    }
+
+    // Anthropic: `{ type: 'image', source: { type: 'url' | 'base64' } }`.
+    if (part.type === 'image' && isObject(part.source)) {
+        const { type: _type, source, ...rest } = part;
+        if (source.type === 'url' && typeof source.url === 'string') {
+            return canonicalImagePart(rest, source.url, undefined);
+        }
+        if (source.type === 'base64' && typeof source.data === 'string') {
+            const mediaType =
+                typeof source.media_type === 'string'
+                    ? source.media_type
+                    : 'application/octet-stream';
+            return canonicalImagePart(
+                rest,
+                `data:${mediaType};base64,${source.data}`,
+                undefined,
+            );
+        }
+        // Anthropic Files API references stay Anthropic-only.
+        return part;
+    }
+
+    // Gemini: `{ inline_data: { mime_type, data } }` (snake or camel case).
+    const inline = isObject(part.inline_data)
+        ? part.inline_data
+        : isObject(part.inlineData)
+          ? part.inlineData
+          : undefined;
+    if (inline && typeof inline.data === 'string') {
+        const mime =
+            typeof inline.mime_type === 'string'
+                ? inline.mime_type
+                : typeof inline.mimeType === 'string'
+                  ? inline.mimeType
+                  : '';
+        const {
+            inline_data: _snake,
+            inlineData: _camel,
+            type: _type,
+            ...rest
+        } = part;
+        const url = `data:${mime || 'application/octet-stream'};base64,${inline.data}`;
+        if (mime.startsWith('image/')) {
+            return canonicalImagePart(rest, url, undefined);
+        }
+        if (mime.startsWith('video/')) return canonicalVideoPart(rest, url);
+        return part;
+    }
+
+    // OpenAI Chat Completions: possibly untyped, possibly a bare string URL,
+    // possibly with `detail` beside the URL instead of inside it.
+    if (
+        part.image_url !== undefined &&
+        (part.type === undefined || part.type === 'image_url')
+    ) {
+        const url = mediaUrlOf(part.image_url);
+        if (url === undefined) return part;
+        const { type: _type, image_url, detail, ...rest } = part;
+        const innerDetail = isObject(image_url) ? image_url.detail : undefined;
+        const alreadyCanonical =
+            part.type === 'image_url' &&
+            isObject(image_url) &&
+            detail === undefined;
+        if (alreadyCanonical) return part;
+        return canonicalImagePart(rest, url, innerDetail ?? detail);
+    }
+    if (
+        part.video_url !== undefined &&
+        (part.type === undefined || part.type === 'video_url')
+    ) {
+        const url = mediaUrlOf(part.video_url);
+        if (url === undefined) return part;
+        if (part.type === 'video_url' && isObject(part.video_url)) return part;
+        const { type: _type, video_url: _video, ...rest } = part;
+        return canonicalVideoPart(rest, url);
+    }
+
+    return part;
+};
+
+/**
+ * Canonicalise every media part in place. Replaces array elements (as the
+ * message normaliser already does) without mutating the original part objects.
+ */
+export const normalizeMediaParts = <T extends { content?: unknown }>(
+    messages: T[],
+): T[] => {
+    for (const message of messages) {
+        if (!message || !Array.isArray(message.content)) continue;
+        const content = message.content as unknown[];
+        for (let i = 0; i < content.length; i++) {
+            const normalized = normalizeMediaPart(content[i]);
+            if (normalized !== content[i]) content[i] = normalized;
+        }
+    }
+    return messages;
+};
+
+/**
+ * Input modalities the messages need beyond text. `puter_path` parts are not
+ * counted: what they point at is unknown until an attempt resolves them.
+ */
+export const requiredInputModalities = (
+    messages: ReadonlyArray<{ content?: unknown }> | undefined,
+): MediaModality[] => {
+    const found = new Set<MediaModality>();
+    for (const message of messages ?? []) {
+        if (!message || !Array.isArray(message.content)) continue;
+        for (const part of message.content as unknown[]) {
+            if (!isObject(part)) continue;
+            if (part.type === 'image_url' || part.image_url !== undefined) {
+                found.add('image');
+            } else if (
+                part.type === 'video_url' ||
+                part.video_url !== undefined
+            ) {
+                found.add('video');
+            }
+        }
+    }
+    return [...found];
+};
+
+/** True when the catalog entry advertises the given input modality. */
+export const modelSupportsModality = (
+    model: Pick<IChatModel, 'modalities'>,
+    modality: string,
+): boolean =>
+    Array.isArray(model.modalities?.input) &&
+    model.modalities.input.includes(modality);
+
+/** True when the Puter model catalog entry advertises image input. */
+export const modelSupportsVision = (
+    model: Pick<IChatModel, 'modalities'>,
+): boolean => modelSupportsModality(model, 'image');
+
+/**
+ * Detect image / puter_path parts so a provider can prefer a vision-capable
+ * model from its catalog (or reject a text-only pick).
+ */
+export const messagesHaveImageContent = (
+    messages: ReadonlyArray<{ content?: unknown }>,
+): boolean => {
+    for (const message of messages) {
+        if (!message || !Array.isArray(message.content)) continue;
+        for (const part of message.content as unknown[]) {
+            if (!isObject(part)) continue;
+            if (part.type === 'image_url' || part.image_url !== undefined) {
+                return true;
+            }
+            if (typeof part.puter_path === 'string' && part.puter_path) {
+                return true;
+            }
+        }
+    }
+    return false;
+};
+
+/** True when any part still carries an unresolved `puter_path`. */
+export const messagesHavePuterPaths = (
+    messages: ReadonlyArray<{ content?: unknown }> | undefined,
+): boolean => {
+    for (const message of messages ?? []) {
+        if (!message || !Array.isArray(message.content)) continue;
+        for (const part of message.content as unknown[]) {
+            if (
+                isObject(part) &&
+                typeof part.puter_path === 'string' &&
+                part.puter_path
+            ) {
+                return true;
+            }
+        }
+    }
+    return false;
+};
+
+/**
+ * The inline note substituted for an attachment a provider cannot carry; same
+ * wording as the `puter_path` resolvers and the image inliner.
+ */
+export const unsupportedMediaTextPart = (
+    reason: string,
+): { type: 'text'; text: string } => ({
+    type: 'text',
+    text: `{error: ${reason}; the user did not write this message}`,
+});


### PR DESCRIPTION
Image input to `puter.ai.chat` now works on every provider, and every provider handles it the same way.

Fixes #3409. Supersedes #3514.

The SDK shorthand `puter.ai.chat(prompt, imageUrl)` sends `{ image_url: { url } }` with no `type`. Until now each provider coped with that on its own, and three of them did not:

- **Claude** forwarded the part untouched; Anthropic answered `messages.0.content.1.type: Field required`.
- **OpenAI Responses and Azure Responses** (every gpt-5.x Responses-only model) sent a Chat Completions `image_url` part; the Responses API answered `Invalid value: 'image_url'. Supported values are: 'input_text', 'input_image', ...`.
- **Mistral** flattened the part to `image_url: '<string>'`, but the Mistral SDK validates camelCase `imageUrl`, so the request failed client-side. The existing unit test asserted the wrong shape.

The symptom had "gone away" on production only because #3529 started keeping reseller routes in the model bucket, so these direct failures fell back to OpenRouter. Every Claude, Responses, and Mistral vision request paid a failed upstream round trip and was served by a reseller.

## How it fits together now

- **One canonical shape.** `utils/mediaParts.ts` canonicalises every inbound media part to the OpenAI Chat Completions form (`{ type: 'image_url', image_url: { url, detail? } }`, `{ type: 'video_url', video_url: { url } }`). It accepts the untyped shorthand, bare string URLs, Responses `input_image`, Anthropic `image` blocks (`url` and `base64` sources), and Gemini `inline_data`. The driver runs it right after message normalisation, so providers only translate from one shape.
- **Provider translators.** Claude maps to Anthropic `image` blocks (`url` source for links, `base64` source with media type for data URLs). The Responses processor emits `input_image` with a string URL and `detail`, and now copies messages instead of mutating the caller's objects with Responses-only shapes. Mistral emits `imageUrl`. Video parts, which none of these accept, become the same inline note the `puter_path` resolvers already use.
- **Capability gate.** The driver returns a clear 400 (`Model X does not support image input`) when a message carries image or video parts and the resolved model's catalog entry declares modalities without them. Entries that declare no modalities (OpenRouter, Together) are not judged.
- **Shared inliner.** The Moonshot http→data-URL fetcher moved to `utils/inlineImages.ts`. Moonshot and Neuralwatt import it from there; Grok-via-Azure (whose fetcher cannot reach every public host) and Gemini (3.1+ returns a bodiless 400 for http image URLs on Google's OpenAI-compatible endpoint) now use it too.
- **`puter_path` for every provider.** The driver resolves `puter_path` parts to inline data URLs before each attempt for any provider that does not declare `resolvesPuterPaths`. Claude declares it and keeps its Files API path. Previously only OpenAI, Azure, Claude, and Meta handled `puter_path`; every other provider forwarded the raw part upstream.

No public API, limit, or wire key changes. Existing callers are unaffected: every shape that worked before still works, and the new gate only fires where the upstream would have rejected the request anyway.

## Testing

**Unit.** `npm run test:backend`: 310 files / 8029 tests passed; the one failing suite in the full run (`appSockets.integration.test.ts`) hit `EADDRINUSE` on a random port and passes in isolation. New: `utils/mediaParts.test.ts`, `ChatCompletionDriver.media.test.ts` (canonicalisation, gate, per-attempt `puter_path` resolution). Extended: Claude, Azure Chat, Gemini, Mistral, OpenAI-util suites. Typecheck: no new errors. ESLint and Prettier clean on all changed source files.

**Live** (local compose instance rebuilt from this branch, real provider keys; the SDK shorthand payload with a 4 KB JPEG, one probe per image-capable model in the catalog):

| Provider | Models probed | Direct 200 | Notes |
|---|---|---|---|
| Claude | 11 | 11 | was: `content.1.type: Field required` → OpenRouter fallback |
| OpenAI Responses | 8 | 8 | was: `Invalid value: 'image_url'` → OpenRouter fallback |
| Azure Responses | 2 | 2 | same as above |
| Mistral | 6 | 6 | was: SDK `imageUrl: Required` → OpenRouter fallback |
| Gemini | 13 | 13 | was: 3.1+ models bodiless 400 on http URLs → OpenRouter fallback |
| Azure Chat (incl. 3 Grok) | 13 | 13 | was: Grok `image_fetch_failed` on http URLs |
| OpenAI Chat | 16 | 16 | |
| Alibaba | 32 | 31 | `qvq-max`: account cannot call it over HTTP (text fails the same way) |
| xAI | 6 | 5 | `grok-4.20-multi-agent` falls back on text-only calls too |
| DeepSeek, MiniMax, Moonshot | 5 | 5 | |
| Meta | 2 | 0 | local key returns 401 |

Data URLs (one model per provider) all served directly as well. "Direct" is judged from the usage shape; OpenAI Chat rows may have been served by Azure, which shares it.

To prove the shape fix rather than a lucky fallback, the same probes were repeated with an unreachable image URL so the reseller fails too. The direct routes now report fetch errors — Claude: `Unable to download the file`; Mistral: `File could not be fetched from url`; Azure Responses: `Error while downloading file. Upstream status code: 404` — where before they reported the schema errors quoted above.

Gate check: an image sent to twelve text-only models across seven providers returned 400 `does not support image input` with no upstream call.

Not covered: Meta Muse Spark (the local key returns 401) and Alibaba `qvq-max` (the account cannot call it over HTTP; text-only fails the same way).
