### PR TITLE
Fix/node signed batch upload

### DIFF
--- a/src/docs/src/FS/upload.md
+++ b/src/docs/src/FS/upload.md
@@ -71,7 +71,7 @@ When the signed batch-write endpoint is unavailable and the SDK falls back to th
 
 ## Uploading directories
 
-Directory uploads (dropped directory entries, or `createFileParent`) are supported on `websites`, `apps`, `nodejs`, and `workers` when the signed batch-write endpoint is available. This includes preserving nested paths and files with the same name in different directories. If the SDK falls back to the older batch endpoint, directory uploads are not supported and reject with `batch_upload_failed`; create the directories with [`puter.fs.mkdir()`](/FS/mkdir/) and upload the files into them instead.
+Directory uploads (dropped directory entries, or `createFileParent`) work on every platform: nested paths are recreated under the destination, and files sharing a name stay apart in the directories they came from. They rely on the signed batch-write endpoint, so against a backend that doesn't have one the SDK falls back to the older batch endpoint, which cannot create directories — the upload rejects with `batch_upload_failed`, and the directories have to be created with [`puter.fs.mkdir()`](/FS/mkdir/) and the files uploaded into them.
 
 ## Thumbnails
 

--- a/src/docs/src/FS/upload.md
+++ b/src/docs/src/FS/upload.md
@@ -63,7 +63,7 @@ If any part of the upload fails, the promise is rejected — it never resolves t
 
 When every failed item failed the same way, that `code` and `status` are also set on the rejection value itself, because the cause belongs to the request rather than to any one file. An upload that exceeds the account's storage quota is the common case: it rejects with `code: 'storage_limit_reached'` and `status: 413` however many files were in it.
 
-On `nodejs` and `workers`, where the upload goes through an older batch endpoint, the rejection value also carries a stable `code`:
+When the signed batch-write endpoint is unavailable and the SDK falls back to the older batch endpoint, the rejection value also carries a stable `code`:
 
 - `batch_upload_failed` — every operation failed, so nothing was written.
 - `batch_upload_partially_failed` — some operations succeeded and others didn't. `failedCount` and `totalCount` say how many, and `results` holds every operation's result in the order they were sent.
@@ -71,7 +71,7 @@ On `nodejs` and `workers`, where the upload goes through an older batch endpoint
 
 ## Uploading directories
 
-Directory uploads (dropped directory entries, or `createFileParent`) are supported on `websites` and `apps`. On `nodejs` and `workers` the upload goes through an older batch endpoint that cannot create the directory tree, so a directory upload rejects with `batch_upload_failed`; create the directories with [`puter.fs.mkdir()`](/FS/mkdir/) and upload the files into them instead.
+Directory uploads (dropped directory entries, or `createFileParent`) are supported on `websites`, `apps`, `nodejs`, and `workers` when the signed batch-write endpoint is available. This includes preserving nested paths and files with the same name in different directories. If the SDK falls back to the older batch endpoint, directory uploads are not supported and reject with `batch_upload_failed`; create the directories with [`puter.fs.mkdir()`](/FS/mkdir/) and upload the files into them instead.
 
 ## Thumbnails
 

--- a/src/puter-js/src/lib/polyfills/xhrshim.js
+++ b/src/puter-js/src/lib/polyfills/xhrshim.js
@@ -187,9 +187,14 @@ const XMLHttpRequestShim = class XMLHttpRequest extends EventTarget {
             this[sRespHeaders] = resp.headers;
             this.readyState = this.constructor.HEADERS_RECEIVED;
 
+            // A bodiless response (`fetch` gives `null`, as an empty 200 from a
+            // signed storage PUT does) has no content-type to read and nothing
+            // to iterate.
+            const body = resp.body ?? [];
+
             if ( (resp.headers.get('content-type') ?? '').includes('application/x-ndjson') || this.streamRequestBadForPerformance ) {
                 let bytes = new Uint8Array();
-                for await ( const chunk of resp.body ) {
+                for await ( const chunk of body ) {
                     this.readyState = this.constructor.LOADING;
 
                     bytes = mergeUint8Arrays(bytes, chunk);
@@ -198,7 +203,7 @@ const XMLHttpRequestShim = class XMLHttpRequest extends EventTarget {
                 }
             } else {
                 const bytesChunks = [];
-                for await ( const chunk of resp.body ) {
+                for await ( const chunk of body ) {
                     bytesChunks.push(chunk);
                 }
                 parseBody.call(this, mergeUint8Arrays(...bytesChunks));

--- a/src/puter-js/src/lib/polyfills/xhrshim.js
+++ b/src/puter-js/src/lib/polyfills/xhrshim.js
@@ -187,7 +187,7 @@ const XMLHttpRequestShim = class XMLHttpRequest extends EventTarget {
             this[sRespHeaders] = resp.headers;
             this.readyState = this.constructor.HEADERS_RECEIVED;
 
-            if ( resp.headers.get('content-type').includes('application/x-ndjson') || this.streamRequestBadForPerformance ) {
+            if ( (resp.headers.get('content-type') ?? '').includes('application/x-ndjson') || this.streamRequestBadForPerformance ) {
                 let bytes = new Uint8Array();
                 for await ( const chunk of resp.body ) {
                     this.readyState = this.constructor.LOADING;

--- a/src/puter-js/src/lib/polyfills/xhrshim.test.js
+++ b/src/puter-js/src/lib/polyfills/xhrshim.test.js
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createServer } from 'node:http';
+import { createRequire } from 'node:module';
+
+// Load the dual-export XHR adapter natively; Vite treats its CommonJS branch as a module mutation.
+const { default: XMLHttpRequestShim } = createRequire(import.meta.url)('./xhrshim.js');
+
+// Signed storage backends answer a PUT with neither a content-type nor a body,
+// shapes the shim used to throw on inside its own `then` — leaving the request
+// hanging with no 'load' and no 'error'.
+let respond;
+let server;
+let origin;
+
+beforeEach(async () => {
+    respond = (res) => { res.end('stored'); };
+    server = createServer(async (req, res) => {
+        for await ( const chunk of req ) void chunk;
+        respond(res);
+    });
+    await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+    origin = `http://127.0.0.1:${server.address().port}`;
+});
+
+afterEach(async () => {
+    server.closeAllConnections();
+    await new Promise(resolve => server.close(resolve));
+});
+
+const put = (body = 'payload') => new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequestShim();
+    xhr.open('PUT', `${origin}/object`);
+    xhr.onload = () => resolve(xhr);
+    xhr.onerror = () => reject(new Error('request errored'));
+    xhr.send(body);
+});
+
+describe('xhrshim', () => {
+    it('completes a response that declares no content-type', async () => {
+        const xhr = await put();
+        expect(xhr.status).toBe(200);
+        expect(xhr.responseText).toBe('stored');
+    });
+
+    it('completes a response with no body', async () => {
+        respond = (res) => { res.statusCode = 204; res.end(); };
+        const xhr = await put();
+        expect(xhr.status).toBe(204);
+        expect(xhr.responseText).toBe('');
+    });
+
+    it('reads a response header regardless of the case asked for', async () => {
+        respond = (res) => { res.setHeader('ETag', '"abc123"'); res.end(); };
+        const xhr = await put();
+        expect(xhr.getResponseHeader('etag')).toBe('"abc123"');
+        expect(xhr.getResponseHeader('ETag')).toBe('"abc123"');
+        expect(xhr.getResponseHeader('content-type')).toBe(null);
+    });
+});

--- a/src/puter-js/src/modules/FileSystem/operations/upload/constants.js
+++ b/src/puter-js/src/modules/FileSystem/operations/upload/constants.js
@@ -14,7 +14,6 @@ export const SIGNED_BATCH_CHUNK_PIPELINE_CONCURRENCY = 4;
 export const SIGNED_BATCH_FILE_UPLOAD_CONCURRENCY = 8;
 export const SIGNED_MULTIPART_PART_UPLOAD_CONCURRENCY = 8;
 export const SIGNED_BATCH_WRITE_UNAVAILABLE_STATUSES = new Set([404, 405, 501]);
-export const SIGNED_BATCH_SUPPORTED_ENVS = ['web', 'gui', 'app', 'nodejs' , 'service-worker', 'web-worker'];
 
 // Smallest upload worth a pre-flight `/df` capacity check. Anything under this
 // is cheaper to just attempt and let the server reject.

--- a/src/puter-js/src/modules/FileSystem/operations/upload/constants.js
+++ b/src/puter-js/src/modules/FileSystem/operations/upload/constants.js
@@ -14,7 +14,7 @@ export const SIGNED_BATCH_CHUNK_PIPELINE_CONCURRENCY = 4;
 export const SIGNED_BATCH_FILE_UPLOAD_CONCURRENCY = 8;
 export const SIGNED_MULTIPART_PART_UPLOAD_CONCURRENCY = 8;
 export const SIGNED_BATCH_WRITE_UNAVAILABLE_STATUSES = new Set([404, 405, 501]);
-export const SIGNED_BATCH_SUPPORTED_ENVS = ['web', 'gui', 'app'];
+export const SIGNED_BATCH_SUPPORTED_ENVS = ['web', 'gui', 'app', 'nodejs' , 'service-worker', 'web-worker'];
 
 // Smallest upload worth a pre-flight `/df` capacity check. Anything under this
 // is cheaper to just attempt and let the server reject.

--- a/src/puter-js/src/modules/FileSystem/operations/upload/index.js
+++ b/src/puter-js/src/modules/FileSystem/operations/upload/index.js
@@ -6,7 +6,7 @@
 import * as utils from '../../../../lib/utils.js';
 import getAbsolutePathForApp from '../../utils/getAbsolutePathForApp.js';
 import { promptIfStorageLimitError } from '../storageLimitPrompt.js';
-import { SIGNED_BATCH_WRITE_CAPABILITY_KEY, SIGNED_BATCH_SUPPORTED_ENVS, SPACE_CHECK_MIN_BYTES } from './constants.js';
+import { SIGNED_BATCH_WRITE_CAPABILITY_KEY, SPACE_CHECK_MIN_BYTES } from './constants.js';
 import { normalizeUploadEntries, separateFilesAndDirs } from './entries.js';
 import { generateThumbnails } from './thumbnails.js';
 import { performSignedBatchUpload } from './signedBatchUpload.js';
@@ -169,7 +169,6 @@ const uploadImpl = async function (items, dirPath, options = {}) {
         const signedBatchWriteAllowed = signedBatchWriteCapability !== false;
 
         const shouldAttemptSignedBatchWrite = (
-            SIGNED_BATCH_SUPPORTED_ENVS.includes(puter.env) &&
             !options.shortcutTo &&
             (files.length > 0 || signedDirectories.length > 0) &&
             signedBatchWriteAllowed

--- a/src/puter-js/tests/api/suites/fs.suite.ts
+++ b/src/puter-js/tests/api/suites/fs.suite.ts
@@ -555,6 +555,29 @@ export default suite('fs', {
         t.assert.equal(await blob.text(), 'upload two');
     },
 
+    'upload preserves nested paths and duplicate names in nodejs': async (t) => {
+        const dir = `${home(t)}/fs-suite-upload-nested`;
+        await t.puter.fs.mkdir(dir);
+        const files = [
+            droppedFile('content a', 'folder-a/file.txt'),
+            droppedFile('content b', 'folder-b/file.txt'),
+        ];
+
+        await t.puter.fs.upload(files, dir, {
+            parsedDataTransferItems: true,
+            createFileParent: true,
+        });
+
+        t.assert.equal(
+            await (await t.puter.fs.read(`${dir}/folder-a/file.txt`)).text(),
+            'content a',
+        );
+        t.assert.equal(
+            await (await t.puter.fs.read(`${dir}/folder-b/file.txt`)).text(),
+            'content b',
+        );
+    },
+
     'upload of a single File resolves to one entry, not an array': async (t) => {
         const dir = `${home(t)}/fs-suite-upload-single`;
         await t.puter.fs.mkdir(dir);

--- a/src/puter-js/tests/api/suites/fs.suite.ts
+++ b/src/puter-js/tests/api/suites/fs.suite.ts
@@ -555,7 +555,7 @@ export default suite('fs', {
         t.assert.equal(await blob.text(), 'upload two');
     },
 
-    'upload preserves nested paths and duplicate names in nodejs': async (t) => {
+    'upload keeps same-named files apart by the directory they came from': async (t) => {
         const dir = `${home(t)}/fs-suite-upload-nested`;
         await t.puter.fs.mkdir(dir);
         const files = [
@@ -798,61 +798,53 @@ export default suite('fs', {
         );
     },
 
-    // Directory uploads only work on the signed batch-write path. The legacy
-    // `/batch` fallback (node, workers) sends a mkdir operation the backend
-    // does not accept, so these are pinned where the behaviour is correct
-    // rather than asserted everywhere and quietly relaxed. What the legacy
-    // path does instead is asserted below, in the legacy upload tests.
-    'upload of parsed drop entries creates the dropped directory tree': {
-        platforms: ['browser'],
-        fn: async (t) => {
-            const dir = `${home(t)}/fs-suite-upload-drop`;
-            await t.puter.fs.mkdir(dir);
-            await t.puter.fs.upload(
-                [
-                    { isDirectory: true, fullPath: 'dropped' },
-                    droppedFile('inside the dropped dir', 'dropped/inside.txt'),
-                ] as never,
-                dir,
-                { parsedDataTransferItems: true },
-            );
-            t.assert.equal(
-                Boolean((await t.puter.fs.stat(`${dir}/dropped`)).is_dir),
-                true,
-            );
-            t.assert.equal(
-                await (await t.puter.fs.read(`${dir}/dropped/inside.txt`)).text(),
-                'inside the dropped dir',
-            );
-        },
+    // Directory uploads only work on the signed batch-write path, which every
+    // platform now takes. What the legacy `/batch` fallback does instead is
+    // asserted below, in the legacy upload tests.
+    'upload of parsed drop entries creates the dropped directory tree': async (t) => {
+        const dir = `${home(t)}/fs-suite-upload-drop`;
+        await t.puter.fs.mkdir(dir);
+        await t.puter.fs.upload(
+            [
+                { isDirectory: true, fullPath: 'dropped' },
+                droppedFile('inside the dropped dir', 'dropped/inside.txt'),
+            ] as never,
+            dir,
+            { parsedDataTransferItems: true },
+        );
+        t.assert.equal(
+            Boolean((await t.puter.fs.stat(`${dir}/dropped`)).is_dir),
+            true,
+        );
+        t.assert.equal(
+            await (await t.puter.fs.read(`${dir}/dropped/inside.txt`)).text(),
+            'inside the dropped dir',
+        );
     },
 
-    'upload with createFileParent builds the directories the files sit in': {
-        platforms: ['browser'],
-        fn: async (t) => {
-            const dir = `${home(t)}/fs-suite-upload-parents`;
-            await t.puter.fs.mkdir(dir);
-            await t.puter.fs.upload(
-                [
-                    droppedFile('leaf a', 'nested/a.txt'),
-                    droppedFile('leaf b', 'nested/deep/b.txt'),
-                ] as never,
-                dir,
-                { parsedDataTransferItems: true, createFileParent: true },
-            );
-            t.assert.equal(
-                Boolean((await t.puter.fs.stat(`${dir}/nested/deep`)).is_dir),
-                true,
-            );
-            t.assert.equal(
-                await (await t.puter.fs.read(`${dir}/nested/a.txt`)).text(),
-                'leaf a',
-            );
-            t.assert.equal(
-                await (await t.puter.fs.read(`${dir}/nested/deep/b.txt`)).text(),
-                'leaf b',
-            );
-        },
+    'upload with createFileParent builds the directories the files sit in': async (t) => {
+        const dir = `${home(t)}/fs-suite-upload-parents`;
+        await t.puter.fs.mkdir(dir);
+        await t.puter.fs.upload(
+            [
+                droppedFile('leaf a', 'nested/a.txt'),
+                droppedFile('leaf b', 'nested/deep/b.txt'),
+            ] as never,
+            dir,
+            { parsedDataTransferItems: true, createFileParent: true },
+        );
+        t.assert.equal(
+            Boolean((await t.puter.fs.stat(`${dir}/nested/deep`)).is_dir),
+            true,
+        );
+        t.assert.equal(
+            await (await t.puter.fs.read(`${dir}/nested/a.txt`)).text(),
+            'leaf a',
+        );
+        t.assert.equal(
+            await (await t.puter.fs.read(`${dir}/nested/deep/b.txt`)).text(),
+            'leaf b',
+        );
     },
 
     'upload skips .DS_Store entries': async (t) => {


### PR DESCRIPTION
I Fixed `fs.upload()` for Node.js uploads containing nested folders and duplicate file names.

## Changes

- Enable signed batch-write uploads for `nodejs`.
- Prevent crashes when a response has no `content-type` header.
- Add a regression test for nested paths and duplicate file names.
- Update the upload documentation.

## Testing

```powershell
npm run test:puterjs:node -- -t "upload preserves nested paths and duplicate names in nodejs"