### PR TITLE
feat: add TeamStore.countActiveSeats for the billable seat count

### DIFF
--- a/src/backend/stores/team/TeamStore.test.ts
+++ b/src/backend/stores/team/TeamStore.test.ts
@@ -452,6 +452,75 @@ describe('TeamStore', () => {
         ).resolves.toBe(false);
     });
 
+    // -- seat counts --------------------------------------------------
+
+    // `countSeats` bounds the cap and `countActiveSeats` is the billable
+    // count, so the two must disagree exactly when a seat is suspended.
+    describe('counting seats', () => {
+        const suspend = async (userId: number) => {
+            await server.clients.db.write(
+                'UPDATE `user` SET `suspended` = 1 WHERE `id` = ?',
+                [userId],
+            );
+        };
+
+        const seatedTeam = async (seats = 0) => {
+            const team = await store.create({
+                ownerUserId: owner.id,
+                name: 'Counted',
+                handle: freeHandle(),
+            });
+            const members: { id: number }[] = [];
+            for (let i = 0; i < seats; i++) {
+                const m = await makeUser();
+                await store.addMember(team.uid, m.id, { orgOwned: true });
+                members.push(m);
+            }
+            return { team, members };
+        };
+
+        it('counts provisioned seats and active seats alike when none is suspended', async () => {
+            const { team } = await seatedTeam(3);
+            expect(await store.countSeats(team.id)).toBe(3);
+            expect(await store.countActiveSeats(team.id)).toBe(3);
+        });
+
+        it('drops a suspended seat from the active count but not from the cap', async () => {
+            // The console promises a suspended account costs nothing per
+            // account, while the seat it holds is still taken.
+            const { team, members } = await seatedTeam(3);
+            await suspend(members[0].id);
+
+            expect(await store.countActiveSeats(team.id)).toBe(2);
+            expect(await store.countSeats(team.id)).toBe(3);
+        });
+
+        it('still counts a provisioned seat that has never been activated', async () => {
+            // It holds a temporary password, not a suspension — it is paid for.
+            const { team, members } = await seatedTeam(1);
+            await server.clients.db.write(
+                'UPDATE `user` SET `requires_password_change` = 1 WHERE `id` = ?',
+                [members[0].id],
+            );
+
+            expect(await store.countActiveSeats(team.id)).toBe(1);
+        });
+
+        it('excludes the payer, who is not a seat', async () => {
+            const { team } = await seatedTeam(2);
+            const payer = await makeUser();
+            await server.stores.user.update(payer.id, { password: 'hashed' });
+            await store.addMember(team.uid, payer.id, { orgOwned: false });
+
+            expect(await store.countActiveSeats(team.id)).toBe(2);
+        });
+
+        it('is zero for a team with no seats, not an error', async () => {
+            const { team } = await seatedTeam(0);
+            expect(await store.countActiveSeats(team.id)).toBe(0);
+        });
+    });
+
     // -- pagination ---------------------------------------------------
 
     it('pages members on `id` and stops when the set is exhausted', async () => {

--- a/src/backend/stores/team/TeamStore.ts
+++ b/src/backend/stores/team/TeamStore.ts
@@ -577,6 +577,25 @@ export class TeamStore extends PuterStore {
         return Number(rows[0]?.n ?? 0);
     }
 
+    /**
+     * Seats that are provisioned and not suspended.
+     *
+     * Distinct from `countSeats` on purpose. That one bounds the cap, where a
+     * suspended seat still counts because it still holds a username. This one
+     * answers "how many accounts is the team getting the benefit of", which is
+     * what the console tells the owner they pay per account for.
+     */
+    async countActiveSeats(teamId: number): Promise<number> {
+        const rows = (await this.clients.db.read(
+            'SELECT COUNT(*) AS n FROM `jct_user_group` ug ' +
+                'JOIN `user` u ON u.`id` = ug.`user_id` ' +
+                'WHERE ug.`group_id` = ? AND ug.`org_owned` = 1 ' +
+                'AND (u.`suspended` IS NULL OR u.`suspended` = 0)',
+            [teamId],
+        )) as { n: number }[];
+        return Number(rows[0]?.n ?? 0);
+    }
+
     /** Live teams this user owns. Soft-deleted ones do not count. */
     async countOwned(ownerUserId: number): Promise<number> {
         const rows = (await this.clients.db.read(


### PR DESCRIPTION
Adds a third seat count to `TeamStore`. Small and standalone — it does not depend on any of the Teams phase PRs.

## Why

Per-seat billing needs *active* provisioned seats, and neither existing count is that:

| method | counts | used by |
| --- | --- | --- |
| `countSeats` | all `org_owned = 1`, **suspended included** | the seat cap |
| `countPayers` | `org_owned = 0` — the owner | payer checks |
| `countActiveSeats` *(new)* | `org_owned = 1` and not suspended | billing |

`countSeats` is right for the cap: a suspended seat still holds its username, so it still occupies a seat. It is wrong for billing — charging for it contradicts the admin console, which tells the owner "0 suspended accounts cost nothing per account". So this is a new method, not a change to either existing one.

## The one judgement call

An **unactivated** seat is still counted. It holds a temporary password rather than a suspension, and it is paid for. That makes this filter deliberately narrower than `listDirectory`, which also excludes `requires_password_change` — the directory hides accounts nobody has logged into yet, but billing should not.

## Testing

`npx vitest run --config src/backend/vitest.config.ts src/backend/stores/team src/backend/services/team` → **127 passed** on the rebased branch, 5 of them new.

Falsified: removing the suspended clause fails exactly one test and leaves the other 34 green —

```
× drops a suspended seat from the active count but not from the cap
  AssertionError: expected 3 to be 2
  Tests  1 failed | 34 passed (35)
```

`npm run typecheck` → no new errors. (It also reports "52 baselined errors fixed"; that is identical on unmodified `main`, so it is pre-existing drift and I have not locked it in here.)

---

## Verified downstream, on a running server

This is the fix for a live overcharge, so it was tested by pointing the prod extensions' vendored copy at this branch and restarting — not only by unit test.

Scenario: a team with two provisioned seats, one of them suspended, priced through the real purchase route.

**Vendored copy on `main`** (no `countActiveSeats`) — the caller falls back to `countSeats` and bills the suspended seat:

```
== suspended seat ==
  PASS disable seat 1
  PASS suspended seat is billed, the known over-count
  KNOWN GAP the vendored copy has no countActiveSeats; awaiting HeyPuter/puter#3837
...
All checks passed, with 1 known gap(s)
```

**Vendored copy on this branch** — same scenario, same script:

```
== suspended seat ==
  PASS disable seat 1
  PASS suspended seat is not billed
...
All checks passed
```

$20.00 → $10.00 for one active seat and one suspended. That is the whole point: the admin console tells the owner "0 suspended accounts cost nothing per account", and until this lands that statement is false.

No change is needed on the consumer side. It already prefers `countActiveSeats` when the store exposes it and only falls back otherwise, and the downstream check derives its expectation from whether the vendored `TeamStore` has the method — so merging this and bumping the submodule flips that check from "assert the known over-count" to "assert the correct price" with no follow-up edit. An earlier version of the check tolerated either number, which would have let a later regression pass as a known gap.

Consumer: HeyPuter/heyputer#1203.

## Rebased

Rebased onto current `main` (`6146ab9`) so the check above ran against today's tree rather than a stale base. `npx vitest run --config src/backend/vitest.config.ts src/backend/stores/team src/backend/services/team` → **127 passed**. `npm run typecheck` → no new errors.

